### PR TITLE
System.NullReferenceException: Object reference not set to an instance of an object in Test Engine

### DIFF
--- a/src/Microsoft.PowerApps.TestEngine/TestInfra/PlaywrightTestInfraFunctions.cs
+++ b/src/Microsoft.PowerApps.TestEngine/TestInfra/PlaywrightTestInfraFunctions.cs
@@ -123,6 +123,9 @@ namespace Microsoft.PowerApps.TestEngine.TestInfra
             // TODO: consider whether to make waiting for network idle state part of the function input
             var response = await Page.GotoAsync(url, new PageGotoOptions() { WaitUntil = WaitUntilState.NetworkIdle });
 
+            // The response might be null because "The method either throws an error or returns a main resource response.
+            // The only exceptions are navigation to about:blank or navigation to the same URL with a different hash, which would succeed and return null."
+            //(From playwright https://playwright.dev/dotnet/docs/api/class-page#page-goto)
             if (response != null && !response.Ok )
             {
                 _singleTestInstanceState.GetLogger().LogError($"Error navigating to page: {url}, response is: {response?.Status}");


### PR DESCRIPTION
Resolve the page navigate to the same URL with a hash issue.