### PR TITLE
Get logging to work

### DIFF
--- a/src/Microsoft.PowerApps.TestEngine/Reporting/TestLogger.cs
+++ b/src/Microsoft.PowerApps.TestEngine/Reporting/TestLogger.cs
@@ -44,6 +44,9 @@ namespace Microsoft.PowerApps.TestEngine.Reporting
         public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
         {
             var logString = $"[{logLevel}] - [{eventId}]: {formatter(state, exception)}{Environment.NewLine}";
+            
+            Console.Out.WriteLine(logString);
+            
             if (logLevel <= LogLevel.Debug)
             {
                 DebugLogs.Add(logString);

--- a/src/PowerAppsTestEngine/Program.cs
+++ b/src/PowerAppsTestEngine/Program.cs
@@ -19,8 +19,7 @@ var serviceProvider = new ServiceCollection()
         {
             loggingBuilder
             .ClearProviders()
-            .AddProvider(new TestLoggerProvider(new FileSystem()))
-            .AddConsole(); // TODO: figure out why I can't have both console logging and the test logger at the same time.
+            .AddProvider(new TestLoggerProvider(new FileSystem()));
         })
     .AddScoped<ITestInfraFunctions, PlaywrightTestInfraFunctions>()
     .AddSingleton<ITestConfigParser, YamlTestConfigParser>()


### PR DESCRIPTION
#9:
Once the test logging provider is registered, nothing gets logged to the console (See https://github.com/microsoft/PowerApps-TestEngine/blob/3716ea76accf0ed1e85f6dffe995981094b94606/src/PowerAppsTestEngine/Program.cs).

Figure out why this is happening. Absolute worst case, we also can implement our own console logging in the test logging provider.

Exit criteria:

Logs get surfaced in the console