### PR TITLE
Avoiding the usage of global npm

### DIFF
--- a/.github/workflows/yaml-integration-tests.yml
+++ b/.github/workflows/yaml-integration-tests.yml
@@ -17,8 +17,8 @@ jobs:
             user1Password: '${{ secrets.POWER_PLATFORM_PASSWORD }}'
         run: |   
           cd src/PowerAppsTestEngine
-          npm install -g playwright@1.22.0
-          playwright install  
+          dotnet build
+          pwsh bin/Debug/net6.0/playwright.ps1 install
           IFS='}' read -ra testplans <<< "${{ inputs.parameters }}"      # separate the parameters to testplans
           for testplan in "${testplans[@]}" 
             do


### PR DESCRIPTION
Change the use of global npm install in github action to use the playwright from bin folder.
This change will avoid the need to update the version in npm install command and rather use the version from build playwright version.

## Validation

Workflow runs successfully.