### PR TITLE
Fixing the select two param function

### DIFF
--- a/src/Microsoft.PowerApps.TestEngine/PowerFx/Functions/Select/SelectTwoParamsFunction.cs
+++ b/src/Microsoft.PowerApps.TestEngine/PowerFx/Functions/Select/SelectTwoParamsFunction.cs
@@ -54,7 +54,8 @@ namespace Microsoft.PowerApps.TestEngine.PowerFx.Functions
 
             var recordType = new RecordType().Add(controlName, new RecordType());
             var powerAppControlModel = new ControlRecordValue(recordType, _powerAppFunctions, controlName);
-            var result = await _powerAppFunctions.SelectControlAsync(powerAppControlModel.GetItemPath());
+            
+            var result = await _powerAppFunctions.SelectControlAsync(itemPath);
 
             if (!result)
             {


### PR DESCRIPTION
Fixing the Select with 2 params work.

Proposed: Itempath needs to be passed into the selectcontrolasync()

`Select(control, row or column)`
`Select(Gallery1,1)`