### PR TITLE
Simplify SetProperty() by moving helper from overloads to class

### DIFF
--- a/src/Microsoft.PowerApps.TestEngine/PowerFx/Functions/SetPropertyFunction.cs
+++ b/src/Microsoft.PowerApps.TestEngine/PowerFx/Functions/SetPropertyFunction.cs
@@ -23,21 +23,8 @@ namespace Microsoft.PowerApps.TestEngine.PowerFx.Functions
         {
             _powerAppFunctions = powerAppFunctions;
         }
-    }
 
-    public class SetPropertyFunctionNumber : SetPropertyFunction
-    {
-        public SetPropertyFunctionNumber(IPowerAppFunctions powerAppFunctions) : base(powerAppFunctions, FormulaType.Number)
-        {
-        }
-
-        public BlankValue Execute(RecordValue obj, StringValue propName, NumberValue value)
-        {
-            SetProperty(obj, propName, value).Wait();
-            return FormulaValue.NewBlank();
-        }
-
-        private async Task SetProperty(RecordValue obj, StringValue propName, NumberValue value)
+        protected async Task SetProperty(RecordValue obj, StringValue propName, FormulaValue value)
         {
             if (obj == null)
             {
@@ -54,13 +41,26 @@ namespace Microsoft.PowerApps.TestEngine.PowerFx.Functions
                 throw new ArgumentException(nameof(value));
             }
 
-            var controlModel = (ControlRecordValue)obj; 
+            var controlModel = (ControlRecordValue)obj;
             var result = await _powerAppFunctions.SetPropertyAsync(controlModel.GetItemPath(propName.Value), value);
 
             if (!result)
             {
                 throw new Exception($"Unable to set property {controlModel.Name}");
             }
+        }
+    }
+
+    public class SetPropertyFunctionNumber : SetPropertyFunction
+    {
+        public SetPropertyFunctionNumber(IPowerAppFunctions powerAppFunctions) : base(powerAppFunctions, FormulaType.Number)
+        {
+        }
+
+        public BlankValue Execute(RecordValue obj, StringValue propName, NumberValue value)
+        {
+            SetProperty(obj, propName, value).Wait();
+            return FormulaValue.NewBlank();
         }
     }
 
@@ -75,32 +75,6 @@ namespace Microsoft.PowerApps.TestEngine.PowerFx.Functions
             SetProperty(obj, propName, value).Wait();
             return FormulaValue.NewBlank();
         }
-
-        private async Task SetProperty(RecordValue obj, StringValue propName, StringValue value)
-        {
-            if (obj == null)
-            {
-                throw new ArgumentException(nameof(obj));
-            }
-
-            if (propName == null)
-            {
-                throw new ArgumentException(nameof(propName));
-            }
-
-            if (value == null)
-            {
-                throw new ArgumentException(nameof(value));
-            }
-
-            var controlModel = (ControlRecordValue)obj; 
-            var result = await _powerAppFunctions.SetPropertyAsync(controlModel.GetItemPath(propName.Value), value);
-
-            if (!result)
-            {
-                throw new Exception($"Unable to set property {controlModel.Name}");
-            }
-        }
     }
 
     public class SetPropertyFunctionBoolean : SetPropertyFunction
@@ -114,32 +88,6 @@ namespace Microsoft.PowerApps.TestEngine.PowerFx.Functions
             SetProperty(obj, propName, value).Wait();
             return FormulaValue.NewBlank();
         }
-
-        private async Task SetProperty(RecordValue obj, StringValue propName, BooleanValue value)
-        {
-            if (obj == null)
-            {
-                throw new ArgumentException(nameof(obj));
-            }
-
-            if (propName == null)
-            {
-                throw new ArgumentException(nameof(propName));
-            }
-
-            if (value == null)
-            {
-                throw new ArgumentException(nameof(value));
-            }
-
-            var controlModel = (ControlRecordValue)obj; 
-            var result = await _powerAppFunctions.SetPropertyAsync(controlModel.GetItemPath(propName.Value), value);
-
-            if (!result)
-            {
-                throw new Exception($"Unable to set property {controlModel.Name}");
-            }
-        }
     }
 
     public class SetPropertyFunctionDate : SetPropertyFunction
@@ -152,32 +100,6 @@ namespace Microsoft.PowerApps.TestEngine.PowerFx.Functions
         {
             SetProperty(obj, propName, value).Wait();
             return FormulaValue.NewBlank();
-        }
-
-        private async Task SetProperty(RecordValue obj, StringValue propName, DateValue value)
-        {
-            if (obj == null)
-            {
-                throw new ArgumentException(nameof(obj));
-            }
-
-            if (propName == null)
-            {
-                throw new ArgumentException(nameof(propName));
-            }
-
-            if (value == null)
-            {
-                throw new ArgumentException(nameof(value));
-            }
-
-            var controlModel = (ControlRecordValue)obj; 
-            var result = await _powerAppFunctions.SetPropertyAsync(controlModel.GetItemPath(propName.Value), value);
-
-            if (!result)
-            {
-                throw new Exception($"Unable to set property {controlModel.Name}");
-            }
         }
     }
 


### PR DESCRIPTION
We can save lines of code by moving the SetProperty() function into a direct member function of the class, and allow it to take in any formula type.