### PR TITLE
Have onTestSuiteComplete Output into Suite Directory

### DIFF
--- a/.github/workflows/dotnet-format.yml
+++ b/.github/workflows/dotnet-format.yml
@@ -26,4 +26,4 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Run dotnet format
-        run: dotnet format '.\src\Microsoft.PowerApps.TestEngine' --verify-no-changes --severity error
+        run: dotnet format '.\src\Microsoft.PowerApps.TestEngine' --verify-no-changes --severity warn

--- a/src/Microsoft.PowerApps.TestEngine/SingleTestRunner.cs
+++ b/src/Microsoft.PowerApps.TestEngine/SingleTestRunner.cs
@@ -164,12 +164,14 @@ namespace Microsoft.PowerApps.TestEngine
                             _testReporter.EndTest(testRunId, testId, TestSuccess, message, additionalFiles, TestException?.Message, TestException?.StackTrace);
                         }
                     }
+                }
 
-                    if (!string.IsNullOrEmpty(testSuiteDefinition.OnTestSuiteComplete))
-                    {
-                        Logger.LogInformation($"Running OnTestSuiteComplete for test suite: {testSuiteDefinition.TestSuiteName}");
-                        _powerFxEngine.Execute(testSuiteDefinition.OnTestSuiteComplete);
-                    }
+                // Execute OnTestSuiteComplete
+                if (!string.IsNullOrEmpty(testSuiteDefinition.OnTestSuiteComplete))
+                {
+                    Logger.LogInformation($"Running OnTestSuiteComplete for test suite: {testSuiteDefinition.TestSuiteName}");
+                    _testState.SetTestResultsDirectory(testResultDirectory);
+                    _powerFxEngine.Execute(testSuiteDefinition.OnTestSuiteComplete);
                 }
             }
             catch (Exception ex)

--- a/src/Microsoft.PowerApps.TestEngine/TestStudioConverter/CreateYAMLTestPlan.cs
+++ b/src/Microsoft.PowerApps.TestEngine/TestStudioConverter/CreateYAMLTestPlan.cs
@@ -246,7 +246,7 @@ namespace Microsoft.PowerApps.TestEngine.TestStudioConverter
             return TestCases;
         }
 
-        public TestPlanDefinition? GetYamlTestPlan()
+        public TestPlanDefinition GetYamlTestPlan()
         {
             return YamlTestPlan;
         }


### PR DESCRIPTION
# Pull Request Template

## Description
- Before executing onTestSuiteComplete, set the test result directory to suite output directory.
- Set dotnet format check to allow no warnings

## Checklist

- [X] The code change is covered by unit tests. I have added tests that prove my fix is effective or that my feature works
- [X] I have performed end-to-end test locally.
- [X] New and existing unit tests pass locally with my changes
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I used clear names for everything
- [X] I have performed a self-review of my own code
