### PR TITLE
Allow users to specify domain

### DIFF
--- a/docs/CommandInput.md
+++ b/docs/CommandInput.md
@@ -12,7 +12,7 @@ The executable can take in inputs defined in `config.dev.json`, or as command li
 | OutputDirectory | Path to folder the test results will be placed. Optional. If this is not provided, it will be placed in the `TestOutput` folder. |
 | LogLevel | Level for logging (Folllows [this](https://docs.microsoft.com/en-us/dotnet/api/microsoft.extensions.logging.loglevel?view=dotnet-plat-ext-6.0)). Optional. If this is not provided, Information level logs and higher will be logged |
 | QueryParams | Specify query parameters to be added to the Power Apps URL. |
-| Domain | Specify what URL domain your app uses. |
+| Domain | Specify what URL domain your app uses. This is optional; if not set, it will default to 'apps.powerapps.com'. |
 ## Config.json
 
 Please view the checked in `config.json` file for the latest format.

--- a/docs/CommandInput.md
+++ b/docs/CommandInput.md
@@ -12,7 +12,7 @@ The executable can take in inputs defined in `config.dev.json`, or as command li
 | OutputDirectory | Path to folder the test results will be placed. Optional. If this is not provided, it will be placed in the `TestOutput` folder. |
 | LogLevel | Level for logging (Folllows [this](https://docs.microsoft.com/en-us/dotnet/api/microsoft.extensions.logging.loglevel?view=dotnet-plat-ext-6.0)). Optional. If this is not provided, Information level logs and higher will be logged |
 | QueryParams | Specify query parameters to be added to the Power Apps URL. |
-
+| Domain | Specify what URL domain your app uses. |
 ## Config.json
 
 Please view the checked in `config.json` file for the latest format.
@@ -31,6 +31,7 @@ When provided, command line parameters will override anything specified in `conf
 | -o | OutputDirectory |
 | -l | LogLevel |
 | -q | QueryParams |
+| -d | Domain |
 
 ## Test plan conversion
 The exe can also be used to convert an msapp's test json to a Test Engine yaml test plan.

--- a/src/Microsoft.PowerApps.TestEngine.Tests/Config/TestStateTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/Config/TestStateTests.cs
@@ -134,15 +134,15 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Config
 
             var environmentId = Guid.NewGuid().ToString();
             var tenantId = Guid.NewGuid().ToString();
-            var cloud = "Prod";
+            var domain = "apps.powerapps.com";
             var outputDirectory = Guid.NewGuid().ToString();
 
             state.SetEnvironment(environmentId);
             Assert.Equal(environmentId, state.GetEnvironment());
             state.SetTenant(tenantId);
             Assert.Equal(tenantId, state.GetTenant());
-            state.SetCloud(cloud);
-            Assert.Equal(cloud, state.GetCloud());
+            state.SetDomain(domain);
+            Assert.Equal(domain, state.GetDomain());
             state.SetOutputDirectory(outputDirectory);
             Assert.Equal(outputDirectory, state.GetOutputDirectory());
         }
@@ -471,10 +471,10 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Config
         [Theory]
         [InlineData("")]
         [InlineData(null)]
-        public void SetCloudThrowsOnNullInput(string cloud)
+        public void SetDomainThrowsOnNullInput(string domain)
         {
             var state = new TestState(MockTestConfigParser.Object);
-            Assert.Throws<ArgumentNullException>(() => state.SetCloud(cloud));
+            Assert.Throws<ArgumentNullException>(() => state.SetDomain(domain));
         }
 
         [Theory]

--- a/src/Microsoft.PowerApps.TestEngine.Tests/PowerApps/PowerAppsUrlMapperTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/PowerApps/PowerAppsUrlMapperTests.cs
@@ -28,7 +28,6 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerApps
         [InlineData("myEnvironment", "apps.powerapps.com", "myApp", "appId", "myTenant", "https://apps.powerapps.com/play/e/myEnvironment/an/myApp?tenantId=myTenant&source=testengine&enablePATest=true&patestSDKVersion=0.0.1", "&enablePATest=true&patestSDKVersion=0.0.1")]
         [InlineData("myEnvironment", "apps.powerapps.com", "myApp", "appId", "myTenant", "https://apps.powerapps.com/play/e/myEnvironment/an/myApp?tenantId=myTenant&source=testengine", "")]
         [InlineData("defaultEnvironment", "apps.test.powerapps.com", "defaultApp", "appId", "defaultTenant", "https://apps.test.powerapps.com/play/e/defaultEnvironment/an/defaultApp?tenantId=defaultTenant&source=testengine", "")]
-        [InlineData("myEnvironment", "APPS.POWERAPPS.COM", "myApp", "appId", "myTenant", "https://apps.powerapps.com/play/e/myEnvironment/an/myApp?tenantId=myTenant&source=testengine", "")]
         [InlineData("defaultEnvironment", "apps.powerapps.com", null, "appId", "defaultTenant", "https://apps.powerapps.com/play/e/defaultEnvironment/a/appId?tenantId=defaultTenant&source=testengine", "")]
         public void GenerateAppUrlTest(string environmentId, string domain, string appLogicalName, string appId, string tenantId, string expectedAppUrl, string queryParams)
         {

--- a/src/Microsoft.PowerApps.TestEngine.Tests/PowerApps/PowerAppsUrlMapperTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/PowerApps/PowerAppsUrlMapperTests.cs
@@ -29,8 +29,6 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerApps
         [InlineData("myEnvironment", "apps.powerapps.com", "myApp", "appId", "myTenant", "https://apps.powerapps.com/play/e/myEnvironment/an/myApp?tenantId=myTenant&source=testengine", "")]
         [InlineData("defaultEnvironment", "apps.test.powerapps.com", "defaultApp", "appId", "defaultTenant", "https://apps.test.powerapps.com/play/e/defaultEnvironment/an/defaultApp?tenantId=defaultTenant&source=testengine", "")]
         [InlineData("myEnvironment", "APPS.POWERAPPS.COM", "myApp", "appId", "myTenant", "https://apps.powerapps.com/play/e/myEnvironment/an/myApp?tenantId=myTenant&source=testengine", "")]
-        [InlineData("defaultEnvironment", "", "defaultApp", "appId", "defaultTenant", "https://apps.powerapps.com/play/e/defaultEnvironment/an/defaultApp?tenantId=defaultTenant&source=testengine", "")]
-        [InlineData("defaultEnvironment", null, "defaultApp", "appId", "defaultTenant", "https://apps.powerapps.com/play/e/defaultEnvironment/an/defaultApp?tenantId=defaultTenant&source=testengine", "")]
         [InlineData("defaultEnvironment", "apps.powerapps.com", null, "appId", "defaultTenant", "https://apps.powerapps.com/play/e/defaultEnvironment/a/appId?tenantId=defaultTenant&source=testengine", "")]
         public void GenerateAppUrlTest(string environmentId, string domain, string appLogicalName, string appId, string tenantId, string expectedAppUrl, string queryParams)
         {
@@ -41,7 +39,6 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerApps
             var powerAppUrlMapper = new PowerAppsUrlMapper(MockTestState.Object, MockSingleTestInstanceState.Object);
             Assert.Equal(expectedAppUrl, powerAppUrlMapper.GenerateTestUrl(domain, queryParams));
             MockTestState.Verify(x => x.GetEnvironment(), Times.Once());
-            MockTestState.Verify(x => x.GetDomain(), Times.Once());
             MockSingleTestInstanceState.Verify(x => x.GetTestSuiteDefinition(), Times.Once());
             MockTestState.Verify(x => x.GetTenant(), Times.Once());
         }

--- a/src/Microsoft.PowerApps.TestEngine.Tests/PowerApps/PowerAppsUrlMapperTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/PowerApps/PowerAppsUrlMapperTests.cs
@@ -25,25 +25,23 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerApps
         }
 
         [Theory]
-        [InlineData("myEnvironment", "Prod", "myApp", "appId", "myTenant", "https://apps.powerapps.com/play/e/myEnvironment/an/myApp?tenantId=myTenant&source=testengine&enablePATest=true&patestSDKVersion=0.0.1", "&enablePATest=true&patestSDKVersion=0.0.1")]
-        [InlineData("myEnvironment", "Prod", "myApp", "appId", "myTenant", "https://apps.powerapps.com/play/e/myEnvironment/an/myApp?tenantId=myTenant&source=testengine", "")]
-        [InlineData("defaultEnvironment", "Test", "defaultApp", "appId", "defaultTenant", "https://apps.test.powerapps.com/play/e/defaultEnvironment/an/defaultApp?tenantId=defaultTenant&source=testengine", "")]
-        [InlineData("defaultEnvironment", "test", "defaultApp", "appId", "defaultTenant", "https://apps.test.powerapps.com/play/e/defaultEnvironment/an/defaultApp?tenantId=defaultTenant&source=testengine", "")]
-        [InlineData("myEnvironment", "PROD", "myApp", "appId", "myTenant", "https://apps.powerapps.com/play/e/myEnvironment/an/myApp?tenantId=myTenant&source=testengine", "")]
-        [InlineData("myEnvironment", "prod", "myApp", "appId", "myTenant", "https://apps.powerapps.com/play/e/myEnvironment/an/myApp?tenantId=myTenant&source=testengine", "")]
+        [InlineData("myEnvironment", "apps.powerapps.com", "myApp", "appId", "myTenant", "https://apps.powerapps.com/play/e/myEnvironment/an/myApp?tenantId=myTenant&source=testengine&enablePATest=true&patestSDKVersion=0.0.1", "&enablePATest=true&patestSDKVersion=0.0.1")]
+        [InlineData("myEnvironment", "apps.powerapps.com", "myApp", "appId", "myTenant", "https://apps.powerapps.com/play/e/myEnvironment/an/myApp?tenantId=myTenant&source=testengine", "")]
+        [InlineData("defaultEnvironment", "apps.test.powerapps.com", "defaultApp", "appId", "defaultTenant", "https://apps.test.powerapps.com/play/e/defaultEnvironment/an/defaultApp?tenantId=defaultTenant&source=testengine", "")]
+        [InlineData("myEnvironment", "APPS.POWERAPPS.COM", "myApp", "appId", "myTenant", "https://apps.powerapps.com/play/e/myEnvironment/an/myApp?tenantId=myTenant&source=testengine", "")]
         [InlineData("defaultEnvironment", "", "defaultApp", "appId", "defaultTenant", "https://apps.powerapps.com/play/e/defaultEnvironment/an/defaultApp?tenantId=defaultTenant&source=testengine", "")]
         [InlineData("defaultEnvironment", null, "defaultApp", "appId", "defaultTenant", "https://apps.powerapps.com/play/e/defaultEnvironment/an/defaultApp?tenantId=defaultTenant&source=testengine", "")]
-        [InlineData("defaultEnvironment", "prod", null, "appId", "defaultTenant", "https://apps.powerapps.com/play/e/defaultEnvironment/a/appId?tenantId=defaultTenant&source=testengine", "")]
-        public void GenerateAppUrlTest(string environmentId, string cloud, string appLogicalName, string appId, string tenantId, string expectedAppUrl, string queryParams)
+        [InlineData("defaultEnvironment", "apps.powerapps.com", null, "appId", "defaultTenant", "https://apps.powerapps.com/play/e/defaultEnvironment/a/appId?tenantId=defaultTenant&source=testengine", "")]
+        public void GenerateAppUrlTest(string environmentId, string domain, string appLogicalName, string appId, string tenantId, string expectedAppUrl, string queryParams)
         {
             MockTestState.Setup(x => x.GetEnvironment()).Returns(environmentId);
-            MockTestState.Setup(x => x.GetCloud()).Returns(cloud);
+            MockTestState.Setup(x => x.GetDomain()).Returns(domain);
             MockSingleTestInstanceState.Setup(x => x.GetTestSuiteDefinition()).Returns(new TestSuiteDefinition() { AppLogicalName = appLogicalName, AppId = appId });
             MockTestState.Setup(x => x.GetTenant()).Returns(tenantId);
             var powerAppUrlMapper = new PowerAppsUrlMapper(MockTestState.Object, MockSingleTestInstanceState.Object);
             Assert.Equal(expectedAppUrl, powerAppUrlMapper.GenerateTestUrl(queryParams));
             MockTestState.Verify(x => x.GetEnvironment(), Times.Once());
-            MockTestState.Verify(x => x.GetCloud(), Times.Once());
+            MockTestState.Verify(x => x.GetDomain(), Times.Once());
             MockSingleTestInstanceState.Verify(x => x.GetTestSuiteDefinition(), Times.Once());
             MockTestState.Verify(x => x.GetTenant(), Times.Once());
         }

--- a/src/Microsoft.PowerApps.TestEngine.Tests/PowerApps/PowerAppsUrlMapperTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/PowerApps/PowerAppsUrlMapperTests.cs
@@ -39,7 +39,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerApps
             MockSingleTestInstanceState.Setup(x => x.GetTestSuiteDefinition()).Returns(new TestSuiteDefinition() { AppLogicalName = appLogicalName, AppId = appId });
             MockTestState.Setup(x => x.GetTenant()).Returns(tenantId);
             var powerAppUrlMapper = new PowerAppsUrlMapper(MockTestState.Object, MockSingleTestInstanceState.Object);
-            Assert.Equal(expectedAppUrl, powerAppUrlMapper.GenerateTestUrl(queryParams));
+            Assert.Equal(expectedAppUrl, powerAppUrlMapper.GenerateTestUrl(domain, queryParams));
             MockTestState.Verify(x => x.GetEnvironment(), Times.Once());
             MockTestState.Verify(x => x.GetDomain(), Times.Once());
             MockSingleTestInstanceState.Verify(x => x.GetTestSuiteDefinition(), Times.Once());
@@ -61,7 +61,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerApps
             MockSingleTestInstanceState.Setup(x => x.GetLogger()).Returns(MockLogger.Object);
             LoggingTestHelper.SetupMock(MockLogger);
             var powerAppUrlMapper = new PowerAppsUrlMapper(MockTestState.Object, MockSingleTestInstanceState.Object);
-            Assert.Throws<InvalidOperationException>(() => powerAppUrlMapper.GenerateTestUrl(""));
+            Assert.Throws<InvalidOperationException>(() => powerAppUrlMapper.GenerateTestUrl("", ""));
         }
 
         [Fact]
@@ -74,7 +74,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerApps
             MockSingleTestInstanceState.Setup(x => x.GetLogger()).Returns(MockLogger.Object);
             LoggingTestHelper.SetupMock(MockLogger);
             var powerAppUrlMapper = new PowerAppsUrlMapper(MockTestState.Object, MockSingleTestInstanceState.Object);
-            Assert.Throws<InvalidOperationException>(() => powerAppUrlMapper.GenerateTestUrl(""));
+            Assert.Throws<InvalidOperationException>(() => powerAppUrlMapper.GenerateTestUrl("", ""));
         }
     }
 }

--- a/src/Microsoft.PowerApps.TestEngine.Tests/SingleTestRunnerTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/SingleTestRunnerTests.cs
@@ -92,7 +92,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
 
             MockUserManager.Setup(x => x.LoginAsUserAsync(appUrl)).Returns(Task.CompletedTask);
 
-            MockUrlMapper.Setup(x => x.GenerateTestUrl("")).Returns(appUrl);
+            MockUrlMapper.Setup(x => x.GenerateTestUrl("", "")).Returns(appUrl);
 
             MockTestLogger.Setup(x => x.WriteToLogsFile(It.IsAny<string>(), It.IsAny<string>()));
             TestLoggerProvider.TestLoggers.Add(testSuiteId, MockTestLogger.Object);
@@ -117,7 +117,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
             MockTestInfraFunctions.Verify(x => x.SetupAsync(), Times.Once());
             MockUserManager.Verify(x => x.LoginAsUserAsync(appUrl), Times.Once());
             MockTestInfraFunctions.Verify(x => x.SetupNetworkRequestMockAsync(), Times.Once());
-            MockUrlMapper.Verify(x => x.GenerateTestUrl(""), Times.Once());
+            MockUrlMapper.Verify(x => x.GenerateTestUrl("", ""), Times.Once());
             MockTestInfraFunctions.Verify(x => x.GoToUrlAsync(appUrl), Times.Once());
             MockTestState.Verify(x => x.GetTestSuiteDefinition(), Times.Exactly(2));
             MockTestReporter.Verify(x => x.CreateTest(testRunId, testSuiteId, testSuiteDefinition.TestCases[0].TestCaseName, "TODO"), Times.Once());
@@ -166,7 +166,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
 
             SetupMocks(testData.testRunId, testData.testSuiteId, testData.testId, testData.appUrl, testData.testSuiteDefinition, true, additionalFiles);
 
-            await singleTestRunner.RunTestAsync(testData.testRunId, testData.testRunDirectory, testData.testSuiteDefinition, testData.browserConfig, "");
+            await singleTestRunner.RunTestAsync(testData.testRunId, testData.testRunDirectory, testData.testSuiteDefinition, testData.browserConfig, "", "");
 
             VerifyTestStateSetup(testData.testSuiteId, testData.testRunId, testData.testSuiteDefinition, testData.testResultDirectory, testData.browserConfig, 2);
             VerifySuccessfulTestExecution(testData.testCaseResultDirectory, testData.testSuiteDefinition, testData.browserConfig, testData.testSuiteId, testData.testRunId, testData.testId, true, additionalFiles, null, null, testData.appUrl);
@@ -192,7 +192,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
 
             SetupMocks(testData.testRunId, testData.testSuiteId, testData.testId, testData.appUrl, testData.testSuiteDefinition, true, additionalFiles);
 
-            await singleTestRunner.RunTestAsync(testData.testRunId, testData.testRunDirectory, testData.testSuiteDefinition, testData.browserConfig, "");
+            await singleTestRunner.RunTestAsync(testData.testRunId, testData.testRunDirectory, testData.testSuiteDefinition, testData.browserConfig, "", "");
 
             VerifyTestStateSetup(testData.testSuiteId, testData.testRunId, testData.testSuiteDefinition, testData.testResultDirectory, testData.browserConfig);
             VerifySuccessfulTestExecution(testData.testCaseResultDirectory, testData.testSuiteDefinition, testData.browserConfig, testData.testSuiteId, testData.testRunId, testData.testId, true, additionalFiles, null, null, testData.appUrl);
@@ -215,8 +215,8 @@ namespace Microsoft.PowerApps.TestEngine.Tests
 
             SetupMocks(testData.testRunId, testData.testSuiteId, testData.testId, testData.appUrl, testData.testSuiteDefinition, true, testData.additionalFiles);
 
-            await singleTestRunner.RunTestAsync(testData.testRunId, testData.testRunDirectory, testData.testSuiteDefinition, testData.browserConfig, "");
-            await Assert.ThrowsAsync<InvalidOperationException>(async () => { await singleTestRunner.RunTestAsync(testData.testRunId, testData.testRunDirectory, testData.testSuiteDefinition, testData.browserConfig, ""); });
+            await singleTestRunner.RunTestAsync(testData.testRunId, testData.testRunDirectory, testData.testSuiteDefinition, testData.browserConfig, "", "");
+            await Assert.ThrowsAsync<InvalidOperationException>(async () => { await singleTestRunner.RunTestAsync(testData.testRunId, testData.testRunDirectory, testData.testSuiteDefinition, testData.browserConfig, "", ""); });
         }
 
         [Fact]
@@ -235,7 +235,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
 
             SetupMocks(testData.testRunId, testData.testSuiteId, testData.testId, testData.appUrl, testData.testSuiteDefinition, false, testData.additionalFiles);
 
-            await singleTestRunner.RunTestAsync(testData.testRunId, testData.testRunDirectory, testData.testSuiteDefinition, testData.browserConfig, "");
+            await singleTestRunner.RunTestAsync(testData.testRunId, testData.testRunDirectory, testData.testSuiteDefinition, testData.browserConfig, "", "");
 
             VerifyTestStateSetup(testData.testSuiteId, testData.testRunId, testData.testSuiteDefinition, testData.testResultDirectory, testData.browserConfig, 2);
             VerifyFinallyExecution(testData.testResultDirectory, 1, 0, 0, 1);
@@ -259,7 +259,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
             var exceptionToThrow = new InvalidOperationException("Test exception");
             additionalMockSetup(exceptionToThrow);
 
-            await singleTestRunner.RunTestAsync(testData.testRunId, testData.testRunDirectory, testData.testSuiteDefinition, testData.browserConfig, "");
+            await singleTestRunner.RunTestAsync(testData.testRunId, testData.testRunDirectory, testData.testSuiteDefinition, testData.browserConfig, "", "");
 
             VerifyTestStateSetup(testData.testSuiteId, testData.testRunId, testData.testSuiteDefinition, testData.testResultDirectory, testData.browserConfig);
             LoggingTestHelper.VerifyLogging(MockLogger, exceptionToThrow.ToString(), LogLevel.Error, Times.AtLeastOnce());
@@ -324,7 +324,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
         {
             await SingleTestRunnerHandlesExceptionsThrownCorrectlyHelper((Exception exceptionToThrow) =>
             {
-                MockUrlMapper.Setup(x => x.GenerateTestUrl("")).Throws(exceptionToThrow);
+                MockUrlMapper.Setup(x => x.GenerateTestUrl("", "")).Throws(exceptionToThrow);
             });
         }
 
@@ -357,7 +357,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
 
             MockPowerFxEngine.Setup(x => x.Execute(It.IsAny<string>())).Throws(exceptionToThrow);
 
-            await singleTestRunner.RunTestAsync(testData.testRunId, testData.testRunDirectory, testData.testSuiteDefinition, testData.browserConfig, "");
+            await singleTestRunner.RunTestAsync(testData.testRunId, testData.testRunDirectory, testData.testSuiteDefinition, testData.browserConfig, "", "");
 
             VerifyTestStateSetup(testData.testSuiteId, testData.testRunId, testData.testSuiteDefinition, testData.testResultDirectory, testData.browserConfig, 2);
             LoggingTestHelper.VerifyLogging(MockLogger, exceptionToThrow.ToString(), LogLevel.Error, Times.Once());

--- a/src/Microsoft.PowerApps.TestEngine.Tests/TestEngineTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/TestEngineTests.cs
@@ -75,7 +75,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
             var testRunId = Guid.NewGuid().ToString();
             var expectedOutputDirectory = "TestOutput";
             var testRunDirectory = Path.Combine(expectedOutputDirectory, testRunId.Substring(0, 6));
-            var expectedCloud = "Prod";
+            var domain = "apps.powerapps.com";
 
             var expectedTestReportPath = "C:\\test.trx";
 
@@ -86,12 +86,12 @@ namespace Microsoft.PowerApps.TestEngine.Tests
 
             Assert.Equal(expectedTestReportPath, testReportPath);
 
-            Verify(testConfigFile, environmentId, tenantId, expectedCloud, "", expectedOutputDirectory, testRunId, testRunDirectory, testSuiteDefinition, testSettings);
+            Verify(testConfigFile, environmentId, tenantId, domain, "", expectedOutputDirectory, testRunId, testRunDirectory, testSuiteDefinition, testSettings);
         }
 
         [Theory]
         [ClassData(typeof(TestDataGenerator))]
-        public async Task TestEngineTest(string outputDirectory, string cloud, TestSettings testSettings, TestSuiteDefinition testSuiteDefinition)
+        public async Task TestEngineTest(string outputDirectory, string domain, TestSettings testSettings, TestSuiteDefinition testSuiteDefinition)
         {
             var testConfigFile = "C:\\testPlan.fx.yaml";
             var environmentId = "defaultEnviroment";
@@ -103,10 +103,10 @@ namespace Microsoft.PowerApps.TestEngine.Tests
                 expectedOutputDirectory = "TestOutput";
             }
             var testRunDirectory = Path.Combine(expectedOutputDirectory, testRunId.Substring(0, 6));
-            var expectedCloud = cloud;
-            if (string.IsNullOrEmpty(expectedCloud))
+
+            if (string.IsNullOrEmpty(domain))
             {
-                expectedCloud = "Prod";
+                domain = "apps.powerapps.com";
             }
 
             var expectedTestReportPath = "C:\\test.trx";
@@ -114,11 +114,11 @@ namespace Microsoft.PowerApps.TestEngine.Tests
             SetupMocks(expectedOutputDirectory, testSettings, testSuiteDefinition, testRunId, expectedTestReportPath);
 
             var testEngine = new TestEngine(MockState.Object, ServiceProvider, MockTestReporter.Object, MockFileSystem.Object, MockLoggerFactory.Object);
-            var testReportPath = await testEngine.RunTestAsync(testConfigFile, environmentId, tenantId, outputDirectory, cloud, "");
+            var testReportPath = await testEngine.RunTestAsync(testConfigFile, environmentId, tenantId, outputDirectory, domain, "");
 
             Assert.Equal(expectedTestReportPath, testReportPath);
 
-            Verify(testConfigFile, environmentId, tenantId, expectedCloud, "", expectedOutputDirectory, testRunId, testRunDirectory, testSuiteDefinition, testSettings);
+            Verify(testConfigFile, environmentId, tenantId, domain, "", expectedOutputDirectory, testRunId, testRunDirectory, testSuiteDefinition, testSettings);
         }
 
         private void SetupMocks(string outputDirectory, TestSettings testSettings, TestSuiteDefinition testSuiteDefinition, string testRunId, string testReportPath)
@@ -126,7 +126,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
             MockState.Setup(x => x.ParseAndSetTestState(It.IsAny<string>()));
             MockState.Setup(x => x.SetEnvironment(It.IsAny<string>()));
             MockState.Setup(x => x.SetTenant(It.IsAny<string>()));
-            MockState.Setup(x => x.SetCloud(It.IsAny<string>()));
+            MockState.Setup(x => x.SetDomain(It.IsAny<string>()));
             MockState.Setup(x => x.SetOutputDirectory(It.IsAny<string>()));
             MockState.Setup(x => x.GetOutputDirectory()).Returns(outputDirectory);
             MockState.Setup(x => x.GetTestSettings()).Returns(testSettings);
@@ -147,13 +147,13 @@ namespace Microsoft.PowerApps.TestEngine.Tests
         }
 
 
-        private void Verify(string testConfigFile, string environmentId, string tenantId, string cloud, string queryParams,
+        private void Verify(string testConfigFile, string environmentId, string tenantId, string domain, string queryParams,
             string outputDirectory, string testRunId, string testRunDirectory, TestSuiteDefinition testSuiteDefinition, TestSettings testSettings)
         {
             MockState.Verify(x => x.ParseAndSetTestState(testConfigFile), Times.Once());
             MockState.Verify(x => x.SetEnvironment(environmentId), Times.Once());
             MockState.Verify(x => x.SetTenant(tenantId), Times.Once());
-            MockState.Verify(x => x.SetCloud(cloud), Times.Once());
+            MockState.Verify(x => x.SetDomain(domain), Times.Once());
             MockState.Verify(x => x.SetOutputDirectory(outputDirectory), Times.Once());
 
             MockTestReporter.Verify(x => x.CreateTestRun("Power Fx Test Runner", "User"), Times.Once());
@@ -163,7 +163,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
 
             foreach (var browserConfig in testSettings.BrowserConfigurations)
             {
-                MockSingleTestRunner.Verify(x => x.RunTestAsync(testRunId, testRunDirectory, testSuiteDefinition, browserConfig, queryParams), Times.Once());
+                MockSingleTestRunner.Verify(x => x.RunTestAsync(testRunId, testRunDirectory, testSuiteDefinition, browserConfig, domain, queryParams), Times.Once());
             }
 
             MockTestReporter.Verify(x => x.EndTestRun(testRunId), Times.Once());

--- a/src/Microsoft.PowerApps.TestEngine.Tests/TestEngineTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/TestEngineTests.cs
@@ -82,7 +82,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
             SetupMocks(expectedOutputDirectory, testSettings, testSuiteDefinition, testRunId, expectedTestReportPath);
 
             var testEngine = new TestEngine(MockState.Object, ServiceProvider, MockTestReporter.Object, MockFileSystem.Object, MockLoggerFactory.Object);
-            var testReportPath = await testEngine.RunTestAsync(testConfigFile, environmentId, tenantId, "", "", "");
+            var testReportPath = await testEngine.RunTestAsync(testConfigFile, environmentId, tenantId, "", domain, "");
 
             Assert.Equal(expectedTestReportPath, testReportPath);
 

--- a/src/Microsoft.PowerApps.TestEngine.Tests/TestEngineTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/TestEngineTests.cs
@@ -140,7 +140,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
 
             MockFileSystem.Setup(x => x.CreateDirectory(It.IsAny<string>()));
 
-            MockSingleTestRunner.Setup(x => x.RunTestAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<TestSuiteDefinition>(), It.IsAny<BrowserConfiguration>(), It.IsAny<string>())).Returns(Task.CompletedTask);
+            MockSingleTestRunner.Setup(x => x.RunTestAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<TestSuiteDefinition>(), It.IsAny<BrowserConfiguration>(), It.IsAny<string>(), It.IsAny<string>())).Returns(Task.CompletedTask);
 
             MockLoggerFactory.Setup(x => x.CreateLogger(It.IsAny<string>())).Returns(MockLogger.Object);
             LoggingTestHelper.SetupMock(MockLogger);

--- a/src/Microsoft.PowerApps.TestEngine/Config/ITestState.cs
+++ b/src/Microsoft.PowerApps.TestEngine/Config/ITestState.cs
@@ -41,16 +41,16 @@ namespace Microsoft.PowerApps.TestEngine.Config
         public string GetEnvironment();
 
         /// <summary>
-        /// Set the cloud the app should be opened in.
+        /// Set the domain of the URL where the app will be launched
         /// </summary>
-        /// <param name="cloud">Cloud</param>
-        public void SetCloud(string cloud);
+        /// <param name="domain">Domain</param>
+        public void SetDomain(string domain);
 
         /// <summary>
-        /// Gets the cloud the app should be opened in.
+        /// Gets the domain of the URL where the app will be launched
         /// </summary>
-        /// <returns>Cloud</returns>
-        public string GetCloud();
+        /// <returns>Domain</returns>
+        public string GetDomain();
 
         /// <summary>
         /// Sets the tenant the app should be opened in.

--- a/src/Microsoft.PowerApps.TestEngine/Config/TestState.cs
+++ b/src/Microsoft.PowerApps.TestEngine/Config/TestState.cs
@@ -14,7 +14,7 @@ namespace Microsoft.PowerApps.TestEngine.Config
         private TestPlanDefinition TestPlanDefinition { get; set; }
         private List<TestCase> TestCases { get; set; } = new List<TestCase>();
         private string EnvironmentId { get; set; }
-        private string Cloud { get; set; }
+        private string Domain { get; set; }
 
         private string TenantId { get; set; }
 
@@ -167,19 +167,18 @@ namespace Microsoft.PowerApps.TestEngine.Config
             return EnvironmentId;
         }
 
-        public void SetCloud(string cloud)
+        public void SetDomain(string domain)
         {
-            if (string.IsNullOrEmpty(cloud))
+            if (string.IsNullOrEmpty(domain))
             {
-                throw new ArgumentNullException(nameof(cloud));
+                throw new ArgumentNullException(nameof(domain));
             }
-            // TODO: validate clouds
-            Cloud = cloud;
+            Domain = domain;
         }
 
-        public string GetCloud()
+        public string GetDomain()
         {
-            return Cloud;
+            return Domain;
         }
 
         public void SetTenant(string tenantId)

--- a/src/Microsoft.PowerApps.TestEngine/ISingleTestRunner.cs
+++ b/src/Microsoft.PowerApps.TestEngine/ISingleTestRunner.cs
@@ -18,6 +18,6 @@ namespace Microsoft.PowerApps.TestEngine
         /// <param name="testSuiteDefinition">Definition of test suite</param>
         /// <param name="browserConfig">Brower to run test on</param>
         /// <returns>Task</returns>
-        public Task RunTestAsync(string testRunId, string testRunDirectory, TestSuiteDefinition testSuiteDefinition, BrowserConfiguration browserConfig, string queryParams);
+        public Task RunTestAsync(string testRunId, string testRunDirectory, TestSuiteDefinition testSuiteDefinition, BrowserConfiguration browserConfig, string domain, string queryParams);
     }
 }

--- a/src/Microsoft.PowerApps.TestEngine/PowerApps/IUrlMapper.cs
+++ b/src/Microsoft.PowerApps.TestEngine/PowerApps/IUrlMapper.cs
@@ -5,7 +5,7 @@ using Microsoft.Extensions.Logging;
 namespace Microsoft.PowerApps.TestEngine.PowerApps
 {
     /// <summary>
-    /// Map urls based on the cloud
+    /// Map urls
     /// </summary>
     public interface IUrlMapper
     {
@@ -13,6 +13,6 @@ namespace Microsoft.PowerApps.TestEngine.PowerApps
         /// Generates url for the test
         /// </summary>
         /// <returns>Test url</returns>
-        public string GenerateTestUrl(string queryParams);
+        public string GenerateTestUrl(string domain, string queryParams);
     }
 }

--- a/src/Microsoft.PowerApps.TestEngine/PowerApps/PowerAppsUrlMapper.cs
+++ b/src/Microsoft.PowerApps.TestEngine/PowerApps/PowerAppsUrlMapper.cs
@@ -7,7 +7,7 @@ using Microsoft.PowerApps.TestEngine.Config;
 namespace Microsoft.PowerApps.TestEngine.PowerApps
 {
     /// <summary>
-    /// Map urls based on the cloud
+    /// Map urls
     /// </summary>
     public class PowerAppsUrlMapper : IUrlMapper
     {
@@ -20,7 +20,7 @@ namespace Microsoft.PowerApps.TestEngine.PowerApps
             _singleTestInstanceState = singleTestInstanceState;
         }
 
-        public string GenerateTestUrl(string additionalQueryParams)
+        public string GenerateTestUrl(string domain, string additionalQueryParams)
         {
             var environment = _testState.GetEnvironment();
             if (string.IsNullOrEmpty(environment))
@@ -51,10 +51,6 @@ namespace Microsoft.PowerApps.TestEngine.PowerApps
                 _singleTestInstanceState.GetLogger().LogError("Tenant cannot be empty.");
                 throw new InvalidOperationException();
             }
-
-            var cloud = _testState.GetCloud();
-
-            string domain = "apps.powerapps.com";
 
             var queryParametersForTestUrl = GetQueryParametersForTestUrl(tenantId, additionalQueryParams);
 

--- a/src/Microsoft.PowerApps.TestEngine/PowerApps/PowerAppsUrlMapper.cs
+++ b/src/Microsoft.PowerApps.TestEngine/PowerApps/PowerAppsUrlMapper.cs
@@ -54,26 +54,7 @@ namespace Microsoft.PowerApps.TestEngine.PowerApps
 
             var cloud = _testState.GetCloud();
 
-            if (cloud == null)
-            {
-                cloud = "";
-            }
-
-            string domain;
-            // TODO: implement the other clouds
-            switch (cloud.ToLower())
-            {
-                case "test":
-                    domain = "apps.test.powerapps.com";
-                    break;
-                case "prod":
-                    domain = "apps.powerapps.com";
-                    break;
-                default:
-                    // TODO: determine what happens on default
-                    domain = "apps.powerapps.com";
-                    break;
-            }
+            string domain = "apps.powerapps.com";
 
             var queryParametersForTestUrl = GetQueryParametersForTestUrl(tenantId, additionalQueryParams);
 

--- a/src/Microsoft.PowerApps.TestEngine/SingleTestRunner.cs
+++ b/src/Microsoft.PowerApps.TestEngine/SingleTestRunner.cs
@@ -51,7 +51,7 @@ namespace Microsoft.PowerApps.TestEngine
             _loggerFactory = loggerFactory;
         }
 
-        public async Task RunTestAsync(string testRunId, string testRunDirectory, TestSuiteDefinition testSuiteDefinition, BrowserConfiguration browserConfig, string queryParams)
+        public async Task RunTestAsync(string testRunId, string testRunDirectory, TestSuiteDefinition testSuiteDefinition, BrowserConfiguration browserConfig, string domain, string queryParams)
         {
             RunCount++;
 
@@ -94,7 +94,7 @@ namespace Microsoft.PowerApps.TestEngine
                 await _testInfraFunctions.SetupAsync();
                 Logger.LogInformation("Test infrastructure setup finished");
 
-                var desiredUrl = _urlMapper.GenerateTestUrl(queryParams);
+                var desiredUrl = _urlMapper.GenerateTestUrl(domain, queryParams);
                 Logger.LogTrace($"Desired URL: {desiredUrl}");
 
                 // Navigate to test url

--- a/src/Microsoft.PowerApps.TestEngine/TestEngine.cs
+++ b/src/Microsoft.PowerApps.TestEngine/TestEngine.cs
@@ -92,9 +92,9 @@ namespace Microsoft.PowerApps.TestEngine
                 _state.ParseAndSetTestState(testConfigFile);
                 _state.SetEnvironment(environmentId);
                 _state.SetTenant(tenantId);
+                _state.SetDomain(domain);
 
                 Logger.LogDebug($"Using domain: {domain}");
-                _state.SetDomain(domain);
 
                 await RunTestByWorkerCountAsync(testRunId, testRunDirectory, domain, queryParams);
                 _testReporter.EndTestRun(testRunId);

--- a/src/PowerAppsTestEngine/InputOptions.cs
+++ b/src/PowerAppsTestEngine/InputOptions.cs
@@ -11,5 +11,6 @@ namespace PowerAppsTestEngine
         public string? OutputDirectory { get; set; }
         public string? LogLevel { get; set; }
         public string? QueryParams { get; set; }
+        public string? Domain { get; set; }
     }
 }

--- a/src/PowerAppsTestEngine/Program.cs
+++ b/src/PowerAppsTestEngine/Program.cs
@@ -26,7 +26,8 @@ var switchMappings = new Dictionary<string, string>()
     { "-t", "TenantId" },
     { "-o", "OutputDirectory" },
     { "-l", "LogLevel" },
-    { "-q", "QueryParams" }
+    { "-q", "QueryParams" },
+    { "-d", "Domain" }
 };
 
 if (args.Length > 1)
@@ -117,6 +118,15 @@ else
         }
     }
 
+    if (!string.IsNullOrEmpty(inputOptions.Domain))
+    {
+        if (inputOptions.Domain.Substring(0, 1) == "-")
+        {
+            Console.Out.WriteLine("[Error]: Domain field is blank.");
+            return;
+        }
+    }
+
     var logLevel = LogLevel.Information; // Default log level
     if (!string.IsNullOrEmpty(inputOptions.LogLevel) && !Enum.TryParse(inputOptions.LogLevel, true, out logLevel))
     {
@@ -147,17 +157,22 @@ else
     .AddSingleton<TestEngine>()
     .BuildServiceProvider();
 
-
     TestEngine testEngine = serviceProvider.GetRequiredService<TestEngine>();
 
     var queryParams = "";
+    var domain = "apps.powerapps.com";
 
     if (!string.IsNullOrEmpty(inputOptions.QueryParams))
     {
         queryParams = inputOptions.QueryParams;
     }
 
-    var testResult = await testEngine.RunTestAsync(inputOptions.TestPlanFile, inputOptions.EnvironmentId, inputOptions.TenantId, inputOptions.OutputDirectory, "", queryParams);
+    if (!string.IsNullOrEmpty(inputOptions.Domain))
+    {
+        domain = inputOptions.Domain;
+    }
+
+    var testResult = await testEngine.RunTestAsync(inputOptions.TestPlanFile, inputOptions.EnvironmentId, inputOptions.TenantId, inputOptions.OutputDirectory, domain, queryParams);
 
     Console.Out.WriteLine($"Test results can be found here: {testResult}");
 }

--- a/src/PowerAppsTestEngine/config.json
+++ b/src/PowerAppsTestEngine/config.json
@@ -4,5 +4,6 @@
   "testPlanFile": "",
   "outputDirectory": "",
   "logLevel": "",
+  "domain":  "",
   "queryParams": ""
 }


### PR DESCRIPTION
## Description

Allow users to be able to specify what domain they want to target. Default will be: "apps.powerapps.com".

## Checklist

- [x] The code change is covered by unit tests. I have added tests that prove my fix is effective or that my feature works
- [x] I have performed end-to-end test locally.
- [x] New and existing unit tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I used clear names for everything
- [x] I have performed a self-review of my own code
