### PR TITLE
Skip 'Stay Signed In' if not present

### DIFF
--- a/src/Microsoft.PowerApps.TestEngine/SingleTestRunner.cs
+++ b/src/Microsoft.PowerApps.TestEngine/SingleTestRunner.cs
@@ -99,7 +99,7 @@ namespace Microsoft.PowerApps.TestEngine
 
                 // Navigate to test url
                 await _testInfraFunctions.GoToUrlAsync(desiredUrl);
-                Logger.LogInformation("Successfully navigate page to target URL.");
+                Logger.LogInformation("Successfully navigated to target URL");
 
                 // Log in user
                 await _userManager.LoginAsUserAsync(desiredUrl);

--- a/src/Microsoft.PowerApps.TestEngine/TestInfra/PlaywrightTestInfraFunctions.cs
+++ b/src/Microsoft.PowerApps.TestEngine/TestInfra/PlaywrightTestInfraFunctions.cs
@@ -332,7 +332,7 @@ namespace Microsoft.PowerApps.TestEngine.TestInfra
                     await this.ClickAsync("input[type=\"submit\"]");
 
                     PageWaitForSelectorOptions selectorOptions = new PageWaitForSelectorOptions();
-                    selectorOptions.Timeout = 8;
+                    selectorOptions.Timeout = 800;
 
                     // For instances where there is a 'Stay signed in?' dialogue box
                     try
@@ -356,7 +356,7 @@ namespace Microsoft.PowerApps.TestEngine.TestInfra
 
                         try
                         {
-                            selectorOptions.Timeout = 2;
+                            selectorOptions.Timeout = 200;
 
                             // Check if we received a password error
                             await Page.WaitForSelectorAsync("[id=\"passwordError\"]", selectorOptions);

--- a/src/Microsoft.PowerApps.TestEngine/TestInfra/PlaywrightTestInfraFunctions.cs
+++ b/src/Microsoft.PowerApps.TestEngine/TestInfra/PlaywrightTestInfraFunctions.cs
@@ -334,7 +334,7 @@ namespace Microsoft.PowerApps.TestEngine.TestInfra
                     // For instances where there is a 'Stay signed in?' dialogue box
                     try
                     {
-                         ValidatePage();
+                        ValidatePage();
 
                         logger.LogDebug("Checking if asked to stay signed in.");
 
@@ -360,7 +360,7 @@ namespace Microsoft.PowerApps.TestEngine.TestInfra
                             hasPasswordError = true;
                         }
                         catch (Exception peException)
-                        {  
+                        {
                             logger.LogDebug("Exception encountered: " + peException.ToString());
                         }
 

--- a/src/Microsoft.PowerApps.TestEngine/TestInfra/PlaywrightTestInfraFunctions.cs
+++ b/src/Microsoft.PowerApps.TestEngine/TestInfra/PlaywrightTestInfraFunctions.cs
@@ -336,16 +336,14 @@ namespace Microsoft.PowerApps.TestEngine.TestInfra
                     {
                         // Set options for the WaitForSelectorOptions function
                         PageWaitForSelectorOptions selectorOptions = new PageWaitForSelectorOptions();
-                        selectorOptions.Timeout = 0;
-
                         ValidatePage();
 
-                        logger.LogDebug("Checking for 'Stay signed in?' dialogue box.");
+                        logger.LogDebug("Checking for 'Stay signed in?' dialogue box");
 
                         // Check if we received a 'Stay signed in?' box?
-                        await Page.WaitForSelectorAsync("[id=\"idBtn_Back\"]", selectorOptions);
+                        await Page.WaitForSelectorAsync("[id=\"KmsiCheckboxField\"]", selectorOptions);
 
-                        logger.LogDebug("'Stay signed in?' dialogue box appeared.");
+                        logger.LogDebug("'Stay signed in?' dialogue box appeared");
 
                         // Click to stay signed in
                         await Page.ClickAsync("[id=\"idBtn_Back\"]");
@@ -353,12 +351,9 @@ namespace Microsoft.PowerApps.TestEngine.TestInfra
                     // If there is no 'Stay signed in?' box, an exception will throw; just catch and continue
                     catch (Exception)
                     {
-
-                        logger.LogDebug("'Stay signed in?' dialogue box did not appear.");
+                        logger.LogDebug("'Stay signed in?' dialogue box did not appear");
                     }
-
                     await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
-
                 }, options);
             }
             catch (TimeoutException)

--- a/src/Microsoft.PowerApps.TestEngine/TestInfra/PlaywrightTestInfraFunctions.cs
+++ b/src/Microsoft.PowerApps.TestEngine/TestInfra/PlaywrightTestInfraFunctions.cs
@@ -332,7 +332,7 @@ namespace Microsoft.PowerApps.TestEngine.TestInfra
                     await this.ClickAsync("input[type=\"submit\"]");
 
                     PageWaitForSelectorOptions selectorOptions = new PageWaitForSelectorOptions();
-                    selectorOptions.Timeout = 800;
+                    selectorOptions.Timeout = 8000;
 
                     // For instances where there is a 'Stay signed in?' dialogue box
                     try
@@ -356,7 +356,7 @@ namespace Microsoft.PowerApps.TestEngine.TestInfra
 
                         try
                         {
-                            selectorOptions.Timeout = 200;
+                            selectorOptions.Timeout = 2000;
 
                             // Check if we received a password error
                             await Page.WaitForSelectorAsync("[id=\"passwordError\"]", selectorOptions);

--- a/src/Microsoft.PowerApps.TestEngine/TestInfra/PlaywrightTestInfraFunctions.cs
+++ b/src/Microsoft.PowerApps.TestEngine/TestInfra/PlaywrightTestInfraFunctions.cs
@@ -331,15 +331,17 @@ namespace Microsoft.PowerApps.TestEngine.TestInfra
                     // Submit password form
                     await this.ClickAsync("input[type=\"submit\"]");
 
+                    PageWaitForSelectorOptions selectorOptions = new PageWaitForSelectorOptions();
+                    selectorOptions.Timeout = 8;
+
                     // For instances where there is a 'Stay signed in?' dialogue box
                     try
                     {
-                        ValidatePage();
-
+                        
                         logger.LogDebug("Checking if asked to stay signed in.");
 
                         // Check if we received a 'Stay signed in?' box?
-                        await Page.WaitForSelectorAsync("[id=\"KmsiCheckboxField\"]");
+                        await Page.WaitForSelectorAsync("[id=\"KmsiCheckboxField\"]", selectorOptions);
                         logger.LogDebug("Was asked to 'stay signed in'.");
 
                         // Click to stay signed in
@@ -355,8 +357,10 @@ namespace Microsoft.PowerApps.TestEngine.TestInfra
 
                         try
                         {
+                            selectorOptions.Timeout = 2;
+
                             // Check if we received a password error
-                            await Page.WaitForSelectorAsync("[id=\"passwordError\"]");
+                            await Page.WaitForSelectorAsync("[id=\"passwordError\"]", selectorOptions);
                             hasPasswordError = true;
                         }
                         catch (Exception peException)

--- a/src/Microsoft.PowerApps.TestEngine/TestInfra/PlaywrightTestInfraFunctions.cs
+++ b/src/Microsoft.PowerApps.TestEngine/TestInfra/PlaywrightTestInfraFunctions.cs
@@ -314,7 +314,7 @@ namespace Microsoft.PowerApps.TestEngine.TestInfra
 
             // URL that should be redirected to
             options.UrlString = desiredUrl;
-            
+
             ValidatePage();
 
             try
@@ -337,7 +337,7 @@ namespace Microsoft.PowerApps.TestEngine.TestInfra
                         // Set options for the WaitForSelectorOptions function
                         PageWaitForSelectorOptions selectorOptions = new PageWaitForSelectorOptions();
                         selectorOptions.Timeout = 0;
-                        
+
                         ValidatePage();
 
                         logger.LogDebug("Checking for 'Stay signed in?' dialogue box.");

--- a/src/Microsoft.PowerApps.TestEngine/TestInfra/PlaywrightTestInfraFunctions.cs
+++ b/src/Microsoft.PowerApps.TestEngine/TestInfra/PlaywrightTestInfraFunctions.cs
@@ -340,8 +340,12 @@ namespace Microsoft.PowerApps.TestEngine.TestInfra
                         
                         ValidatePage();
 
+                        logger.LogDebug("Checking for 'Stay signed in?' dialogue box.");
+
                         // Check if we received a 'Stay signed in?' box?
                         await Page.WaitForSelectorAsync("[id=\"idBtn_Back\"]", selectorOptions);
+
+                        logger.LogDebug("'Stay signed in?' dialogue box appeared.");
 
                         // Click to stay signed in
                         await Page.ClickAsync("[id=\"idBtn_Back\"]");
@@ -349,7 +353,8 @@ namespace Microsoft.PowerApps.TestEngine.TestInfra
                     // If there is no 'Stay signed in?' box, an exception will throw; just catch and continue
                     catch (Exception)
                     {
-                        
+
+                        logger.LogDebug("'Stay signed in?' dialogue box did not appear.");
                     }
 
                     await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);

--- a/src/Microsoft.PowerApps.TestEngine/TestInfra/PlaywrightTestInfraFunctions.cs
+++ b/src/Microsoft.PowerApps.TestEngine/TestInfra/PlaywrightTestInfraFunctions.cs
@@ -320,9 +320,12 @@ namespace Microsoft.PowerApps.TestEngine.TestInfra
                     await Page.FillAsync(selector, value);
                     await this.ClickAsync("input[type=\"submit\"]");
 
-                    ValidatePage();
-                    await Page.ClickAsync("[id=\"idBtn_Back\"]");
-                    await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+                    // Check if going to stay signed in page; may not always go there
+                    // if(){
+                        ValidatePage();
+                        await Page.ClickAsync("[id=\"idBtn_Back\"]");
+                        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+                    // }
                 }, options);
             }
             catch (TimeoutException)

--- a/src/Microsoft.PowerApps.TestEngine/TestInfra/PlaywrightTestInfraFunctions.cs
+++ b/src/Microsoft.PowerApps.TestEngine/TestInfra/PlaywrightTestInfraFunctions.cs
@@ -337,7 +337,6 @@ namespace Microsoft.PowerApps.TestEngine.TestInfra
                     // For instances where there is a 'Stay signed in?' dialogue box
                     try
                     {
-                        
                         logger.LogDebug("Checking if asked to stay signed in.");
 
                         // Check if we received a 'Stay signed in?' box?

--- a/src/Microsoft.PowerApps.TestEngine/TestInfra/PlaywrightTestInfraFunctions.cs
+++ b/src/Microsoft.PowerApps.TestEngine/TestInfra/PlaywrightTestInfraFunctions.cs
@@ -338,12 +338,8 @@ namespace Microsoft.PowerApps.TestEngine.TestInfra
                         PageWaitForSelectorOptions selectorOptions = new PageWaitForSelectorOptions();
                         ValidatePage();
 
-                        logger.LogDebug("Checking for 'Stay signed in?' dialogue box");
-
                         // Check if we received a 'Stay signed in?' box?
                         await Page.WaitForSelectorAsync("[id=\"KmsiCheckboxField\"]", selectorOptions);
-
-                        logger.LogDebug("'Stay signed in?' dialogue box appeared");
 
                         // Click to stay signed in
                         await Page.ClickAsync("[id=\"idBtn_Back\"]");
@@ -351,7 +347,6 @@ namespace Microsoft.PowerApps.TestEngine.TestInfra
                     // If there is no 'Stay signed in?' box, an exception will throw; just catch and continue
                     catch (Exception)
                     {
-                        logger.LogDebug("'Stay signed in?' dialogue box did not appear");
                     }
                     await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
                 }, options);


### PR DESCRIPTION
## Description

Test engine hard coded the step to click on the "stay signed in?" page during the sign-in process. For users with specific settings, they may not have the page, which blocks the test execution. Do not wait for 'Stay Signed In' if not present

## Checklist

- [ ] The code change is covered by unit tests. I have added tests that prove my fix is effective or that my feature works
- [x] I have performed end-to-end test locally.
- [x] New and existing unit tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I used clear names for everything
- [x] I have performed a self-review of my own code
