### PR TITLE
Fix SetProperty with Table input

### DIFF
--- a/src/Microsoft.PowerApps.TestEngine/Microsoft.PowerApps.TestEngine.csproj
+++ b/src/Microsoft.PowerApps.TestEngine/Microsoft.PowerApps.TestEngine.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0-preview.3.22175.4" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0-preview.3.22175.4" />
     <PackageReference Include="Microsoft.Playwright" Version="1.21.0" />
-    <PackageReference Include="Microsoft.PowerFx.Interpreter" Version="0.2.2-preview.20220802-315097" />
+    <PackageReference Include="Microsoft.PowerFx.Interpreter" Version="0.2.3-preview.20221122-330455" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="YamlDotNet" Version="11.2.1" />
   </ItemGroup>

--- a/src/Microsoft.PowerApps.TestEngine/PowerApps/PowerAppFunctions.cs
+++ b/src/Microsoft.PowerApps.TestEngine/PowerApps/PowerAppFunctions.cs
@@ -223,21 +223,21 @@ namespace Microsoft.PowerApps.TestEngine.PowerApps
             return await _testInfraFunctions.RunJavascriptAsync<bool>(expression);
         }
 
-        public async Task<bool> SetPropertyTableAsync(ItemPath itemPath, TableValue value)
+        public async Task<bool> SetPropertyTableAsync(ItemPath itemPath, TableValue tableValue)
         {
             ValidateItemPath(itemPath, false);
 
             var itemPathString = JsonConvert.SerializeObject(itemPath);
-            RecordValueObject[] jsonArr = new RecordValueObject[value.Rows.Count()];
+            RecordValueObject[] jsonArr = new RecordValueObject[tableValue.Rows.Count()];
 
             var index = 0;
-            foreach (var row in value.Rows)
+            foreach (var row in tableValue.Rows)
             {
                 if (row.IsValue)
                 {
-                    var recordValue = row.Value.GetField("Value");
+                    var recordValue = row.Value.Fields.First().Value;
                     var val = recordValue.GetType().GetProperty("Value").GetValue(recordValue).ToString();
-                    if (val != null)
+                    if (!String.IsNullOrEmpty(val))
                     {
                         jsonArr[index++] = new RecordValueObject(val);
                     }

--- a/src/nuget.config
+++ b/src/nuget.config
@@ -3,6 +3,6 @@
     <packageSources>
         <clear />
         <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />        
-        <add key="SDK@Local" value="https://pkgs.dev.azure.com/ConversationalAI/BotFramework/_packaging/SDK%40Local/nuget/v3/index.json" />
+        <add key="SDK@Local" value="https://pkgs.dev.azure.com/ConversationalAI/BotFramework/_packaging/SDK/nuget/v3/index.json" />
     </packageSources>
 </configuration>


### PR DESCRIPTION
# Pull Request Template

## Description

- The bug is that the SetProperty function only works for Table inputs like` Table( { Value: "Strawberry" }, { Value: "Vanilla" } )`. It should work for inputs like `Table({Color:"red"}, {Color:"green"}, {Color:"blue"})` as well. The previous code hard coded the property to be retrieved to be "Value". 
- Updated PowerFX version as we are out-of-date.

## Checklist

- [x] The code change is covered by unit tests. I have added tests that prove my fix is effective or that my feature works
- [x] I have performed end-to-end test locally.
- [x] New and existing unit tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I used clear names for everything
- [x] I have performed a self-review of my own code
