### PR TITLE
Modify SetProperty to work with JSSDK

### DIFF
--- a/src/Microsoft.PowerApps.TestEngine.Tests/PowerApps/PowerAppFunctionsTest.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/PowerApps/PowerAppFunctionsTest.cs
@@ -100,43 +100,49 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerApps
         [Fact]
         public async Task SetPropertyStringAsyncTest()
         {
-            MockTestInfraFunctions.Setup(x => x.RunJavascriptAsync<bool>(It.IsAny<string>(), It.IsAny<String[]>())).Returns(Task.FromResult(true));
+            MockTestInfraFunctions.Setup(x => x.RunJavascriptAsync<bool>(It.IsAny<string>())).Returns(Task.FromResult(true));
             var powerAppFunctions = new PowerAppFunctions(MockTestInfraFunctions.Object, MockSingleTestInstanceState.Object, MockTestState.Object);
             string itemPathString = "{\"controlName\":\"Button1\",\"index\":null,\"parentControl\":null,\"propertyName\":\"Text\"}";
             var itemPath = JsonConvert.DeserializeObject<ItemPath>(itemPathString);
-            var argument = new string[] { itemPathString, "A" };
-            var result = await powerAppFunctions.SetPropertyAsync(itemPath, StringValue.New("A"));
+            var value = "A";
+            var stringValue = StringValue.New(value);
+            var sanitizedValue = Uri.EscapeDataString(value.ToString());
+            var result = await powerAppFunctions.SetPropertyAsync(itemPath, stringValue);
 
             Assert.True(result);
-            MockTestInfraFunctions.Verify(x => x.RunJavascriptAsync<bool>("([itemPathString, objectValue]) => PowerAppsTestEngine.setPropertyValue(itemPathString, objectValue)", argument), Times.Once());
+            MockTestInfraFunctions.Verify(x => x.RunJavascriptAsync<bool>($"PowerAppsTestEngine.setPropertyValue({itemPathString}, \"{sanitizedValue}\")"), Times.Once());
         }
 
         [Fact]
         public async Task SetPropertyNumberAsyncTest()
         {
-            MockTestInfraFunctions.Setup(x => x.RunJavascriptAsync<bool>(It.IsAny<string>(), It.IsAny<String[]>())).Returns(Task.FromResult(true));
+            MockTestInfraFunctions.Setup(x => x.RunJavascriptAsync<bool>(It.IsAny<string>())).Returns(Task.FromResult(true));
             var powerAppFunctions = new PowerAppFunctions(MockTestInfraFunctions.Object, MockSingleTestInstanceState.Object, MockTestState.Object);
             string itemPathString = "{\"controlName\":\"Rating1\",\"index\":null,\"parentControl\":null,\"propertyName\":\"Value\"}";
             var itemPath = JsonConvert.DeserializeObject<ItemPath>(itemPathString);
-            var argument = new string[] { itemPathString, "5" };
-            var result = await powerAppFunctions.SetPropertyAsync(itemPath, NumberValue.New(5));
+            var value = 5;
+            var numberValue = NumberValue.New(value);
+            var sanitizedValue = Uri.EscapeDataString(value.ToString());
+            var result = await powerAppFunctions.SetPropertyAsync(itemPath, numberValue);
 
             Assert.True(result);
-            MockTestInfraFunctions.Verify(x => x.RunJavascriptAsync<bool>("([itemPathString, objectValue]) => PowerAppsTestEngine.setPropertyValue(itemPathString, objectValue)", argument), Times.Once());
+            MockTestInfraFunctions.Verify(x => x.RunJavascriptAsync<bool>($"PowerAppsTestEngine.setPropertyValue({itemPathString}, \"{sanitizedValue}\")"), Times.Once());
         }
 
         [Fact]
         public async Task SetPropertyBooleanAsyncTest()
         {
-            MockTestInfraFunctions.Setup(x => x.RunJavascriptAsync<bool>(It.IsAny<string>(), It.IsAny<String[]>())).Returns(Task.FromResult(true));
+            MockTestInfraFunctions.Setup(x => x.RunJavascriptAsync<bool>(It.IsAny<string>())).Returns(Task.FromResult(true));
             var powerAppFunctions = new PowerAppFunctions(MockTestInfraFunctions.Object, MockSingleTestInstanceState.Object, MockTestState.Object);
             string itemPathString = "{\"controlName\":\"Toggle1\",\"index\":null,\"parentControl\":null,\"propertyName\":\"Value\"}";
             var itemPath = JsonConvert.DeserializeObject<ItemPath>(itemPathString);
-            var argument = new string[] { itemPathString, "True" };
-            var result = await powerAppFunctions.SetPropertyAsync(itemPath, BooleanValue.New(true));
+            var value = true;
+            var booleanValue = BooleanValue.New(value);
+            var sanitizedValue = Uri.EscapeDataString(value.ToString());
+            var result = await powerAppFunctions.SetPropertyAsync(itemPath, booleanValue);
 
             Assert.True(result);
-            MockTestInfraFunctions.Verify(x => x.RunJavascriptAsync<bool>("([itemPathString, objectValue]) => PowerAppsTestEngine.setPropertyValue(itemPathString, objectValue)", argument), Times.Once());
+            MockTestInfraFunctions.Verify(x => x.RunJavascriptAsync<bool>($"PowerAppsTestEngine.setPropertyValue({itemPathString}, \"{sanitizedValue}\")"), Times.Once());
         }
 
         [Fact]
@@ -207,7 +213,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerApps
         {
             MockSingleTestInstanceState.Setup(x => x.GetLogger()).Returns(MockLogger.Object);
             MockLogger.Setup(x => x.Log<It.IsAnyType>(It.IsAny<LogLevel>(),It.IsAny<EventId>(), It.IsAny<It.IsAnyType>(), It.IsAny<Exception?>(), It.IsAny<Func<It.IsAnyType,Exception?,string>>()));
-            MockTestInfraFunctions.Setup(x => x.RunJavascriptAsync<bool>(It.IsAny<string>(), It.IsAny<string[]>())).Returns(Task.FromResult(true));
+            MockTestInfraFunctions.Setup(x => x.RunJavascriptAsync<bool>(It.IsAny<string>())).Returns(Task.FromResult(true));
 
             var powerAppFunctions = new PowerAppFunctions(MockTestInfraFunctions.Object, MockSingleTestInstanceState.Object, MockTestState.Object);
 
@@ -328,7 +334,6 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerApps
             expectedFormulaTypes.Add("AllItems2", TableType.Empty().Add(new NamedFormulaType("Gallery1", gallery1RecordType)).Add(new NamedFormulaType("Button3", button3RecordType)));
             expectedFormulaTypes.Add("SelectedItem2", RecordType.Empty().Add(new NamedFormulaType("Gallery1", gallery1RecordType)).Add(new NamedFormulaType("Button3", button3RecordType)));
 
-            var publishedAppIframeName = "fullscreen-app-host";
             MockSingleTestInstanceState.Setup(x => x.GetLogger()).Returns(MockLogger.Object);
             MockTestInfraFunctions.Setup(x => x.AddScriptTagAsync(It.IsAny<string>(), It.IsAny<string>())).Returns(Task.CompletedTask);
             MockTestInfraFunctions.Setup(x => x.RunJavascriptAsync<string>("PowerAppsTestEngine.getAppStatus()")).Returns(Task.FromResult("Idle"));
@@ -381,7 +386,6 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerApps
                     }
                 }
             };
-            var publishedAppIframeName = "fullscreen-app-host";
             MockSingleTestInstanceState.Setup(x => x.GetLogger()).Returns(MockLogger.Object);
             MockTestInfraFunctions.Setup(x => x.AddScriptTagAsync(It.IsAny<string>(), It.IsAny<string>())).Returns(Task.CompletedTask);
             MockTestInfraFunctions.Setup(x => x.RunJavascriptAsync<string>("PowerAppsTestEngine.getAppStatus()")).Returns(Task.FromResult("Idle"));
@@ -408,7 +412,6 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerApps
         [InlineData("{ controls: [] }")]
         public async Task LoadPowerAppsObjectModelAsyncWithNoModelTest(string jsObjectModelString)
         {
-            var publishedAppIframeName = "fullscreen-app-host";
             MockSingleTestInstanceState.Setup(x => x.GetLogger()).Returns(MockLogger.Object);
             MockTestInfraFunctions.Setup(x => x.AddScriptTagAsync(It.IsAny<string>(), It.IsAny<string>())).Returns(Task.CompletedTask);
             MockTestInfraFunctions.Setup(x => x.RunJavascriptAsync<string>("PowerAppsTestEngine.getAppStatus()")).Returns(Task.FromResult("Idle"));
@@ -525,7 +528,6 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerApps
         [Fact]
         public async Task LoadPowerAppsObjectModelAsyncWaitsForAppToLoad()
         {
-            var publishedAppIframeName = "fullscreen-app-host";
             MockSingleTestInstanceState.Setup(x => x.GetLogger()).Returns(MockLogger.Object);
             MockTestInfraFunctions.Setup(x => x.AddScriptTagAsync(It.IsAny<string>(), It.IsAny<string>())).Returns(Task.CompletedTask);
             MockTestInfraFunctions.SetupSequence(x => x.RunJavascriptAsync<string>("PowerAppsTestEngine.getAppStatus()"))
@@ -549,7 +551,6 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerApps
         [Fact]
         public async Task LoadPowerAppsObjectModelAsyncWaitsForAppToLoadWithExceptions()
         {
-            var publishedAppIframeName = "fullscreen-app-host";
             MockSingleTestInstanceState.Setup(x => x.GetLogger()).Returns(MockLogger.Object);
             MockTestInfraFunctions.Setup(x => x.AddScriptTagAsync(It.IsAny<string>(), It.IsAny<string>())).Returns(Task.CompletedTask);
             MockTestInfraFunctions.SetupSequence(x => x.RunJavascriptAsync<string>("PowerAppsTestEngine.getAppStatus()"))
@@ -574,7 +575,6 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerApps
         [Fact]
         public async Task LoadPowerAppsObjectModelAsyncWaitsForAppToBeIdle()
         {
-            var publishedAppIframeName = "fullscreen-app-host";
             MockSingleTestInstanceState.Setup(x => x.GetLogger()).Returns(MockLogger.Object);
             MockTestInfraFunctions.Setup(x => x.AddScriptTagAsync(It.IsAny<string>(), It.IsAny<string>())).Returns(Task.CompletedTask);
             MockTestInfraFunctions.SetupSequence(x => x.RunJavascriptAsync<string>("PowerAppsTestEngine.getAppStatus()"))
@@ -598,7 +598,6 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerApps
         [Fact]
         public async Task LoadPowerAppsObjectModelAsyncWaitsForAppToBeIdleWithExceptions()
         {
-            var publishedAppIframeName = "fullscreen-app-host";
             MockSingleTestInstanceState.Setup(x => x.GetLogger()).Returns(MockLogger.Object);
             MockTestInfraFunctions.Setup(x => x.AddScriptTagAsync(It.IsAny<string>(), It.IsAny<string>())).Returns(Task.CompletedTask);
             MockTestInfraFunctions.SetupSequence(x => x.RunJavascriptAsync<string>("PowerAppsTestEngine.getAppStatus()"))

--- a/src/Microsoft.PowerApps.TestEngine/Microsoft.PowerApps.TestEngine.csproj
+++ b/src/Microsoft.PowerApps.TestEngine/Microsoft.PowerApps.TestEngine.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0-preview.3.22175.4" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0-preview.3.22175.4" />
     <PackageReference Include="Microsoft.Playwright" Version="1.21.0" />
-    <PackageReference Include="Microsoft.PowerFx.Interpreter" Version="0.2.2-preview.20220802-315097" />
+    <PackageReference Include="Microsoft.PowerFx.Interpreter" Version="0.2.3-preview.20221122-330455" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="YamlDotNet" Version="11.2.1" />
   </ItemGroup>

--- a/src/Microsoft.PowerApps.TestEngine/PowerApps/PowerAppFunctions.cs
+++ b/src/Microsoft.PowerApps.TestEngine/PowerApps/PowerAppFunctions.cs
@@ -214,21 +214,21 @@ namespace Microsoft.PowerApps.TestEngine.PowerApps
             return await _testInfraFunctions.RunJavascriptAsync<bool>(expression);
         }
 
-        public async Task<bool> SetPropertyTableAsync(ItemPath itemPath, TableValue value)
+        public async Task<bool> SetPropertyTableAsync(ItemPath itemPath, TableValue tableValue)
         {
             ValidateItemPath(itemPath, false);
 
             var itemPathString = JsonConvert.SerializeObject(itemPath);
-            RecordValueObject[] jsonArr = new RecordValueObject[value.Rows.Count()];
+            RecordValueObject[] jsonArr = new RecordValueObject[tableValue.Rows.Count()];
 
             var index = 0;
-            foreach (var row in value.Rows)
+            foreach (var row in tableValue.Rows)
             {
                 if (row.IsValue)
                 {
-                    var recordValue = row.Value.GetField("Value");
+                    var recordValue = row.Value.Fields.First().Value;
                     var val = recordValue.GetType().GetProperty("Value").GetValue(recordValue).ToString();
-                    if (val != null)
+                    if (!String.IsNullOrEmpty(val))
                     {
                         jsonArr[index++] = new RecordValueObject(val);
                     }

--- a/src/Microsoft.PowerApps.TestEngine/PowerApps/PowerAppFunctions.cs
+++ b/src/Microsoft.PowerApps.TestEngine/PowerApps/PowerAppFunctions.cs
@@ -182,9 +182,9 @@ namespace Microsoft.PowerApps.TestEngine.PowerApps
             ValidateItemPath(itemPath, false);
             // TODO: handle components
             var itemPathString = JsonConvert.SerializeObject(itemPath);
-            var argument = new string[] { itemPathString, objectValue.ToString() };
-            var expression = "([itemPathString, objectValue]) => PowerAppsTestEngine.setPropertyValue(itemPathString, objectValue)";
-            return await _testInfraFunctions.RunJavascriptAsync<bool>(expression, argument);
+            var sanitizedObjectValue = Uri.EscapeDataString(objectValue.ToString());
+            var expression = $"PowerAppsTestEngine.setPropertyValue({itemPathString}, \"{sanitizedObjectValue}\")";
+            return await _testInfraFunctions.RunJavascriptAsync<bool>(expression);
         }
 
         public async Task<bool> SetPropertyDateAsync(ItemPath itemPath, DateValue value)

--- a/src/Microsoft.PowerApps.TestEngine/TestInfra/ITestInfraFunctions.cs
+++ b/src/Microsoft.PowerApps.TestEngine/TestInfra/ITestInfraFunctions.cs
@@ -73,7 +73,6 @@ namespace Microsoft.PowerApps.TestEngine.TestInfra
         /// <param name="jsExpression">Javascript expression to run</param>
         /// <returns>Return value of javascript</returns>
         public Task<T> RunJavascriptAsync<T>(string jsExpression);
-        public Task<T> RunJavascriptAsync<T>(string jsExpression, string[] arguments);
 
         /// <summary>
         /// Fills in user email 

--- a/src/Microsoft.PowerApps.TestEngine/TestInfra/PlaywrightTestInfraFunctions.cs
+++ b/src/Microsoft.PowerApps.TestEngine/TestInfra/PlaywrightTestInfraFunctions.cs
@@ -278,19 +278,6 @@ namespace Microsoft.PowerApps.TestEngine.TestInfra
             return await Page.EvaluateAsync<T>(jsExpression);
         }
 
-        public async Task<T> RunJavascriptAsync<T>(string jsExpression, string[] arguments)
-        {
-            ValidatePage();
-            var santizedArguments = new string[arguments.Length];
-            for (int i = 0; i < arguments.Length; i++)
-            { // encode and add to sanitizedArguments 
-                var argument = arguments[i];
-                var encode = Uri.EscapeDataString(argument);
-                santizedArguments[i] = encode;
-            }
-            return await Page.EvaluateAsync<T>(jsExpression, santizedArguments);
-        }
-
         // Justification: Limited ability to run unit tests for 
         // Playwright actions on the sign-in page
         [ExcludeFromCodeCoverage]

--- a/src/nuget.config
+++ b/src/nuget.config
@@ -3,6 +3,6 @@
     <packageSources>
         <clear />
         <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />        
-        <add key="SDK@Local" value="https://pkgs.dev.azure.com/ConversationalAI/BotFramework/_packaging/SDK%40Local/nuget/v3/index.json" />
+        <add key="SDK@Local" value="https://pkgs.dev.azure.com/ConversationalAI/BotFramework/_packaging/SDK/nuget/v3/index.json" />
     </packageSources>
 </configuration>


### PR DESCRIPTION
## Description

Modify SetProperty to work with JSSDK

### Details
- Fix the issue that _RunJavascriptAsync<T>(string jsExpression, string[] arguments)_ causes BadParameter error in PA-Client. Replace with _RunJavascriptAsync<T>(string jsExpression)_
- Merge in a main branch bug fix into JSSDK feature branch (when reviewing, I suggest review each commit respectively to avoid confusion)

## Checklist

- [x] The code change is covered by unit tests. I have added tests that prove my fix is effective or that my feature works
- [x] I have performed end-to-end test locally.
- [x] New and existing unit tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I used clear names for everything
- [x] I have performed a self-review of my own code
