### PR TITLE
Handling published without JSSDK errorcode

### DIFF
--- a/src/Microsoft.PowerApps.TestEngine.Tests/Helpers/ExceptionHandlingHelperTest.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/Helpers/ExceptionHandlingHelperTest.cs
@@ -19,12 +19,12 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Helpers
         [Fact]
         public void CheckIfOutDatedPublishedAppTrue()
         {
-            Exception exception= new Exception(PowerAppFunctions.PublishedAppWithoutJSSDKErrorCode);
+            Exception exception= new Exception(ExceptionHandlingHelper.PublishedAppWithoutJSSDKErrorCode);
             LoggingTestHelper.SetupMock(MockLogger);
             ExceptionHandlingHelper.CheckIfOutDatedPublishedApp(exception,MockLogger.Object);
 
             // Verify the message is logged in this case
-            LoggingTestHelper.VerifyLogging(MockLogger, PowerAppFunctions.PublishedAppWithoutJSSDKMessage, LogLevel.Error, Times.Once());
+            LoggingTestHelper.VerifyLogging(MockLogger, ExceptionHandlingHelper.PublishedAppWithoutJSSDKMessage, LogLevel.Error, Times.Once());
         }
         [Fact]
         public void CheckIfOutDatedPublishedAppFalse()
@@ -34,7 +34,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Helpers
             ExceptionHandlingHelper.CheckIfOutDatedPublishedApp(exception, MockLogger.Object);
 
             // Verify the message is never logged in this case
-            LoggingTestHelper.VerifyLogging(MockLogger, PowerAppFunctions.PublishedAppWithoutJSSDKMessage, LogLevel.Error, Times.Never());
+            LoggingTestHelper.VerifyLogging(MockLogger, ExceptionHandlingHelper.PublishedAppWithoutJSSDKMessage, LogLevel.Error, Times.Never());
         }
 
     }

--- a/src/Microsoft.PowerApps.TestEngine.Tests/Helpers/ExceptionHandlingHelperTest.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/Helpers/ExceptionHandlingHelperTest.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using Microsoft.Extensions.Logging;
+using Microsoft.PowerApps.TestEngine.Helpers;
+using Microsoft.PowerApps.TestEngine.PowerApps;
+using Moq;
+using Xunit;
+
+namespace Microsoft.PowerApps.TestEngine.Tests.Helpers
+{
+    public class ExceptionHandlingHelperTest
+    {
+        private Mock<ILogger> MockLogger;
+
+        public ExceptionHandlingHelperTest()
+        {
+            MockLogger = new Mock<ILogger>(MockBehavior.Strict);
+        }
+
+        [Fact]
+        public void CheckIfOutDatedPublishedAppTrue()
+        {
+            Exception exception= new Exception(PowerAppFunctions.PublishedAppWithoutJSSDKErrorCode);
+            LoggingTestHelper.SetupMock(MockLogger);
+            ExceptionHandlingHelper.CheckIfOutDatedPublishedApp(exception,MockLogger.Object);
+
+            // Verify the message is logged in this case
+            LoggingTestHelper.VerifyLogging(MockLogger, PowerAppFunctions.PublishedAppWithoutJSSDKMessage, LogLevel.Error, Times.Once());
+        }
+        [Fact]
+        public void CheckIfOutDatedPublishedAppFalse()
+        {
+            Exception exception = new Exception();
+            LoggingTestHelper.SetupMock(MockLogger);
+            ExceptionHandlingHelper.CheckIfOutDatedPublishedApp(exception, MockLogger.Object);
+
+            // Verify the message is never logged in this case
+            LoggingTestHelper.VerifyLogging(MockLogger, PowerAppFunctions.PublishedAppWithoutJSSDKMessage, LogLevel.Error, Times.Never());
+        }
+
+    }
+}

--- a/src/Microsoft.PowerApps.TestEngine.Tests/PowerApps/PowerAppFunctionsTest.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/PowerApps/PowerAppFunctionsTest.cs
@@ -674,7 +674,8 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerApps
         // Testing if app outdated and needs to be republished, error thrown right and captured
         // Published App JSSDK not found tests
         [Fact]
-        public async Task CheckIfAppIsIdleAsyncFailsWithNoPublishedAppFunction() {
+        public async Task CheckIfAppIsIdleAsyncFailsWithNoPublishedAppFunction()
+        {
             MockSingleTestInstanceState.Setup(x => x.GetLogger()).Returns(MockLogger.Object);
             MockTestInfraFunctions.SetupSequence(x => x.RunJavascriptAsync<string>("typeof PowerAppsTestEngine"))
                 .Returns(Task.FromResult("object"));
@@ -740,7 +741,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerApps
             var itemPath = JsonConvert.DeserializeObject<ItemPath>(itemPathString);
 
             var pair = new KeyValuePair<string, FormulaValue>("Value", StringValue.New("2"));
-            var nameValue = new NamedValue(pair);         
+            var nameValue = new NamedValue(pair);
 
             MockSingleTestInstanceState.Setup(x => x.GetLogger()).Returns(MockLogger.Object);
             MockTestInfraFunctions.Setup(x => x.RunJavascriptAsync<bool>(It.IsAny<string>()))
@@ -843,7 +844,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerApps
             MockTestInfraFunctions.Verify(x => x.RunJavascriptAsync<string>($"PowerAppsTestEngine.getPropertyValue({JsonConvert.SerializeObject(itemPath)}).then((propertyValue) => JSON.stringify(propertyValue));"), Times.Once());
             LoggingTestHelper.VerifyLogging(MockLogger, PowerAppFunctions.PublishedAppWithoutJSSDKMessage, LogLevel.Error, Times.Once());
         }
-        
+
         // End Published App JSSDK not found tests
     }
 }

--- a/src/Microsoft.PowerApps.TestEngine.Tests/PowerApps/PowerAppFunctionsTest.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/PowerApps/PowerAppFunctionsTest.cs
@@ -671,16 +671,14 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerApps
             LoggingTestHelper.VerifyLogging(MockLogger, "Start to load power apps object model", LogLevel.Debug, Times.Once());
         }
 
-
         // Testing if app outdated and needs to be republished, error thrown right and captured
         // Published App JSSDK not found tests
         [Fact]
         public async Task CheckIfAppIsIdleAsyncFailsWithNoPublishedAppFunction() {
             MockSingleTestInstanceState.Setup(x => x.GetLogger()).Returns(MockLogger.Object);
-            MockTestInfraFunctions.Setup(x => x.AddScriptTagAsync(It.IsAny<string>(), It.IsAny<string>())).Returns(Task.CompletedTask);
             MockTestInfraFunctions.SetupSequence(x => x.RunJavascriptAsync<string>("typeof PowerAppsTestEngine"))
                 .Returns(Task.FromResult("object"));
-            MockTestInfraFunctions.SetupSequence(x => x.RunJavascriptAsync<string>("PowerAppsTestEngine.getAppStatus()"))
+            MockTestInfraFunctions.Setup(x => x.RunJavascriptAsync<string>(It.IsAny<string>()))
                 .Throws(new Exception("1"));
 
             var testSettings = new TestSettings() { Timeout = 3000 };
@@ -691,7 +689,161 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerApps
             await Assert.ThrowsAsync<Exception>(async () => { await powerAppFunctions.LoadPowerAppsObjectModelAsync(); });
 
             MockTestInfraFunctions.Verify(x => x.RunJavascriptAsync<string>("PowerAppsTestEngine.getAppStatus()"), Times.AtLeast(1));
+            LoggingTestHelper.VerifyLogging(MockLogger, PowerAppFunctions.PublishedAppWithoutJSSDKMessage, LogLevel.Error, Times.Once());
         }
+
+        [Fact]
+        public async Task LoadPowerAppsObjectModelAsyncNoPublishedAppFunction()
+        {
+            MockSingleTestInstanceState.Setup(x => x.GetLogger()).Returns(MockLogger.Object);
+            MockTestInfraFunctions.Setup(x => x.AddScriptTagAsync(It.IsAny<string>(), It.IsAny<string>())).Returns(Task.CompletedTask);
+            MockTestInfraFunctions.SetupSequence(x => x.RunJavascriptAsync<string>("typeof PowerAppsTestEngine"))
+                .Returns(Task.FromResult("object"));
+            MockTestInfraFunctions.Setup(x => x.RunJavascriptAsync<string>("PowerAppsTestEngine.getAppStatus()"))
+                .Returns(Task.FromResult("Idle"));
+            MockTestInfraFunctions.Setup(x => x.RunJavascriptAsync<string>("PowerAppsTestEngine.buildObjectModel().then((objectModel) => JSON.stringify(objectModel));")).Throws(new Exception("1"));
+
+            var testSettings = new TestSettings() { Timeout = 12000 };
+            MockTestState.Setup(x => x.GetTestSettings()).Returns(testSettings);
+            LoggingTestHelper.SetupMock(MockLogger);
+            var powerAppFunctions = new PowerAppFunctions(MockTestInfraFunctions.Object, MockSingleTestInstanceState.Object, MockTestState.Object);
+            await Assert.ThrowsAsync<Exception>(async () => { await powerAppFunctions.LoadPowerAppsObjectModelAsync(); });
+
+            MockTestInfraFunctions.Verify(x => x.RunJavascriptAsync<string>("typeof PowerAppsTestEngine"), Times.Once());
+            MockTestInfraFunctions.Verify(x => x.RunJavascriptAsync<string>("PowerAppsTestEngine.getAppStatus()"), Times.Once());
+            MockTestInfraFunctions.Verify(x => x.RunJavascriptAsync<string>("PowerAppsTestEngine.buildObjectModel().then((objectModel) => JSON.stringify(objectModel));"), Times.Once());
+            LoggingTestHelper.VerifyLogging(MockLogger, "Start to load power apps object model", LogLevel.Debug, Times.Once());
+            LoggingTestHelper.VerifyLogging(MockLogger, PowerAppFunctions.PublishedAppWithoutJSSDKMessage, LogLevel.Error, Times.Once());
+        }
+
+        [Fact]
+        public async Task SelectControlAsyncFailsNoPublishedAppFunction()
+        {
+            var itemPath = JsonConvert.DeserializeObject<ItemPath>("{\"controlName\":\"Label1\",\"index\":null,\"parentControl\":null,\"propertyName\":null}");
+
+            MockSingleTestInstanceState.Setup(x => x.GetLogger()).Returns(MockLogger.Object);
+            MockTestInfraFunctions.Setup(x => x.RunJavascriptAsync<bool>(It.IsAny<string>()))
+                .Throws(new Exception("1"));
+
+            LoggingTestHelper.SetupMock(MockLogger);
+            var powerAppFunctions = new PowerAppFunctions(MockTestInfraFunctions.Object, MockSingleTestInstanceState.Object, MockTestState.Object);
+            await Assert.ThrowsAsync<Exception>(async () => { await powerAppFunctions.SelectControlAsync(itemPath); });
+
+            MockTestInfraFunctions.Verify(x => x.RunJavascriptAsync<bool>(It.IsAny<string>()), Times.Once());
+            LoggingTestHelper.VerifyLogging(MockLogger, PowerAppFunctions.PublishedAppWithoutJSSDKMessage, LogLevel.Error, Times.Once());
+        }
+
+        [Fact]
+        public async Task SetPropertyRecordAsyncNoPublishedAppFunction()
+        {
+            string itemPathString = "{\"controlName\":\"Dropdown1\",\"index\":null,\"parentControl\":null,\"propertyName\":\"Selected\"}";
+            var itemPath = JsonConvert.DeserializeObject<ItemPath>(itemPathString);
+
+            var pair = new KeyValuePair<string, FormulaValue>("Value", StringValue.New("2"));
+            var nameValue = new NamedValue(pair);         
+
+            MockSingleTestInstanceState.Setup(x => x.GetLogger()).Returns(MockLogger.Object);
+            MockTestInfraFunctions.Setup(x => x.RunJavascriptAsync<bool>(It.IsAny<string>()))
+                .Throws(new Exception("1"));
+
+            LoggingTestHelper.SetupMock(MockLogger);
+            var powerAppFunctions = new PowerAppFunctions(MockTestInfraFunctions.Object, MockSingleTestInstanceState.Object, MockTestState.Object);
+            await Assert.ThrowsAsync<Exception>(async () => { await powerAppFunctions.SetPropertyRecordAsync(itemPath, RecordValue.NewRecordFromFields(nameValue)); });
+            var value = "{\"Value\":\"2\"}";
+
+            MockTestInfraFunctions.Verify(x => x.RunJavascriptAsync<bool>($"PowerAppsTestEngine.setPropertyValue({itemPathString},{{\"Selected\":{value}}})"), Times.Once());
+            LoggingTestHelper.VerifyLogging(MockLogger, PowerAppFunctions.PublishedAppWithoutJSSDKMessage, LogLevel.Error, Times.Once());
+        }
+
+        [Fact]
+        public async Task SetPropertyTableAsyncNoPublishedAppFunction()
+        {
+            string itemPathString = "{\"controlName\":\"ComboBox1\",\"index\":null,\"parentControl\":null,\"propertyName\":\"SelectedItems\"}";
+            var itemPath = JsonConvert.DeserializeObject<ItemPath>(itemPathString);
+
+            //Record Type for table 
+            var controlType = RecordType.Empty().Add("Value", FormulaType.String);
+
+            //First record value for table 
+            var pair1 = new KeyValuePair<string, FormulaValue>("Value", StringValue.New("2"));
+            var name1Value = new NamedValue(pair1);
+            var record1Value = RecordValue.NewRecordFromFields(name1Value);
+
+            //Second record value for table 
+            var pair2 = new KeyValuePair<string, FormulaValue>("Value", StringValue.New("3"));
+            var name2Value = new NamedValue(pair2);
+            var record2Value = RecordValue.NewRecordFromFields(name2Value);
+
+            RecordValue[] values = new RecordValue[] { record1Value, record2Value };
+            var value = "[{\"Value\":\"2\"},{\"Value\":\"3\"}]";
+
+            MockSingleTestInstanceState.Setup(x => x.GetLogger()).Returns(MockLogger.Object);
+            MockTestInfraFunctions.Setup(x => x.RunJavascriptAsync<bool>(It.IsAny<string>()))
+                .Throws(new Exception("1"));
+
+            LoggingTestHelper.SetupMock(MockLogger);
+            var powerAppFunctions = new PowerAppFunctions(MockTestInfraFunctions.Object, MockSingleTestInstanceState.Object, MockTestState.Object);
+            await Assert.ThrowsAsync<Exception>(async () => { await powerAppFunctions.SetPropertyTableAsync(itemPath, TableValue.NewTable(controlType, values)); });
+
+            MockTestInfraFunctions.Verify(x => x.RunJavascriptAsync<bool>($"PowerAppsTestEngine.setPropertyValue({itemPathString},{{\"SelectedItems\":{value}}})"), Times.Once());
+            LoggingTestHelper.VerifyLogging(MockLogger, PowerAppFunctions.PublishedAppWithoutJSSDKMessage, LogLevel.Error, Times.Once());
+        }
+
+        [Fact]
+        public async Task SetPropertyDateAsyncNoPublishedAppFunction()
+        {
+            DateTime dt = new DateTime(1970, 1, 1, 0, 0, 0);
+            string itemPathString = "{\"controlName\":\"DatePicker1\",\"index\":null,\"parentControl\":null,\"propertyName\":\"SelectedDate\"}";
+            var itemPath = JsonConvert.DeserializeObject<ItemPath>(itemPathString);
+
+            MockSingleTestInstanceState.Setup(x => x.GetLogger()).Returns(MockLogger.Object);
+            MockTestInfraFunctions.Setup(x => x.RunJavascriptAsync<bool>(It.IsAny<string>()))
+                .Throws(new Exception("1"));
+
+            LoggingTestHelper.SetupMock(MockLogger);
+            var powerAppFunctions = new PowerAppFunctions(MockTestInfraFunctions.Object, MockSingleTestInstanceState.Object, MockTestState.Object);
+            await Assert.ThrowsAsync<Exception>(async () => { await powerAppFunctions.SetPropertyDateAsync(itemPath, DateValue.NewDateOnly(dt.Date)); });
+
+            MockTestInfraFunctions.Verify(x => x.RunJavascriptAsync<bool>($"PowerAppsTestEngine.setPropertyValue({itemPathString},{{\"SelectedDate\":Date.parse(\"{((DateValue)DateValue.NewDateOnly(dt.Date)).Value}\")}})"), Times.Once());
+            LoggingTestHelper.VerifyLogging(MockLogger, PowerAppFunctions.PublishedAppWithoutJSSDKMessage, LogLevel.Error, Times.Once());
+        }
+
+        [Fact]
+        public async Task GetItemCountAsyncNoPublishedAppFunction()
+        {
+            var itemPath = JsonConvert.DeserializeObject<ItemPath>("{\"controlName\":\"Button1\",\"index\":null,\"parentControl\":null,\"propertyName\":null}");
+
+            MockTestState.Setup(x => x.GetTimeout()).Returns(30000);
+            MockSingleTestInstanceState.Setup(x => x.GetLogger()).Returns(MockLogger.Object);
+            MockTestInfraFunctions.Setup(x => x.RunJavascriptAsync<int>(It.IsAny<string>()))
+                .Throws(new Exception("1"));
+
+            LoggingTestHelper.SetupMock(MockLogger);
+            var powerAppFunctions = new PowerAppFunctions(MockTestInfraFunctions.Object, MockSingleTestInstanceState.Object, MockTestState.Object);
+
+            await Assert.ThrowsAsync<Exception>(async () => { powerAppFunctions.GetItemCount(itemPath); });
+            MockTestInfraFunctions.Verify(x => x.RunJavascriptAsync<int>($"PowerAppsTestEngine.getItemCount({JsonConvert.SerializeObject(itemPath)})"), Times.Once());
+            LoggingTestHelper.VerifyLogging(MockLogger, PowerAppFunctions.PublishedAppWithoutJSSDKMessage, LogLevel.Error, Times.Once());
+        }
+
+        [Fact]
+        public async Task GetPropertyAsyncNoPublishedAppFunction()
+        {
+            var itemPath = JsonConvert.DeserializeObject<ItemPath>("{\"controlName\":\"Label1\",\"index\":null,\"parentControl\":null,\"propertyName\":\"Text\"}");
+
+            MockTestState.Setup(x => x.GetTimeout()).Returns(30000);
+            MockSingleTestInstanceState.Setup(x => x.GetLogger()).Returns(MockLogger.Object);
+            MockTestInfraFunctions.Setup(x => x.RunJavascriptAsync<string>(It.IsAny<string>()))
+                .Throws(new Exception("1"));
+
+            LoggingTestHelper.SetupMock(MockLogger);
+            var powerAppFunctions = new PowerAppFunctions(MockTestInfraFunctions.Object, MockSingleTestInstanceState.Object, MockTestState.Object);
+
+            await Assert.ThrowsAsync<Exception>(async () => { powerAppFunctions.GetPropertyValueFromControl<string>(itemPath); });
+            MockTestInfraFunctions.Verify(x => x.RunJavascriptAsync<string>($"PowerAppsTestEngine.getPropertyValue({JsonConvert.SerializeObject(itemPath)}).then((propertyValue) => JSON.stringify(propertyValue));"), Times.Once());
+            LoggingTestHelper.VerifyLogging(MockLogger, PowerAppFunctions.PublishedAppWithoutJSSDKMessage, LogLevel.Error, Times.Once());
+        }
+        
         // End Published App JSSDK not found tests
     }
 }

--- a/src/Microsoft.PowerApps.TestEngine.Tests/PowerApps/PowerAppFunctionsTest.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/PowerApps/PowerAppFunctionsTest.cs
@@ -670,23 +670,27 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerApps
             LoggingTestHelper.VerifyLogging(MockLogger, "Start to load power apps object model", LogLevel.Debug, Times.Once());
         }
 
+
+        // Testing if app outdated and needs to be republished, error thrown right and captured
+        // Published App JSSDK not found tests
         [Fact]
-        public async Task CheckIfAppIsIdleAsyncFailsWithNoPublishedAppJSSDK() {
+        public async Task CheckIfAppIsIdleAsyncFailsWithNoPublishedAppFunction() {
             MockSingleTestInstanceState.Setup(x => x.GetLogger()).Returns(MockLogger.Object);
             MockTestInfraFunctions.Setup(x => x.AddScriptTagAsync(It.IsAny<string>(), It.IsAny<string>())).Returns(Task.CompletedTask);
             MockTestInfraFunctions.SetupSequence(x => x.RunJavascriptAsync<string>("typeof PowerAppsTestEngine"))
                 .Returns(Task.FromResult("object"));
             MockTestInfraFunctions.SetupSequence(x => x.RunJavascriptAsync<string>("PowerAppsTestEngine.getAppStatus()"))
                 .Throws(new Exception("1"));
+
             var testSettings = new TestSettings() { Timeout = 3000 };
             MockTestState.Setup(x => x.GetTestSettings()).Returns(testSettings);
+
             LoggingTestHelper.SetupMock(MockLogger);
             var powerAppFunctions = new PowerAppFunctions(MockTestInfraFunctions.Object, MockSingleTestInstanceState.Object, MockTestState.Object);
             await Assert.ThrowsAsync<Exception>(async () => { await powerAppFunctions.LoadPowerAppsObjectModelAsync(); });
 
-            MockTestInfraFunctions.Verify(x => x.RunJavascriptAsync<string>("typeof PowerAppsTestEngine"), Times.AtLeastOnce());
             MockTestInfraFunctions.Verify(x => x.RunJavascriptAsync<string>("PowerAppsTestEngine.getAppStatus()"), Times.AtLeast(1));
-            LoggingTestHelper.VerifyLogging(MockLogger, PowerAppFunctions.PublishedAppWithoutJSSDKMessage, LogLevel.Error, Times.Once());
         }
+        // End Published App JSSDK not found tests
     }
 }

--- a/src/Microsoft.PowerApps.TestEngine.Tests/PowerApps/PowerAppFunctionsTest.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/PowerApps/PowerAppFunctionsTest.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.PowerApps.TestEngine.Config;
+using Microsoft.PowerApps.TestEngine.Helpers;
 using Microsoft.PowerApps.TestEngine.PowerApps;
 using Microsoft.PowerApps.TestEngine.TestInfra;
 using Microsoft.PowerApps.TestEngine.Tests.Helpers;
@@ -714,7 +715,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerApps
             await Assert.ThrowsAsync<Exception>(async () => { await powerAppFunctions.LoadPowerAppsObjectModelAsync(); });
 
             MockTestInfraFunctions.Verify(x => x.RunJavascriptAsync<string>("PowerAppsTestEngine.getAppStatus()"), Times.AtLeast(1));
-            LoggingTestHelper.VerifyLogging(MockLogger, PowerAppFunctions.PublishedAppWithoutJSSDKMessage, LogLevel.Error, Times.Once());
+            LoggingTestHelper.VerifyLogging(MockLogger, ExceptionHandlingHelper.PublishedAppWithoutJSSDKMessage, LogLevel.Error, Times.Once());
         }
 
         [Fact]
@@ -738,7 +739,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerApps
             MockTestInfraFunctions.Verify(x => x.RunJavascriptAsync<string>("PowerAppsTestEngine.getAppStatus()"), Times.Once());
             MockTestInfraFunctions.Verify(x => x.RunJavascriptAsync<string>("PowerAppsTestEngine.buildObjectModel().then((objectModel) => JSON.stringify(objectModel));"), Times.Once());
             LoggingTestHelper.VerifyLogging(MockLogger, "Start to load power apps object model", LogLevel.Debug, Times.Once());
-            LoggingTestHelper.VerifyLogging(MockLogger, PowerAppFunctions.PublishedAppWithoutJSSDKMessage, LogLevel.Error, Times.Once());
+            LoggingTestHelper.VerifyLogging(MockLogger, ExceptionHandlingHelper.PublishedAppWithoutJSSDKMessage, LogLevel.Error, Times.Once());
         }
 
         [Fact]
@@ -755,7 +756,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerApps
             await Assert.ThrowsAsync<Exception>(async () => { await powerAppFunctions.SelectControlAsync(itemPath); });
 
             MockTestInfraFunctions.Verify(x => x.RunJavascriptAsync<bool>(It.IsAny<string>()), Times.Once());
-            LoggingTestHelper.VerifyLogging(MockLogger, PowerAppFunctions.PublishedAppWithoutJSSDKMessage, LogLevel.Error, Times.Once());
+            LoggingTestHelper.VerifyLogging(MockLogger, ExceptionHandlingHelper.PublishedAppWithoutJSSDKMessage, LogLevel.Error, Times.Once());
         }
 
         [Fact]
@@ -777,7 +778,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerApps
             var value = "{\"Value\":\"2\"}";
 
             MockTestInfraFunctions.Verify(x => x.RunJavascriptAsync<bool>($"PowerAppsTestEngine.setPropertyValue({itemPathString},{{\"Selected\":{value}}})"), Times.Once());
-            LoggingTestHelper.VerifyLogging(MockLogger, PowerAppFunctions.PublishedAppWithoutJSSDKMessage, LogLevel.Error, Times.Once());
+            LoggingTestHelper.VerifyLogging(MockLogger, ExceptionHandlingHelper.PublishedAppWithoutJSSDKMessage, LogLevel.Error, Times.Once());
         }
 
         [Fact]
@@ -811,7 +812,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerApps
             await Assert.ThrowsAsync<Exception>(async () => { await powerAppFunctions.SetPropertyTableAsync(itemPath, TableValue.NewTable(controlType, values)); });
 
             MockTestInfraFunctions.Verify(x => x.RunJavascriptAsync<bool>($"PowerAppsTestEngine.setPropertyValue({itemPathString},{{\"SelectedItems\":{value}}})"), Times.Once());
-            LoggingTestHelper.VerifyLogging(MockLogger, PowerAppFunctions.PublishedAppWithoutJSSDKMessage, LogLevel.Error, Times.Once());
+            LoggingTestHelper.VerifyLogging(MockLogger, ExceptionHandlingHelper.PublishedAppWithoutJSSDKMessage, LogLevel.Error, Times.Once());
         }
 
         [Fact]
@@ -830,7 +831,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerApps
             await Assert.ThrowsAsync<Exception>(async () => { await powerAppFunctions.SetPropertyDateAsync(itemPath, DateValue.NewDateOnly(dt.Date)); });
 
             MockTestInfraFunctions.Verify(x => x.RunJavascriptAsync<bool>($"PowerAppsTestEngine.setPropertyValue({itemPathString},{{\"SelectedDate\":Date.parse(\"{((DateValue)DateValue.NewDateOnly(dt.Date)).Value}\")}})"), Times.Once());
-            LoggingTestHelper.VerifyLogging(MockLogger, PowerAppFunctions.PublishedAppWithoutJSSDKMessage, LogLevel.Error, Times.Once());
+            LoggingTestHelper.VerifyLogging(MockLogger, ExceptionHandlingHelper.PublishedAppWithoutJSSDKMessage, LogLevel.Error, Times.Once());
         }
 
         [Fact]
@@ -848,7 +849,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerApps
 
             await Assert.ThrowsAsync<Exception>(async () => { powerAppFunctions.GetItemCount(itemPath); });
             MockTestInfraFunctions.Verify(x => x.RunJavascriptAsync<int>($"PowerAppsTestEngine.getItemCount({JsonConvert.SerializeObject(itemPath)})"), Times.Once());
-            LoggingTestHelper.VerifyLogging(MockLogger, PowerAppFunctions.PublishedAppWithoutJSSDKMessage, LogLevel.Error, Times.Once());
+            LoggingTestHelper.VerifyLogging(MockLogger, ExceptionHandlingHelper.PublishedAppWithoutJSSDKMessage, LogLevel.Error, Times.Once());
         }
 
         [Fact]
@@ -866,7 +867,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerApps
 
             await Assert.ThrowsAsync<Exception>(async () => { powerAppFunctions.GetPropertyValueFromControl<string>(itemPath); });
             MockTestInfraFunctions.Verify(x => x.RunJavascriptAsync<string>($"PowerAppsTestEngine.getPropertyValue({JsonConvert.SerializeObject(itemPath)}).then((propertyValue) => JSON.stringify(propertyValue));"), Times.Once());
-            LoggingTestHelper.VerifyLogging(MockLogger, PowerAppFunctions.PublishedAppWithoutJSSDKMessage, LogLevel.Error, Times.Once());
+            LoggingTestHelper.VerifyLogging(MockLogger, ExceptionHandlingHelper.PublishedAppWithoutJSSDKMessage, LogLevel.Error, Times.Once());
         }
 
         // End Published App JSSDK not found tests

--- a/src/Microsoft.PowerApps.TestEngine.Tests/PowerApps/PowerAppFunctionsTest.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/PowerApps/PowerAppFunctionsTest.cs
@@ -236,6 +236,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerApps
         {
             var itemPath = JsonConvert.DeserializeObject<ItemPath>("{\"controlName\":\"Button1\",\"index\":null,\"parentControl\":null,\"propertyName\":\"Text\"}");
             Guid guid = new Guid("00000000-0000-0000-0000-000000000001");
+            MockSingleTestInstanceState.Setup(x => x.GetLogger()).Returns(MockLogger.Object);
 
             var powerAppFunctions = new PowerAppFunctions(MockTestInfraFunctions.Object, MockSingleTestInstanceState.Object, MockTestState.Object);
             await Assert.ThrowsAsync<ArgumentException>(async () => await powerAppFunctions.SetPropertyAsync(itemPath, GuidValue.New(guid)));

--- a/src/Microsoft.PowerApps.TestEngine/Helpers/ExceptionHandlingHelper.cs
+++ b/src/Microsoft.PowerApps.TestEngine/Helpers/ExceptionHandlingHelper.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.PowerApps.TestEngine.PowerApps;
+
+namespace Microsoft.PowerApps.TestEngine.Helpers
+{
+    internal static class ExceptionHandlingHelper
+    {
+        public static void CheckIfOutDatedPublishedApp(Exception ex, ILogger logger)
+        {
+            if (ex.Message?.ToString() == PowerAppFunctions.PublishedAppWithoutJSSDKErrorCode || ex.InnerException?.Message?.ToString() == PowerAppFunctions.PublishedAppWithoutJSSDKErrorCode)
+            {
+                logger.LogError(PowerAppFunctions.PublishedAppWithoutJSSDKMessage);
+            }
+        }
+    }
+}

--- a/src/Microsoft.PowerApps.TestEngine/Helpers/ExceptionHandlingHelper.cs
+++ b/src/Microsoft.PowerApps.TestEngine/Helpers/ExceptionHandlingHelper.cs
@@ -10,11 +10,16 @@ namespace Microsoft.PowerApps.TestEngine.Helpers
 {
     public static class ExceptionHandlingHelper
     {
+
+        // Error code suggesting published app without JSSDK, error code sent from the serverside JSSDK code
+        public static string PublishedAppWithoutJSSDKErrorCode = "1";
+        public static string PublishedAppWithoutJSSDKMessage = "Please republish the app and try again!";
+
         public static void CheckIfOutDatedPublishedApp(Exception ex, ILogger logger)
         {
-            if (ex.Message?.ToString() == PowerAppFunctions.PublishedAppWithoutJSSDKErrorCode || ex.InnerException?.Message?.ToString() == PowerAppFunctions.PublishedAppWithoutJSSDKErrorCode)
+            if (ex.Message?.ToString() == PublishedAppWithoutJSSDKErrorCode || ex.InnerException?.Message?.ToString() == PublishedAppWithoutJSSDKErrorCode)
             {
-                logger.LogError(PowerAppFunctions.PublishedAppWithoutJSSDKMessage);
+                logger.LogError(PublishedAppWithoutJSSDKMessage);
             }
         }
     }

--- a/src/Microsoft.PowerApps.TestEngine/Helpers/ExceptionHandlingHelper.cs
+++ b/src/Microsoft.PowerApps.TestEngine/Helpers/ExceptionHandlingHelper.cs
@@ -8,7 +8,7 @@ using Microsoft.PowerApps.TestEngine.PowerApps;
 
 namespace Microsoft.PowerApps.TestEngine.Helpers
 {
-    internal static class ExceptionHandlingHelper
+    public static class ExceptionHandlingHelper
     {
         public static void CheckIfOutDatedPublishedApp(Exception ex, ILogger logger)
         {

--- a/src/Microsoft.PowerApps.TestEngine/Helpers/ExceptionHandlingHelper.cs
+++ b/src/Microsoft.PowerApps.TestEngine/Helpers/ExceptionHandlingHelper.cs
@@ -10,7 +10,6 @@ namespace Microsoft.PowerApps.TestEngine.Helpers
 {
     public static class ExceptionHandlingHelper
     {
-
         // Error code suggesting published app without JSSDK, error code sent from the serverside JSSDK code
         public static string PublishedAppWithoutJSSDKErrorCode = "1";
         public static string PublishedAppWithoutJSSDKMessage = "Please republish the app and try again!";

--- a/src/Microsoft.PowerApps.TestEngine/PowerApps/PowerAppFunctions.cs
+++ b/src/Microsoft.PowerApps.TestEngine/PowerApps/PowerAppFunctions.cs
@@ -189,7 +189,7 @@ namespace Microsoft.PowerApps.TestEngine.PowerApps
             catch (Exception ex)
             {
                 ExceptionHandlingHelper.CheckIfOutDatedPublishedApp(ex, _singleTestInstanceState.GetLogger());
-                return false;
+                throw;
             }
         }
 

--- a/src/Microsoft.PowerApps.TestEngine/PowerApps/PowerAppFunctions.cs
+++ b/src/Microsoft.PowerApps.TestEngine/PowerApps/PowerAppFunctions.cs
@@ -230,7 +230,7 @@ namespace Microsoft.PowerApps.TestEngine.PowerApps
             catch (Exception ex)
             {
                 ExceptionHandlingHelper.CheckIfOutDatedPublishedApp(ex, _singleTestInstanceState.GetLogger());
-                return false;
+                throw;
             }
         }
 

--- a/src/Microsoft.PowerApps.TestEngine/PowerApps/PowerAppFunctions.cs
+++ b/src/Microsoft.PowerApps.TestEngine/PowerApps/PowerAppFunctions.cs
@@ -31,7 +31,6 @@ namespace Microsoft.PowerApps.TestEngine.PowerApps
         private string LoadObjectModelErrorMessage = "Something went wrong when Test Engine try to load object model.";
         private TypeMapping TypeMapping = new TypeMapping();
 
-        public static bool PrintedError = false;
         public PowerAppFunctions(ITestInfraFunctions testInfraFunctions, ISingleTestInstanceState singleTestInstanceState, ITestState testState)
         {
             _testInfraFunctions = testInfraFunctions;
@@ -77,9 +76,8 @@ namespace Microsoft.PowerApps.TestEngine.PowerApps
             }
             catch (Exception ex)
             {
-                if (!PrintedError && ex.Message?.ToString() == PublishedAppWithoutJSSDKErrorCode)
+                if (ex.Message?.ToString() == PublishedAppWithoutJSSDKErrorCode)
                 {
-                    PrintedError = true;
                     throw;
                 }
 

--- a/src/Microsoft.PowerApps.TestEngine/PowerApps/PowerAppFunctions.cs
+++ b/src/Microsoft.PowerApps.TestEngine/PowerApps/PowerAppFunctions.cs
@@ -76,7 +76,7 @@ namespace Microsoft.PowerApps.TestEngine.PowerApps
             }
             catch (Exception ex)
             {
-                if (ex.ToString() == PublishedAppWithoutJSSDKErrorCode)
+                if (ex.Message?.ToString() == PublishedAppWithoutJSSDKErrorCode)
                 {
                     _singleTestInstanceState.GetLogger().LogError(PublishedAppWithoutJSSDKMessage);
                 }

--- a/src/Microsoft.PowerApps.TestEngine/PowerApps/PowerAppFunctions.cs
+++ b/src/Microsoft.PowerApps.TestEngine/PowerApps/PowerAppFunctions.cs
@@ -339,7 +339,7 @@ namespace Microsoft.PowerApps.TestEngine.PowerApps
             catch (Exception ex)
             {
                 ExceptionHandlingHelper.CheckIfOutDatedPublishedApp(ex, _singleTestInstanceState.GetLogger());
-                return false;
+                throw;
             }
         }
 

--- a/src/Microsoft.PowerApps.TestEngine/PowerApps/PowerAppFunctions.cs
+++ b/src/Microsoft.PowerApps.TestEngine/PowerApps/PowerAppFunctions.cs
@@ -19,7 +19,11 @@ namespace Microsoft.PowerApps.TestEngine.PowerApps
         private readonly ITestInfraFunctions _testInfraFunctions;
         private readonly ISingleTestInstanceState _singleTestInstanceState;
         private readonly ITestState _testState;
-        private bool IsPlayerJsLoaded { get; set; } = false;
+
+        // Error code suggesting published app without JSSDK, error code sent from the serverside JSSDK code
+        public static string PublishedAppWithoutJSSDKErrorCode = "1";
+        public static string PublishedAppWithoutJSSDKMessage = "Please republish the app and try again!";
+
         public static string PublishedAppIframeName = "fullscreen-app-host";
         private string GetAppStatusErrorMessage = "Something went wrong when Test Engine try to get App status.";
         private string GetItemCountErrorMessage = "Something went wrong when Test Engine try to get item count.";
@@ -72,6 +76,10 @@ namespace Microsoft.PowerApps.TestEngine.PowerApps
             }
             catch (Exception ex)
             {
+                if (ex.ToString() == PublishedAppWithoutJSSDKErrorCode)
+                {
+                    _singleTestInstanceState.GetLogger().LogError(PublishedAppWithoutJSSDKMessage);
+                }
                 _singleTestInstanceState.GetLogger().LogDebug(ex.ToString());
                 return false;
             }

--- a/src/Microsoft.PowerApps.TestEngine/PowerApps/PowerAppFunctions.cs
+++ b/src/Microsoft.PowerApps.TestEngine/PowerApps/PowerAppFunctions.cs
@@ -20,10 +20,6 @@ namespace Microsoft.PowerApps.TestEngine.PowerApps
         private readonly ISingleTestInstanceState _singleTestInstanceState;
         private readonly ITestState _testState;
 
-        // Error code suggesting published app without JSSDK, error code sent from the serverside JSSDK code
-        public static string PublishedAppWithoutJSSDKErrorCode = "1";
-        public static string PublishedAppWithoutJSSDKMessage = "Please republish the app and try again!";
-
         public static string PublishedAppIframeName = "fullscreen-app-host";
         private string GetAppStatusErrorMessage = "Something went wrong when Test Engine tried to get App status.";
         private string GetItemCountErrorMessage = "Something went wrong when Test Engine tried to get item count.";
@@ -84,7 +80,7 @@ namespace Microsoft.PowerApps.TestEngine.PowerApps
             }
             catch (Exception ex)
             {
-                if (ex.Message?.ToString() == PublishedAppWithoutJSSDKErrorCode)
+                if (ex.Message?.ToString() == ExceptionHandlingHelper.PublishedAppWithoutJSSDKErrorCode)
                 {
                     ExceptionHandlingHelper.CheckIfOutDatedPublishedApp(ex, _singleTestInstanceState.GetLogger());
                     throw;

--- a/src/Microsoft.PowerApps.TestEngine/SingleTestRunner.cs
+++ b/src/Microsoft.PowerApps.TestEngine/SingleTestRunner.cs
@@ -151,8 +151,6 @@ namespace Microsoft.PowerApps.TestEngine
                         }
                         catch (Exception ex)
                         {
-                            ExceptionHandlingHelper.CheckIfOutDatedPublishedApp(ex, Logger);
-
                             casesFail++;
                             Logger.LogError(ex.ToString());
                             TestException = ex;
@@ -192,7 +190,6 @@ namespace Microsoft.PowerApps.TestEngine
             }
             catch (Exception ex)
             {
-                ExceptionHandlingHelper.CheckIfOutDatedPublishedApp(ex, Logger);
                 Logger.LogError(ex.ToString());
                 TestException = ex;
             }

--- a/src/Microsoft.PowerApps.TestEngine/SingleTestRunner.cs
+++ b/src/Microsoft.PowerApps.TestEngine/SingleTestRunner.cs
@@ -3,7 +3,6 @@
 
 using Microsoft.Extensions.Logging;
 using Microsoft.PowerApps.TestEngine.Config;
-using Microsoft.PowerApps.TestEngine.Helpers;
 using Microsoft.PowerApps.TestEngine.PowerApps;
 using Microsoft.PowerApps.TestEngine.PowerFx;
 using Microsoft.PowerApps.TestEngine.Reporting;

--- a/src/Microsoft.PowerApps.TestEngine/SingleTestRunner.cs
+++ b/src/Microsoft.PowerApps.TestEngine/SingleTestRunner.cs
@@ -150,7 +150,7 @@ namespace Microsoft.PowerApps.TestEngine
                         }
                         catch (Exception ex)
                         {
-                            if (ex.ToString() == PowerAppFunctions.PublishedAppWithoutJSSDKErrorCode)
+                            if (ex.Message?.ToString() == PowerAppFunctions.PublishedAppWithoutJSSDKErrorCode)
                             {
                                 Logger.LogError(PowerAppFunctions.PublishedAppWithoutJSSDKMessage);
                             }
@@ -194,7 +194,7 @@ namespace Microsoft.PowerApps.TestEngine
             }
             catch (Exception ex)
             {
-                if (ex.ToString() == PowerAppFunctions.PublishedAppWithoutJSSDKErrorCode)
+                if (ex.Message?.ToString() == PowerAppFunctions.PublishedAppWithoutJSSDKErrorCode)
                 {
                     Logger.LogError(PowerAppFunctions.PublishedAppWithoutJSSDKMessage);
                 }

--- a/src/Microsoft.PowerApps.TestEngine/SingleTestRunner.cs
+++ b/src/Microsoft.PowerApps.TestEngine/SingleTestRunner.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.Extensions.Logging;
 using Microsoft.PowerApps.TestEngine.Config;
+using Microsoft.PowerApps.TestEngine.Helpers;
 using Microsoft.PowerApps.TestEngine.PowerApps;
 using Microsoft.PowerApps.TestEngine.PowerFx;
 using Microsoft.PowerApps.TestEngine.Reporting;
@@ -150,10 +151,7 @@ namespace Microsoft.PowerApps.TestEngine
                         }
                         catch (Exception ex)
                         {
-                            if (ex.Message?.ToString() == PowerAppFunctions.PublishedAppWithoutJSSDKErrorCode)
-                            {
-                                Logger.LogError(PowerAppFunctions.PublishedAppWithoutJSSDKMessage);
-                            }
+                            ExceptionHandlingHelper.CheckIfOutDatedPublishedApp(ex, Logger);
 
                             casesFail++;
                             Logger.LogError(ex.ToString());
@@ -194,11 +192,7 @@ namespace Microsoft.PowerApps.TestEngine
             }
             catch (Exception ex)
             {
-                if (ex.Message?.ToString() == PowerAppFunctions.PublishedAppWithoutJSSDKErrorCode)
-                {
-                    Logger.LogError(PowerAppFunctions.PublishedAppWithoutJSSDKMessage);
-                }
-
+                ExceptionHandlingHelper.CheckIfOutDatedPublishedApp(ex, Logger);
                 Logger.LogError(ex.ToString());
                 TestException = ex;
             }

--- a/src/Microsoft.PowerApps.TestEngine/SingleTestRunner.cs
+++ b/src/Microsoft.PowerApps.TestEngine/SingleTestRunner.cs
@@ -150,6 +150,11 @@ namespace Microsoft.PowerApps.TestEngine
                         }
                         catch (Exception ex)
                         {
+                            if (ex.ToString() == PowerAppFunctions.PublishedAppWithoutJSSDKErrorCode)
+                            {
+                                Logger.LogError(PowerAppFunctions.PublishedAppWithoutJSSDKMessage);
+                            }
+
                             casesFail++;
                             Logger.LogError(ex.ToString());
                             TestException = ex;
@@ -189,6 +194,11 @@ namespace Microsoft.PowerApps.TestEngine
             }
             catch (Exception ex)
             {
+                if (ex.ToString() == PowerAppFunctions.PublishedAppWithoutJSSDKErrorCode)
+                {
+                    Logger.LogError(PowerAppFunctions.PublishedAppWithoutJSSDKMessage);
+                }
+
                 Logger.LogError(ex.ToString());
                 TestException = ex;
             }


### PR DESCRIPTION
## Description
Handling published app without JSSDK errorcode. 
- Serverside JSSDK (specifically the webplayer-testengine package) throws an errorcode 1 if published app maybe be outdated.
- This work involves capturing that errorcode and handle it by logging it as an error with a message to republish the app.
- Please note that each testengine functions were handled here.
- The exceptions of each functions (getAppStatus, buildObjectmodel, etc..)are handled in `src/Microsoft.PowerApps.TestEngine/PowerApps/PowerAppFunctions.cs `.

## Checklist
- [x] The code change is covered by unit tests. I have added tests that prove my fix is effective or that my feature works
- [x] I have performed end-to-end test locally.
- [x] New and existing unit tests pass locally with my changes
- [x] My changes generate no new warnings
- [x] I used clear names for everything
- [x] I have performed a self-review of my own code
