### PR TITLE
Use JSON encoding instead of URI encoding for SetProperty

### DIFF
--- a/src/Microsoft.PowerApps.TestEngine.Tests/PowerApps/PowerAppFunctionsTest.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/PowerApps/PowerAppFunctionsTest.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Primitives;
 using Microsoft.PowerApps.TestEngine.Config;
 using Microsoft.PowerApps.TestEngine.PowerApps;
 using Microsoft.PowerApps.TestEngine.TestInfra;
@@ -100,43 +101,49 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerApps
         [Fact]
         public async Task SetPropertyStringAsyncTest()
         {
-            MockTestInfraFunctions.Setup(x => x.RunJavascriptAsync<bool>(It.IsAny<string>(), It.IsAny<String[]>())).Returns(Task.FromResult(true));
+            MockTestInfraFunctions.Setup(x => x.RunJavascriptAsync<bool>(It.IsAny<string>())).Returns(Task.FromResult(true));
             var powerAppFunctions = new PowerAppFunctions(MockTestInfraFunctions.Object, MockSingleTestInstanceState.Object, MockTestState.Object);
             string itemPathString = "{\"controlName\":\"Button1\",\"index\":null,\"parentControl\":null,\"propertyName\":\"Text\"}";
             var itemPath = JsonConvert.DeserializeObject<ItemPath>(itemPathString);
-            var argument = new string[] { itemPathString, "A" };
-            var result = await powerAppFunctions.SetPropertyAsync(itemPath, StringValue.New("A"));
+            var value = "A";
+            var stringValue = StringValue.New(value);
+            var jsonSerializedValue = JsonConvert.SerializeObject(stringValue.Value);
+            var result = await powerAppFunctions.SetPropertyAsync(itemPath, stringValue);
 
             Assert.True(result);
-            MockTestInfraFunctions.Verify(x => x.RunJavascriptAsync<bool>("([itemPathString, objectValue]) => PowerAppsTestEngine.setPropertyValue(itemPathString, objectValue)", argument), Times.Once());
+            MockTestInfraFunctions.Verify(x => x.RunJavascriptAsync<bool>($"PowerAppsTestEngine.setPropertyValue({itemPathString}, {jsonSerializedValue})"), Times.Once());
         }
 
         [Fact]
         public async Task SetPropertyNumberAsyncTest()
         {
-            MockTestInfraFunctions.Setup(x => x.RunJavascriptAsync<bool>(It.IsAny<string>(), It.IsAny<String[]>())).Returns(Task.FromResult(true));
+            MockTestInfraFunctions.Setup(x => x.RunJavascriptAsync<bool>(It.IsAny<string>())).Returns(Task.FromResult(true));
             var powerAppFunctions = new PowerAppFunctions(MockTestInfraFunctions.Object, MockSingleTestInstanceState.Object, MockTestState.Object);
             string itemPathString = "{\"controlName\":\"Rating1\",\"index\":null,\"parentControl\":null,\"propertyName\":\"Value\"}";
             var itemPath = JsonConvert.DeserializeObject<ItemPath>(itemPathString);
-            var argument = new string[] { itemPathString, "5" };
-            var result = await powerAppFunctions.SetPropertyAsync(itemPath, NumberValue.New(5));
+            var value = 5;
+            var numberValue = NumberValue.New(value);
+            var jsonSerializedValue = JsonConvert.SerializeObject(numberValue.Value);
+            var result = await powerAppFunctions.SetPropertyAsync(itemPath, numberValue);
 
             Assert.True(result);
-            MockTestInfraFunctions.Verify(x => x.RunJavascriptAsync<bool>("([itemPathString, objectValue]) => PowerAppsTestEngine.setPropertyValue(itemPathString, objectValue)", argument), Times.Once());
+            MockTestInfraFunctions.Verify(x => x.RunJavascriptAsync<bool>($"PowerAppsTestEngine.setPropertyValue({itemPathString}, {jsonSerializedValue})"), Times.Once());
         }
 
         [Fact]
         public async Task SetPropertyBooleanAsyncTest()
         {
-            MockTestInfraFunctions.Setup(x => x.RunJavascriptAsync<bool>(It.IsAny<string>(), It.IsAny<String[]>())).Returns(Task.FromResult(true));
+            MockTestInfraFunctions.Setup(x => x.RunJavascriptAsync<bool>(It.IsAny<string>())).Returns(Task.FromResult(true));
             var powerAppFunctions = new PowerAppFunctions(MockTestInfraFunctions.Object, MockSingleTestInstanceState.Object, MockTestState.Object);
             string itemPathString = "{\"controlName\":\"Toggle1\",\"index\":null,\"parentControl\":null,\"propertyName\":\"Value\"}";
             var itemPath = JsonConvert.DeserializeObject<ItemPath>(itemPathString);
-            var argument = new string[] { itemPathString, "True" };
-            var result = await powerAppFunctions.SetPropertyAsync(itemPath, BooleanValue.New(true));
+            var value = true;
+            var booleanValue = BooleanValue.New(value);
+            var jsonSerializedValue = JsonConvert.SerializeObject(booleanValue.Value);
+            var result = await powerAppFunctions.SetPropertyAsync(itemPath, booleanValue);
 
             Assert.True(result);
-            MockTestInfraFunctions.Verify(x => x.RunJavascriptAsync<bool>("([itemPathString, objectValue]) => PowerAppsTestEngine.setPropertyValue(itemPathString, objectValue)", argument), Times.Once());
+            MockTestInfraFunctions.Verify(x => x.RunJavascriptAsync<bool>($"PowerAppsTestEngine.setPropertyValue({itemPathString}, {jsonSerializedValue})"), Times.Once());
         }
 
         [Fact]
@@ -207,7 +214,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerApps
         {
             MockSingleTestInstanceState.Setup(x => x.GetLogger()).Returns(MockLogger.Object);
             MockLogger.Setup(x => x.Log<It.IsAnyType>(It.IsAny<LogLevel>(),It.IsAny<EventId>(), It.IsAny<It.IsAnyType>(), It.IsAny<Exception?>(), It.IsAny<Func<It.IsAnyType,Exception?,string>>()));
-            MockTestInfraFunctions.Setup(x => x.RunJavascriptAsync<bool>(It.IsAny<string>(), It.IsAny<string[]>())).Returns(Task.FromResult(true));
+            MockTestInfraFunctions.Setup(x => x.RunJavascriptAsync<bool>(It.IsAny<string>())).Returns(Task.FromResult(true));
 
             var powerAppFunctions = new PowerAppFunctions(MockTestInfraFunctions.Object, MockSingleTestInstanceState.Object, MockTestState.Object);
 

--- a/src/Microsoft.PowerApps.TestEngine.Tests/TestInfra/PlaywrightTestInfraFunctionTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/TestInfra/PlaywrightTestInfraFunctionTests.cs
@@ -567,6 +567,8 @@ namespace Microsoft.PowerApps.TestEngine.Tests.TestInfra
             var jsExpression = "console.log('hello')";
             var expectedResponse = "hello";
 
+            LoggingTestHelper.SetupMock(MockLogger);
+            MockSingleTestInstanceState.Setup(x => x.GetLogger()).Returns(MockLogger.Object);
             MockPage.Setup(x => x.EvaluateAsync<string>(It.IsAny<string>(), It.IsAny<object?>())).Returns(Task.FromResult(expectedResponse));
 
             var playwrightTestInfraFunctions = new PlaywrightTestInfraFunctions(MockTestState.Object, MockSingleTestInstanceState.Object,
@@ -574,6 +576,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.TestInfra
             var result = await playwrightTestInfraFunctions.RunJavascriptAsync<string>(jsExpression);
             Assert.Equal(expectedResponse, result);
 
+            LoggingTestHelper.VerifyLogging(MockLogger, (message) => message.Contains(jsExpression), LogLevel.Debug, Times.Once());
             MockPage.Verify(x => x.EvaluateAsync<string>(jsExpression, null), Times.Once());
         }
 

--- a/src/Microsoft.PowerApps.TestEngine/JS/CanvasAppSdk.js
+++ b/src/Microsoft.PowerApps.TestEngine/JS/CanvasAppSdk.js
@@ -75,11 +75,13 @@ function interactWithControl(itemPath, value) {
     return executePublishedAppScript(script);
 }
 
-function setPropertyValueForControl(itemPath, value) {    
+function setPropertyValueForControl(itemPath, value) {
     if (typeof value == "object") {
-        return interactWithControl(itemPath,value);
-    } 
-    var script = `setPropertyValueForControl("${itemPath}", "${value}")`;
+        return interactWithControl(itemPath, value);
+    } else if (typeof value == "string") {
+        value = JSON.stringify(value);
+    }
+    var script = `setPropertyValueForControl(${JSON.stringify(itemPath)}, ${value})`;
     return executePublishedAppScript(script);
 }
 
@@ -140,7 +142,7 @@ var PowerAppsTestEngine = {
         return selectControl(itemPath)
     },
 
-     setPropertyValue: function(itemPath, value) {
+    setPropertyValue: function(itemPath, value) {
         return setPropertyValueForControl(itemPath, value);
     },
 

--- a/src/Microsoft.PowerApps.TestEngine/JS/PublishedAppTesting.js
+++ b/src/Microsoft.PowerApps.TestEngine/JS/PublishedAppTesting.js
@@ -162,24 +162,19 @@ function selectControl(itemPath) {
 }
 
 function setPropertyValueForControl(itemPath, value) {
-    // Decode itemPath and value
-    var val = unescape(value);
-    var unescapePath = unescape(itemPath);
-    var obj = JSON.parse(unescapePath);
-
-    if (obj.parentControl && obj.parentControl.index !== null) {
+    if (itemPath.parentControl && itemPath.parentControl.index !== null) {
         // Gallery & Nested gallery
-        var galleryBindingContext = getBindingContext(obj.parentControl);     
-        return AppMagic.AuthoringTool.Runtime.getNamedControl(obj.controlName, galleryBindingContext).OpenAjax.setPropertyValueInternal(obj.propertyName, val, galleryBindingContext)
+        var galleryBindingContext = getBindingContext(itemPath.parentControl);     
+        return AppMagic.AuthoringTool.Runtime.getNamedControl(itemPath.controlName, galleryBindingContext).OpenAjax.setPropertyValueInternal(itemPath.propertyName, value, galleryBindingContext)
     }
 
-    if (obj.parentControl) {
+    if (itemPath.parentControl) {
         // Component
-        var componentBindingContext = AppMagic.Controls.GlobalContextManager.bindingContext.componentBindingContexts.lookup(obj.parentControl.controlName);
-        return (AppMagic.AuthoringTool.Runtime.getNamedControl(obj.controlName, componentBindingContext).OpenAjax.setPropertyValueInternal(obj.propertyName, val, componentBindingContext));
+        var componentBindingContext = AppMagic.Controls.GlobalContextManager.bindingContext.componentBindingContexts.lookup(itemPath.parentControl.controlName);
+        return (AppMagic.AuthoringTool.Runtime.getNamedControl(itemPath.controlName, componentBindingContext).OpenAjax.setPropertyValueInternal(itemPath.propertyName, value, componentBindingContext));
     }
     
-    return AppMagic.AuthoringTool.Runtime.getNamedControl(obj.controlName, AppMagic.Controls.GlobalContextManager.bindingContext).OpenAjax.setPropertyValueInternal(obj.propertyName, val, AppMagic.Controls.GlobalContextManager.bindingContext);
+    return AppMagic.AuthoringTool.Runtime.getNamedControl(itemPath.controlName, AppMagic.Controls.GlobalContextManager.bindingContext).OpenAjax.setPropertyValueInternal(itemPath.propertyName, value, AppMagic.Controls.GlobalContextManager.bindingContext);
 }
 
 function interactWithControl(itemPath, value) {

--- a/src/Microsoft.PowerApps.TestEngine/PowerApps/PowerAppFunctions.cs
+++ b/src/Microsoft.PowerApps.TestEngine/PowerApps/PowerAppFunctions.cs
@@ -190,10 +190,8 @@ namespace Microsoft.PowerApps.TestEngine.PowerApps
 
             ValidateItemPath(itemPath, false);
             // TODO: handle components
-            var itemPathString = JsonConvert.SerializeObject(itemPath);
-            var argument = new string[] { itemPathString, objectValue.ToString() };
-            var expression = "([itemPathString, objectValue]) => PowerAppsTestEngine.setPropertyValue(itemPathString, objectValue)";
-            return await _testInfraFunctions.RunJavascriptAsync<bool>(expression, argument);
+            var expression = $"PowerAppsTestEngine.setPropertyValue({JsonConvert.SerializeObject(itemPath)}, {JsonConvert.SerializeObject(objectValue)})";
+            return await _testInfraFunctions.RunJavascriptAsync<bool>(expression);
         }
 
         public async Task<bool> SetPropertyDateAsync(ItemPath itemPath, DateValue value)

--- a/src/Microsoft.PowerApps.TestEngine/PowerApps/PowerAppFunctions.cs
+++ b/src/Microsoft.PowerApps.TestEngine/PowerApps/PowerAppFunctions.cs
@@ -199,10 +199,11 @@ namespace Microsoft.PowerApps.TestEngine.PowerApps
             ValidateItemPath(itemPath, false);
 
             var itemPathString = JsonConvert.SerializeObject(itemPath);
+            var propertyNameString = JsonConvert.SerializeObject(itemPath.PropertyName);
             var recordValue = value.Value;
 
             // Date.parse() parses the date to unix timestamp
-            var expression = $"PowerAppsTestEngine.setPropertyValue({itemPathString},{{\"{itemPath.PropertyName}\":Date.parse(\"{recordValue}\")}})";
+            var expression = $"PowerAppsTestEngine.setPropertyValue({itemPathString},{{{propertyNameString}:Date.parse(\"{recordValue}\")}})";
 
             return await _testInfraFunctions.RunJavascriptAsync<bool>(expression);
         }
@@ -212,11 +213,12 @@ namespace Microsoft.PowerApps.TestEngine.PowerApps
             ValidateItemPath(itemPath, false);
 
             var itemPathString = JsonConvert.SerializeObject(itemPath);
+            var propertyNameString = JsonConvert.SerializeObject(itemPath.PropertyName);
             var recordValue = value.GetField("Value");
             var val = recordValue.GetType().GetProperty("Value").GetValue(recordValue).ToString();
             RecordValueObject json = new RecordValueObject(val);
             var checkVal = JsonConvert.SerializeObject(json);
-            var expression = $"PowerAppsTestEngine.setPropertyValue({itemPathString},{{\"{itemPath.PropertyName}\":{checkVal}}})";
+            var expression = $"PowerAppsTestEngine.setPropertyValue({itemPathString},{{{propertyNameString}:{checkVal}}})";
 
             return await _testInfraFunctions.RunJavascriptAsync<bool>(expression);
         }
@@ -226,6 +228,7 @@ namespace Microsoft.PowerApps.TestEngine.PowerApps
             ValidateItemPath(itemPath, false);
 
             var itemPathString = JsonConvert.SerializeObject(itemPath);
+            var propertyNameString = JsonConvert.SerializeObject(itemPath.PropertyName);
             RecordValueObject[] jsonArr = new RecordValueObject[tableValue.Rows.Count()];
 
             var index = 0;
@@ -242,7 +245,7 @@ namespace Microsoft.PowerApps.TestEngine.PowerApps
                 }
             }
             var checkVal = JsonConvert.SerializeObject(jsonArr);
-            var expression = $"PowerAppsTestEngine.setPropertyValue({itemPathString},{{\"{itemPath.PropertyName}\":{checkVal}}})";
+            var expression = $"PowerAppsTestEngine.setPropertyValue({itemPathString},{{{propertyNameString}:{checkVal}}})";
 
             return await _testInfraFunctions.RunJavascriptAsync<bool>(expression);
         }

--- a/src/Microsoft.PowerApps.TestEngine/TestInfra/ITestInfraFunctions.cs
+++ b/src/Microsoft.PowerApps.TestEngine/TestInfra/ITestInfraFunctions.cs
@@ -73,7 +73,6 @@ namespace Microsoft.PowerApps.TestEngine.TestInfra
         /// <param name="jsExpression">Javascript expression to run</param>
         /// <returns>Return value of javascript</returns>
         public Task<T> RunJavascriptAsync<T>(string jsExpression);
-        public Task<T> RunJavascriptAsync<T>(string jsExpression, string[] arguments);
 
         /// <summary>
         /// Fills in user email 

--- a/src/Microsoft.PowerApps.TestEngine/TestInfra/PlaywrightTestInfraFunctions.cs
+++ b/src/Microsoft.PowerApps.TestEngine/TestInfra/PlaywrightTestInfraFunctions.cs
@@ -275,20 +275,9 @@ namespace Microsoft.PowerApps.TestEngine.TestInfra
         {
             ValidatePage();
 
-            return await Page.EvaluateAsync<T>(jsExpression);
-        }
+            _singleTestInstanceState.GetLogger().LogDebug("Run Javascript: " + jsExpression);
 
-        public async Task<T> RunJavascriptAsync<T>(string jsExpression, string[] arguments)
-        {
-            ValidatePage();
-            var santizedArguments = new string[arguments.Length];
-            for (int i = 0; i < arguments.Length; i++)
-            { // encode and add to sanitizedArguments 
-                var argument = arguments[i];
-                var encode = Uri.EscapeDataString(argument);
-                santizedArguments[i] = encode;
-            }
-            return await Page.EvaluateAsync<T>(jsExpression, santizedArguments);
+            return await Page.EvaluateAsync<T>(jsExpression);
         }
 
         // Justification: Limited ability to run unit tests for 


### PR DESCRIPTION
# Pull Request Template

## Description

We used to use URI encoding to prevent JS script injection. This change is to using JSON encoding instead due to the fact that it's about JS code. 

## Checklist

- [x] The code change is covered by unit tests. I have added tests that prove my fix is effective or that my feature works
- [x] I have performed end-to-end test locally.
- [x] New and existing unit tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I used clear names for everything
- [x] I have performed a self-review of my own code
