### PR TITLE
Extend Default Sample Timeout Time

### DIFF
--- a/samples/basicgallery/testPlan.fx.yaml
+++ b/samples/basicgallery/testPlan.fx.yaml
@@ -24,9 +24,7 @@ testSuite:
           Screenshot("basicgallery_end.png");
 
 testSettings:
-  recordVideo: true
-  browserConfigurations:
-    - browser: Chromium
+  filePath: ../../samples/testSettings.yaml
 
 environmentVariables:
   users:

--- a/samples/basicgallery/testPlanForRegionUsePeriodAsDecimalSeparator.fx.yaml
+++ b/samples/basicgallery/testPlanForRegionUsePeriodAsDecimalSeparator.fx.yaml
@@ -24,9 +24,7 @@ testSuite:
           Screenshot("basicgallery_end.png");;
 
 testSettings:
-  recordVideo: true
-  browserConfigurations:
-    - browser: Chromium
+  filePath: ../../samples/testSettings.yaml
 
 environmentVariables:
   users:

--- a/samples/calculator/testPlan.fx.yaml
+++ b/samples/calculator/testPlan.fx.yaml
@@ -26,16 +26,14 @@ testSuite:
           Assert(Calculator_1.ResultLabel.Text = "10000", "Validate result label has the results of multiplication");
           Assert(Calculator_1.CalculatorResult = 10000, "Validate component output calculator result has the results of multiplication");
     - testCaseName: Check division
-      testSteps: |      
+      testSteps: |
         = Select(Calculator_1.Divide);
           Assert(Calculator_1.ResultLabel.Text = "1", "Validate result label has the results of division");
           Assert(Calculator_1.CalculatorResult = 1, "Validate component output calculator result has the results of division");
           Screenshot("calculator_end.png");
 
 testSettings:
-  recordVideo: true
-  browserConfigurations:
-    - browser: Chromium
+  filePath: ../../samples/testSettings.yaml
 
 environmentVariables:
   users:

--- a/samples/connector/testPlan.fx.yaml
+++ b/samples/connector/testPlan.fx.yaml
@@ -20,9 +20,7 @@ testSuite:
           Screenshot("connectorapp_end.png");
 
 testSettings:
-  recordVideo: true
-  browserConfigurations:
-    - browser: Chromium
+  filePath: ../../samples/testSettings.yaml
 
 environmentVariables:
   users:

--- a/samples/containers/testPlan.fx.yaml
+++ b/samples/containers/testPlan.fx.yaml
@@ -27,9 +27,7 @@ testSuite:
           Screenshot("Container_end.png");
 
 testSettings:
-  recordVideo: true
-  browserConfigurations:
-    - browser: Chromium
+  filePath: ../../samples/testSettings.yaml
 
 environmentVariables:
   users:

--- a/samples/differentvariabletypes/testPlanForScriptInjection.fx.yaml
+++ b/samples/differentvariabletypes/testPlanForScriptInjection.fx.yaml
@@ -16,27 +16,25 @@ testSuite:
           SetProperty(TextInput1.Text, "hi""); alert(""Hello World!");
           
           Assert(TextInput1.Text = "hi""); alert(""Hello World!", "Validate comment box was changed.");
-      
-          Screenshot("stringtype_end.png");   
+
+          Screenshot("stringtype_end.png");
     - testCaseName: Record_Case
       testSteps: |
         = Screenshot("recordtype_loaded.png");
-        
+
          SetProperty(Dropdown1.Selected, {Value:"2""}}); document.body.style.backgroundColor = ""pink""; alert(""Hello World!""); console.log({""foo"",{Value:""2"});
 
-         Screenshot("recordtype_end.png");  
+         Screenshot("recordtype_end.png");
     - testCaseName: Table_Case
       testSteps: |
         = Screenshot("tabletype_loaded.png");
-        
+
           SetProperty(ComboBox1.SelectedItems, Table({Value:"1"},{Value:"2""}]}); document.body.style.backgroundColor = ""pink""; alert(""Hello World!""); console.log({""foo"":[{Value:""1""}, {Value:""2"}));
           
           Screenshot("tabletype_end.png");
 
 testSettings:
-  recordVideo: true
-  browserConfigurations:
-    - browser: Chromium
+  filePath: ../../samples/testSettings.yaml
 
 environmentVariables:
   users:

--- a/samples/manyscreens/testPlan.fx.yaml
+++ b/samples/manyscreens/testPlan.fx.yaml
@@ -31,9 +31,7 @@ testSuite:
           Screenshot("manyscreens_end.png");
 
 testSettings:
-  recordVideo: true
-  browserConfigurations:
-    - browser: Chromium
+  filePath: ../../samples/testSettings.yaml
 
 environmentVariables:
   users:

--- a/samples/nestedgallery/testPlan.fx.yaml
+++ b/samples/nestedgallery/testPlan.fx.yaml
@@ -38,9 +38,7 @@ testSuite:
           Screenshot("nestedgallery_end.png");
 
 testSettings:
-  recordVideo: true
-  browserConfigurations:
-    - browser: Chromium
+  filePath: ../../samples/testSettings.yaml
 
 environmentVariables:
   users:

--- a/samples/pcfcomponent/testPlan.fx.yaml
+++ b/samples/pcfcomponent/testPlan.fx.yaml
@@ -15,9 +15,7 @@ testSuite:
           Screenshot("pcfcomponent_end.png");
 
 testSettings:
-  recordVideo: true
-  browserConfigurations:
-    - browser: Chromium
+  filePath: ../../samples/testSettings.yaml
 
 environmentVariables:
   users:

--- a/samples/template/TestPlanTemplate.fx.yaml
+++ b/samples/template/TestPlanTemplate.fx.yaml
@@ -17,16 +17,13 @@ testSuite:
       testSteps: |
         = Screenshot("template_loaded.png");
           
-          Screenshot("template_end.png"); 
+          Screenshot("template_end.png");
 
 testSettings:
-  recordVideo: true
-  browserConfigurations:
-    - browser: Chromium
+  filePath: ../../samples/testSettings.yaml
 
 environmentVariables:
   users:
     - personaName: User1
       emailKey: user1Email
       passwordKey: user1Password
-

--- a/samples/testSettings.yaml
+++ b/samples/testSettings.yaml
@@ -1,3 +1,4 @@
 recordVideo: true
+timeout: 60000
 browserConfigurations:
   - browser: Chromium


### PR DESCRIPTION
## Description
Extend default sample timeout time to sixty seconds. Primarily for yaml-integration tests.

## Checklist

- [x] The code change is covered by unit tests. I have added tests that prove my fix is effective or that my feature works
- [x] I have performed end-to-end test locally.
- [x] New and existing unit tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I used clear names for everything
- [x] I have performed a self-review of my own code
