### PR TITLE
Use Playwright 1.22.0

### DIFF
--- a/src/Microsoft.PowerApps.TestEngine/Microsoft.PowerApps.TestEngine.csproj
+++ b/src/Microsoft.PowerApps.TestEngine/Microsoft.PowerApps.TestEngine.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0-preview.3.22175.4" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0-preview.3.22175.4" />
-    <PackageReference Include="Microsoft.Playwright" Version="1.21.0" />
+    <PackageReference Include="Microsoft.Playwright" Version="1.22.0" />
     <PackageReference Include="Microsoft.PowerFx.Interpreter" Version="0.2.3-preview.20221122-330455" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="YamlDotNet" Version="11.2.1" />

--- a/src/PowerAppsTestEngine/PowerAppsTestEngine.csproj
+++ b/src/PowerAppsTestEngine/PowerAppsTestEngine.csproj
@@ -10,7 +10,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
-    <PackageReference Include="Microsoft.Playwright" Version="1.22.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
# Pull Request Template

## Description

- Use Playwright 1.22.0 in all the places
- Remove unnecessary package reference

Note: The GitHub Action integration tests have been using Playwright 1.22.0 for a while so it should be safe to upgrade.

## Checklist

- [x] I have performed end-to-end test locally.
- [x] New and existing unit tests pass locally with my changes
- [x] My changes generate no new warnings
- [x] I have performed a self-review of my own code
