### PR TITLE
Fix Integration test

### DIFF
--- a/.github/workflows/yaml-integration-tests.yml
+++ b/.github/workflows/yaml-integration-tests.yml
@@ -29,6 +29,7 @@ jobs:
           name: Sample Tests          # Name of the check run which will be created
           path: |
             **/*.trx
+            **/**/*.trx
           reporter: dotnet-trx        # Format of test results      
       - name: Upload a Build Artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/yaml-integration-tests.yml
+++ b/.github/workflows/yaml-integration-tests.yml
@@ -27,7 +27,7 @@ jobs:
         if: success() || failure()    # run this step even if previous step failed
         with:
           name: Sample Tests          # Name of the check run which will be created
-          path: 'TestResults/*/*.trx'            
+          path: TestResults/**/*.trx            
           reporter: dotnet-trx        # Format of test results      
       - name: Upload a Build Artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/yaml-integration-tests.yml
+++ b/.github/workflows/yaml-integration-tests.yml
@@ -27,7 +27,7 @@ jobs:
         if: success() || failure()    # run this step even if previous step failed
         with:
           name: Sample Tests          # Name of the check run which will be created
-          path: TestResults/**/*.trx            
+          path: 'TestResults/**/*.trx'            
           reporter: dotnet-trx        # Format of test results      
       - name: Upload a Build Artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/yaml-integration-tests.yml
+++ b/.github/workflows/yaml-integration-tests.yml
@@ -27,7 +27,7 @@ jobs:
         if: success() || failure()    # run this step even if previous step failed
         with:
           name: Sample Tests          # Name of the check run which will be created
-          path: 'TestResults/**/*.trx'            
+          path: '**/*.trx'            
           reporter: dotnet-trx        # Format of test results      
       - name: Upload a Build Artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/yaml-integration-tests.yml
+++ b/.github/workflows/yaml-integration-tests.yml
@@ -27,7 +27,7 @@ jobs:
         if: success() || failure()    # run this step even if previous step failed
         with:
           name: Sample Tests          # Name of the check run which will be created
-          path: '**/*.trx'            
+          path: 'TestResults/*/*.trx'            
           reporter: dotnet-trx        # Format of test results      
       - name: Upload a Build Artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/yaml-integration-tests.yml
+++ b/.github/workflows/yaml-integration-tests.yml
@@ -27,9 +27,7 @@ jobs:
         if: success() || failure()    # run this step even if previous step failed
         with:
           name: Sample Tests          # Name of the check run which will be created
-          path: |
-            **/*.trx
-            **/**/*.trx
+          path: '**/*.trx'            
           reporter: dotnet-trx        # Format of test results      
       - name: Upload a Build Artifact
         uses: actions/upload-artifact@v2

--- a/src/Microsoft.PowerApps.TestEngine.Tests/Reporting/TestReporterTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/Reporting/TestReporterTests.cs
@@ -331,6 +331,30 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Reporting
         }
 
         [Fact]
+        public void SkipTestTest()
+        {
+            var testRunName = "testRunName";
+            var testUser = "testUser";
+            var testName = "testName";
+            var testLocation = "C:\\testplan.fx.yaml";
+            var testReporter = new TestReporter(MockFileSystem.Object);
+            var testRunId = testReporter.CreateTestRun(testRunName, testUser);
+
+            testReporter.StartTestRun(testRunId);
+
+            var testSuiteId = testReporter.CreateTestSuite(testRunId, "testSuite");
+            var testId = testReporter.CreateTest(testRunId, testSuiteId, testName, testLocation);
+
+            testReporter.SkipTest(testRunId, testId);
+
+            var testRun = testReporter.GetTestRun(testRunId);
+            var testResult = testRun.Results.UnitTestResults.Where(x => x.TestId == testId).First();
+
+            Assert.True(testResult.Outcome == "Disconnected");
+            Assert.Equal(1, testRun.ResultSummary.Counters.Disconnected);
+        }
+
+        [Fact]
         public void GenerateTestReportTest()
         {
             bool success = true;

--- a/src/Microsoft.PowerApps.TestEngine.Tests/Reporting/TestReporterTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/Reporting/TestReporterTests.cs
@@ -350,8 +350,8 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Reporting
             var testRun = testReporter.GetTestRun(testRunId);
             var testResult = testRun.Results.UnitTestResults.Where(x => x.TestId == testId).First();
 
-            Assert.True(testResult.Outcome == "Disconnected");
-            Assert.Equal(1, testRun.ResultSummary.Counters.Disconnected);
+            Assert.True(testResult.Outcome == "NotExecuted");
+            Assert.Equal(1, testRun.ResultSummary.Counters.NotExecuted);
         }
 
         [Fact]

--- a/src/Microsoft.PowerApps.TestEngine.Tests/SingleTestRunnerTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/SingleTestRunnerTests.cs
@@ -58,6 +58,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
             MockTestReporter.Setup(x => x.CreateTestSuite(It.IsAny<string>(), It.IsAny<string>())).Returns(testSuiteId);
             MockTestReporter.Setup(x => x.StartTest(It.IsAny<string>(), It.IsAny<string>()));
             MockTestReporter.Setup(x => x.EndTest(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<string>(), It.IsAny<List<string>>(), It.IsAny<string>(), It.IsAny<string>()));
+            MockTestReporter.Setup(x => x.EndTestsSkipped(It.IsAny<string>(), It.IsAny<int>()));
 
             MockLoggerFactory.Setup(x => x.CreateLogger(It.IsAny<string>())).Returns(MockLogger.Object);
 

--- a/src/Microsoft.PowerApps.TestEngine.Tests/SingleTestRunnerTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/SingleTestRunnerTests.cs
@@ -263,7 +263,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
 
             VerifyTestStateSetup(testData.testSuiteId, testData.testRunId, testData.testSuiteDefinition, testData.testResultDirectory, testData.browserConfig);
             LoggingTestHelper.VerifyLogging(MockLogger, exceptionToThrow.ToString(), LogLevel.Error, Times.AtLeastOnce());
-            VerifyFinallyExecution(testData.testResultDirectory, 0, 0, 0, 0);
+            VerifyFinallyExecution(testData.testResultDirectory, 1, 0, 1, 0);
         }
 
         [Fact]

--- a/src/Microsoft.PowerApps.TestEngine.Tests/SingleTestRunnerTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/SingleTestRunnerTests.cs
@@ -58,7 +58,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
             MockTestReporter.Setup(x => x.CreateTestSuite(It.IsAny<string>(), It.IsAny<string>())).Returns(testSuiteId);
             MockTestReporter.Setup(x => x.StartTest(It.IsAny<string>(), It.IsAny<string>()));
             MockTestReporter.Setup(x => x.EndTest(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<string>(), It.IsAny<List<string>>(), It.IsAny<string>(), It.IsAny<string>()));
-            MockTestReporter.Setup(x => x.EndTestsSkipped(It.IsAny<string>(), It.IsAny<int>()));
+            MockTestReporter.Setup(x => x.SkipTest(It.IsAny<string>(), It.IsAny<string>()));
 
             MockLoggerFactory.Setup(x => x.CreateLogger(It.IsAny<string>())).Returns(MockLogger.Object);
 

--- a/src/Microsoft.PowerApps.TestEngine/Reporting/ITestReporter.cs
+++ b/src/Microsoft.PowerApps.TestEngine/Reporting/ITestReporter.cs
@@ -58,7 +58,6 @@ namespace Microsoft.PowerApps.TestEngine.Reporting
         /// <param name="stackTrace">Stack trace if test was unsuccessful</param>
         public void EndTest(string testRunId, string testId, bool success, string stdout, List<string> additionalFiles, string errorMessage, string stackTrace);
 
-
         /// <summary>
         /// End test.
         /// </summary>

--- a/src/Microsoft.PowerApps.TestEngine/Reporting/ITestReporter.cs
+++ b/src/Microsoft.PowerApps.TestEngine/Reporting/ITestReporter.cs
@@ -62,8 +62,8 @@ namespace Microsoft.PowerApps.TestEngine.Reporting
         /// End test.
         /// </summary>
         /// <param name="testRunId">Test run id</param>
-        /// <param name="totalCases">Total cases</param>
-        public void EndTestsSkipped(string testRunId, int totalCases);
+        /// <param name="testId">Test id</param>
+        public void SkipTest(string testRunId, string testId);
 
         /// <summary>
         /// Generate test report

--- a/src/Microsoft.PowerApps.TestEngine/Reporting/ITestReporter.cs
+++ b/src/Microsoft.PowerApps.TestEngine/Reporting/ITestReporter.cs
@@ -58,6 +58,14 @@ namespace Microsoft.PowerApps.TestEngine.Reporting
         /// <param name="stackTrace">Stack trace if test was unsuccessful</param>
         public void EndTest(string testRunId, string testId, bool success, string stdout, List<string> additionalFiles, string errorMessage, string stackTrace);
 
+
+        /// <summary>
+        /// End test.
+        /// </summary>
+        /// <param name="testRunId">Test run id</param>
+        /// <param name="totalCases">Total cases</param>
+        public void EndTestsSkipped(string testRunId, int totalCases);
+
         /// <summary>
         /// Generate test report
         /// </summary>

--- a/src/Microsoft.PowerApps.TestEngine/Reporting/TestReporter.cs
+++ b/src/Microsoft.PowerApps.TestEngine/Reporting/TestReporter.cs
@@ -221,6 +221,7 @@ namespace Microsoft.PowerApps.TestEngine.Reporting
             var testResult = testRun.Results.UnitTestResults.Where(x => x.TestId == testId).First();
             testRun.ResultSummary.Counters.Disconnected++;
             testRun.ResultSummary.Counters.Total++;
+            testResult.Outcome = "Disconnected";
         }
 
         public void EndTest(string testRunId, string testId, bool success, string stdout, List<string> additionalFiles, string errorMessage, string stackTrace)

--- a/src/Microsoft.PowerApps.TestEngine/Reporting/TestReporter.cs
+++ b/src/Microsoft.PowerApps.TestEngine/Reporting/TestReporter.cs
@@ -215,6 +215,14 @@ namespace Microsoft.PowerApps.TestEngine.Reporting
             testRun.ResultSummary.Counters.InProgress++;
         }
 
+        public void EndTestsSkipped(string testRunId, int totalCases)
+        {
+            var testRun = GetTestRun(testRunId);
+            
+            testRun.ResultSummary.Counters.Disconnected = totalCases;
+            testRun.ResultSummary.Counters.Total = totalCases; 
+        }
+
         public void EndTest(string testRunId, string testId, bool success, string stdout, List<string> additionalFiles, string errorMessage, string stackTrace)
         {
             var testRun = GetTestRun(testRunId);

--- a/src/Microsoft.PowerApps.TestEngine/Reporting/TestReporter.cs
+++ b/src/Microsoft.PowerApps.TestEngine/Reporting/TestReporter.cs
@@ -220,7 +220,6 @@ namespace Microsoft.PowerApps.TestEngine.Reporting
             var testRun = GetTestRun(testRunId);
             var testResult = testRun.Results.UnitTestResults.Where(x => x.TestId == testId).First();
             testRun.ResultSummary.Counters.Disconnected++;
-            testRun.ResultSummary.Counters.Total++;
             testResult.Outcome = "Disconnected";
         }
 

--- a/src/Microsoft.PowerApps.TestEngine/Reporting/TestReporter.cs
+++ b/src/Microsoft.PowerApps.TestEngine/Reporting/TestReporter.cs
@@ -219,9 +219,8 @@ namespace Microsoft.PowerApps.TestEngine.Reporting
         {
             var testRun = GetTestRun(testRunId);
             var testResult = testRun.Results.UnitTestResults.Where(x => x.TestId == testId).First();
-
             testRun.ResultSummary.Counters.Disconnected++;
-            testRun.ResultSummary.Counters.Total++;                       
+            testRun.ResultSummary.Counters.Total++;
         }
 
         public void EndTest(string testRunId, string testId, bool success, string stdout, List<string> additionalFiles, string errorMessage, string stackTrace)

--- a/src/Microsoft.PowerApps.TestEngine/Reporting/TestReporter.cs
+++ b/src/Microsoft.PowerApps.TestEngine/Reporting/TestReporter.cs
@@ -219,8 +219,8 @@ namespace Microsoft.PowerApps.TestEngine.Reporting
         {
             var testRun = GetTestRun(testRunId);
             var testResult = testRun.Results.UnitTestResults.Where(x => x.TestId == testId).First();
-            testRun.ResultSummary.Counters.Disconnected++;
-            testResult.Outcome = "Disconnected";
+            testRun.ResultSummary.Counters.NotExecuted++;
+            testResult.Outcome = "NotExecuted";
         }
 
         public void EndTest(string testRunId, string testId, bool success, string stdout, List<string> additionalFiles, string errorMessage, string stackTrace)

--- a/src/Microsoft.PowerApps.TestEngine/Reporting/TestReporter.cs
+++ b/src/Microsoft.PowerApps.TestEngine/Reporting/TestReporter.cs
@@ -221,8 +221,7 @@ namespace Microsoft.PowerApps.TestEngine.Reporting
             var testResult = testRun.Results.UnitTestResults.Where(x => x.TestId == testId).First();
 
             testRun.ResultSummary.Counters.Disconnected++;
-            testRun.ResultSummary.Counters.Total++;
-                       
+            testRun.ResultSummary.Counters.Total++;                       
         }
 
         public void EndTest(string testRunId, string testId, bool success, string stdout, List<string> additionalFiles, string errorMessage, string stackTrace)

--- a/src/Microsoft.PowerApps.TestEngine/Reporting/TestReporter.cs
+++ b/src/Microsoft.PowerApps.TestEngine/Reporting/TestReporter.cs
@@ -218,9 +218,8 @@ namespace Microsoft.PowerApps.TestEngine.Reporting
         public void EndTestsSkipped(string testRunId, int totalCases)
         {
             var testRun = GetTestRun(testRunId);
-            
             testRun.ResultSummary.Counters.Disconnected = totalCases;
-            testRun.ResultSummary.Counters.Total = totalCases; 
+            testRun.ResultSummary.Counters.Total = totalCases;
         }
 
         public void EndTest(string testRunId, string testId, bool success, string stdout, List<string> additionalFiles, string errorMessage, string stackTrace)

--- a/src/Microsoft.PowerApps.TestEngine/Reporting/TestReporter.cs
+++ b/src/Microsoft.PowerApps.TestEngine/Reporting/TestReporter.cs
@@ -215,11 +215,14 @@ namespace Microsoft.PowerApps.TestEngine.Reporting
             testRun.ResultSummary.Counters.InProgress++;
         }
 
-        public void EndTestsSkipped(string testRunId, int totalCases)
+        public void SkipTest(string testRunId, string testId)
         {
             var testRun = GetTestRun(testRunId);
-            testRun.ResultSummary.Counters.Disconnected = totalCases;
-            testRun.ResultSummary.Counters.Total = totalCases;
+            var testResult = testRun.Results.UnitTestResults.Where(x => x.TestId == testId).First();
+
+            testRun.ResultSummary.Counters.Disconnected++;
+            testRun.ResultSummary.Counters.Total++;
+                       
         }
 
         public void EndTest(string testRunId, string testId, bool success, string stdout, List<string> additionalFiles, string errorMessage, string stackTrace)

--- a/src/Microsoft.PowerApps.TestEngine/SingleTestRunner.cs
+++ b/src/Microsoft.PowerApps.TestEngine/SingleTestRunner.cs
@@ -215,7 +215,6 @@ namespace Microsoft.PowerApps.TestEngine
 
                 Logger.LogInformation("Total cases: " + casesTotal);
                 Logger.LogInformation("Cases passed: " + casesPass);
-
                 Logger.LogInformation("Cases skipped: " + (casesTotal - (casesFail + casesPass)));
                 Logger.LogInformation("Cases failed: " + casesFail + "\n");
 

--- a/src/Microsoft.PowerApps.TestEngine/SingleTestRunner.cs
+++ b/src/Microsoft.PowerApps.TestEngine/SingleTestRunner.cs
@@ -80,6 +80,7 @@ namespace Microsoft.PowerApps.TestEngine
             var testResultDirectory = Path.Combine(testRunDirectory, $"{_fileSystem.RemoveInvalidFileNameChars(testSuiteName)}_{browserConfigName}_{testSuiteId.Substring(0, 6)}");
             _testState.SetTestResultsDirectory(testResultDirectory);
 
+            casesTotal = _testState.GetTestSuiteDefinition().TestCases.Count();
             try
             {
                 _fileSystem.CreateDirectory(testResultDirectory);
@@ -110,8 +111,6 @@ namespace Microsoft.PowerApps.TestEngine
                 // Set up Power Fx
                 _powerFxEngine.Setup();
                 await _powerFxEngine.UpdatePowerFxModelAsync();
-
-                casesTotal = _testState.GetTestSuiteDefinition().TestCases.Count();
 
                 // Run test case one by one
                 foreach (var testCase in _testState.GetTestSuiteDefinition().TestCases)

--- a/src/Microsoft.PowerApps.TestEngine/SingleTestRunner.cs
+++ b/src/Microsoft.PowerApps.TestEngine/SingleTestRunner.cs
@@ -115,11 +115,11 @@ namespace Microsoft.PowerApps.TestEngine
                 _powerFxEngine.Setup();
                 await _powerFxEngine.UpdatePowerFxModelAsync();
 
+                allTestsSkipped = false;
                 // Run test case one by one
                 foreach (var testCase in _testState.GetTestSuiteDefinition().TestCases)
                 {
-                    TestSuccess = true;
-                    allTestsSkipped = false;
+                    TestSuccess = true;                    
                     var testId = _testReporter.CreateTest(testRunId, testSuiteId, $"{testCase.TestCaseName}", "TODO");
                     _testReporter.StartTest(testRunId, testId);
                     _testState.SetTestId(testId);
@@ -197,16 +197,14 @@ namespace Microsoft.PowerApps.TestEngine
             }
             finally
             {
-                await _testInfraFunctions.EndTestRunAsync();
+            await _testInfraFunctions.EndTestRunAsync();
 
                 if (allTestsSkipped)
                 {
                     // Run test case one by one, mark it as skipped
                     foreach (var testCase in _testState.GetTestSuiteDefinition().TestCases)
                     {
-                        allTestsSkipped = false;
                         var testId = _testReporter.CreateTest(testRunId, testSuiteId, $"{testCase.TestCaseName}", "TODO");
-                        var message = $"{{ \"TestName\": {testCase.TestCaseName}, \"BrowserConfiguration\": {JsonConvert.SerializeObject(browserConfig)}}}";
                         _testReporter.SkipTest(testRunId, testId);
                     }
                 }
@@ -217,6 +215,7 @@ namespace Microsoft.PowerApps.TestEngine
 
                 Logger.LogInformation("Total cases: " + casesTotal);
                 Logger.LogInformation("Cases passed: " + casesPass);
+
                 Logger.LogInformation("Cases skipped: " + (casesTotal - (casesFail + casesPass)));
                 Logger.LogInformation("Cases failed: " + casesFail + "\n");
 

--- a/src/Microsoft.PowerApps.TestEngine/SingleTestRunner.cs
+++ b/src/Microsoft.PowerApps.TestEngine/SingleTestRunner.cs
@@ -119,7 +119,7 @@ namespace Microsoft.PowerApps.TestEngine
                 // Run test case one by one
                 foreach (var testCase in _testState.GetTestSuiteDefinition().TestCases)
                 {
-                    TestSuccess = true;                    
+                    TestSuccess = true;
                     var testId = _testReporter.CreateTest(testRunId, testSuiteId, $"{testCase.TestCaseName}", "TODO");
                     _testReporter.StartTest(testRunId, testId);
                     _testState.SetTestId(testId);

--- a/src/Microsoft.PowerApps.TestEngine/SingleTestRunner.cs
+++ b/src/Microsoft.PowerApps.TestEngine/SingleTestRunner.cs
@@ -62,6 +62,9 @@ namespace Microsoft.PowerApps.TestEngine
                 throw new InvalidOperationException("This test can only be run once.");
             }
 
+            // This flag is needed to check if test run is skipped
+            var allTestsSkipped = true;
+
             var casesTotal = 0;
             var casesPass = 0;
             var casesFail = 0;
@@ -116,6 +119,7 @@ namespace Microsoft.PowerApps.TestEngine
                 foreach (var testCase in _testState.GetTestSuiteDefinition().TestCases)
                 {
                     TestSuccess = true;
+                    allTestsSkipped = false;
                     var testId = _testReporter.CreateTest(testRunId, testSuiteId, $"{testCase.TestCaseName}", "TODO");
                     _testReporter.StartTest(testRunId, testId);
                     _testState.SetTestId(testId);
@@ -194,6 +198,11 @@ namespace Microsoft.PowerApps.TestEngine
             finally
             {
                 await _testInfraFunctions.EndTestRunAsync();
+
+                if (allTestsSkipped)
+                {
+                    _testReporter.EndTestsSkipped(testRunId, casesTotal);
+                }
 
                 Logger.LogInformation($"---------------------------------------------------------------------------\n" +
                                 $"{testSuiteName} TEST SUMMARY" +

--- a/src/Microsoft.PowerApps.TestEngine/SingleTestRunner.cs
+++ b/src/Microsoft.PowerApps.TestEngine/SingleTestRunner.cs
@@ -197,7 +197,7 @@ namespace Microsoft.PowerApps.TestEngine
             }
             finally
             {
-            await _testInfraFunctions.EndTestRunAsync();
+                await _testInfraFunctions.EndTestRunAsync();
 
                 if (allTestsSkipped)
                 {

--- a/src/Microsoft.PowerApps.TestEngine/SingleTestRunner.cs
+++ b/src/Microsoft.PowerApps.TestEngine/SingleTestRunner.cs
@@ -201,7 +201,14 @@ namespace Microsoft.PowerApps.TestEngine
 
                 if (allTestsSkipped)
                 {
-                    _testReporter.EndTestsSkipped(testRunId, casesTotal);
+                    // Run test case one by one, mark it as skipped
+                    foreach (var testCase in _testState.GetTestSuiteDefinition().TestCases)
+                    {
+                        allTestsSkipped = false;
+                        var testId = _testReporter.CreateTest(testRunId, testSuiteId, $"{testCase.TestCaseName}", "TODO");
+                        var message = $"{{ \"TestName\": {testCase.TestCaseName}, \"BrowserConfiguration\": {JsonConvert.SerializeObject(browserConfig)}}}";
+                        _testReporter.SkipTest(testRunId, testId);
+                    }
                 }
 
                 Logger.LogInformation($"---------------------------------------------------------------------------\n" +


### PR DESCRIPTION
## Problem
- TestEngine Yaml-Integration tests fails frequently with the error (**Error: td.UnitTest is not iterable**)
```
Creating test report Sample Tests
Processing test results from TestResults/0ba[44](https://github.com/microsoft/PowerApps-TestEngine/actions/runs/4058670848/jobs/6999496015#step:4:46)3/Results_0ba44369-b153-49c5-bae5-dbf5c69d7fe4.trx
  Processing test results from TestResults/0ce064/Results_0ce06468-6ad0-41b5-ab2d-03c43d071b46.trx
  Processing test results from TestResults/2bb9ce/Results_2bb9cea4-86b7-4832-88f0-87ef4057fdb6.trx
  Processing test results from TestResults/3471b1/Results_3471b1e2-0422-4d95-ba87-ee8786fed56d.trx
  Processing test results from TestResults/3afabc/Results_3afabc51-7aec-48db-8ae9-b6577683baa5.trx
  Processing test results from TestResults/40ef93/Results_40ef935c-5501-4e50-816a-bf183fcfeea7.trx
  Processing test results from TestResults/652f50/Results_652f5053-a8e0-4c[45](https://github.com/microsoft/PowerApps-TestEngine/actions/runs/4058670848/jobs/6999496015#step:4:47)-b918-258f3ec4bb50.trx
  Processing test results from TestResults/835d96/Results_835d96fd-[48](https://github.com/microsoft/PowerApps-TestEngine/actions/runs/4058670848/jobs/6999496015#step:4:50)6c-4cf9-b6f9-80cf196cfce6.trx
  Processing test results from TestResults/85f02f/Results_85f02f1e-41f6-4be2-8044-f6f08b006845.trx
  ::endgroup::
Error: td.UnitTest is not iterable 
```

 - If test runs are skipped the total cases and case skipped not updated
<img width="364" alt="image" src="https://user-images.githubusercontent.com/98551644/216625316-7ee0abac-9743-4fc5-b098-0f1c93d5ead3.png">

## After Fix
<img width="494" alt="image" src="https://user-images.githubusercontent.com/98551644/216692833-8196b2ae-2689-4c87-aa1b-4cbc03075efc.png">

Tests will show as 
<img width="531" alt="image" src="https://user-images.githubusercontent.com/98551644/216719106-40e08f9f-3f55-404b-bbf5-6f9e86f69737.png">


## Checklist
- [x] I have performed end-to-end test locally.
- [x] Existing unit tests pass locally with my changes
- [x] My changes generate no new warnings
- [x] I used clear names for everything
- [x] I have performed a self-review of my own code
