### PR TITLE
Handle skipped tests as failed tests

### DIFF
--- a/src/Microsoft.PowerApps.TestEngine.Tests/Reporting/TestReporterTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/Reporting/TestReporterTests.cs
@@ -331,7 +331,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Reporting
         }
 
         [Fact]
-        public void SkipTestTest()
+        public void FailTestTest()
         {
             var testRunName = "testRunName";
             var testUser = "testUser";

--- a/src/Microsoft.PowerApps.TestEngine.Tests/Reporting/TestReporterTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/Reporting/TestReporterTests.cs
@@ -315,14 +315,14 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Reporting
             {
                 Assert.Equal(1, testRun.ResultSummary.Counters.Passed);
                 Assert.Equal(0, testRun.ResultSummary.Counters.Failed);
-                Assert.Equal("Passed", testRun.Results.UnitTestResults[0].Outcome);
+                Assert.Equal(TestReporter.PassedResultOutcome, testRun.Results.UnitTestResults[0].Outcome);
                 Assert.Null(testRun.Results.UnitTestResults[0].Output.ErrorInfo);
             }
             else
             {
                 Assert.Equal(0, testRun.ResultSummary.Counters.Passed);
                 Assert.Equal(1, testRun.ResultSummary.Counters.Failed);
-                Assert.Equal("Failed", testRun.Results.UnitTestResults[0].Outcome);
+                Assert.Equal(TestReporter.FailedResultOutcome, testRun.Results.UnitTestResults[0].Outcome);
                 Assert.Equal(errorMessage, testRun.Results.UnitTestResults[0].Output.ErrorInfo.Message);
                 Assert.Equal(stackTrace, testRun.Results.UnitTestResults[0].Output.ErrorInfo.StackTrace);
             }
@@ -350,7 +350,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Reporting
             var testRun = testReporter.GetTestRun(testRunId);
             var testResult = testRun.Results.UnitTestResults.Where(x => x.TestId == testId).First();
 
-            Assert.True(testResult.Outcome == "Failed");
+            Assert.True(testResult.Outcome == TestReporter.FailedResultOutcome);
             Assert.Equal(1, testRun.ResultSummary.Counters.Failed);
         }
 

--- a/src/Microsoft.PowerApps.TestEngine.Tests/Reporting/TestReporterTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/Reporting/TestReporterTests.cs
@@ -345,13 +345,13 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Reporting
             var testSuiteId = testReporter.CreateTestSuite(testRunId, "testSuite");
             var testId = testReporter.CreateTest(testRunId, testSuiteId, testName, testLocation);
 
-            testReporter.SkipTest(testRunId, testId);
+            testReporter.FailTest(testRunId, testId);
 
             var testRun = testReporter.GetTestRun(testRunId);
             var testResult = testRun.Results.UnitTestResults.Where(x => x.TestId == testId).First();
 
-            Assert.True(testResult.Outcome == "NotExecuted");
-            Assert.Equal(1, testRun.ResultSummary.Counters.NotExecuted);
+            Assert.True(testResult.Outcome == "Failed");
+            Assert.Equal(1, testRun.ResultSummary.Counters.Failed);
         }
 
         [Fact]

--- a/src/Microsoft.PowerApps.TestEngine.Tests/SingleTestRunnerTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/SingleTestRunnerTests.cs
@@ -58,7 +58,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
             MockTestReporter.Setup(x => x.CreateTestSuite(It.IsAny<string>(), It.IsAny<string>())).Returns(testSuiteId);
             MockTestReporter.Setup(x => x.StartTest(It.IsAny<string>(), It.IsAny<string>()));
             MockTestReporter.Setup(x => x.EndTest(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<string>(), It.IsAny<List<string>>(), It.IsAny<string>(), It.IsAny<string>()));
-            MockTestReporter.Setup(x => x.SkipTest(It.IsAny<string>(), It.IsAny<string>()));
+            MockTestReporter.Setup(x => x.FailTest(It.IsAny<string>(), It.IsAny<string>()));
 
             MockLoggerFactory.Setup(x => x.CreateLogger(It.IsAny<string>())).Returns(MockLogger.Object);
 

--- a/src/Microsoft.PowerApps.TestEngine/Reporting/ITestReporter.cs
+++ b/src/Microsoft.PowerApps.TestEngine/Reporting/ITestReporter.cs
@@ -63,7 +63,7 @@ namespace Microsoft.PowerApps.TestEngine.Reporting
         /// </summary>
         /// <param name="testRunId">Test run id</param>
         /// <param name="testId">Test id</param>
-        public void SkipTest(string testRunId, string testId);
+        public void FailTest(string testRunId, string testId);
 
         /// <summary>
         /// Generate test report

--- a/src/Microsoft.PowerApps.TestEngine/Reporting/TestReporter.cs
+++ b/src/Microsoft.PowerApps.TestEngine/Reporting/TestReporter.cs
@@ -215,12 +215,12 @@ namespace Microsoft.PowerApps.TestEngine.Reporting
             testRun.ResultSummary.Counters.InProgress++;
         }
 
-        public void SkipTest(string testRunId, string testId)
+        public void FailTest(string testRunId, string testId)
         {
             var testRun = GetTestRun(testRunId);
             var testResult = testRun.Results.UnitTestResults.Where(x => x.TestId == testId).First();
-            testRun.ResultSummary.Counters.NotExecuted++;
-            testResult.Outcome = "NotExecuted";
+            testRun.ResultSummary.Counters.Failed++;
+            testResult.Outcome = "Failed";
         }
 
         public void EndTest(string testRunId, string testId, bool success, string stdout, List<string> additionalFiles, string errorMessage, string stackTrace)

--- a/src/Microsoft.PowerApps.TestEngine/Reporting/TestReporter.cs
+++ b/src/Microsoft.PowerApps.TestEngine/Reporting/TestReporter.cs
@@ -13,6 +13,9 @@ namespace Microsoft.PowerApps.TestEngine.Reporting
         private readonly IFileSystem _fileSystem;
         private readonly DateTime _defaultDateTime = new DateTime();
 
+        public static string FailedResultOutcome = "Failed";
+        public static string PassedResultOutcome = "Passed";
+
         public TestReporter(IFileSystem fileSystem)
         {
             _fileSystem = fileSystem;
@@ -220,7 +223,7 @@ namespace Microsoft.PowerApps.TestEngine.Reporting
             var testRun = GetTestRun(testRunId);
             var testResult = testRun.Results.UnitTestResults.Where(x => x.TestId == testId).First();
             testRun.ResultSummary.Counters.Failed++;
-            testResult.Outcome = "Failed";
+            testResult.Outcome = FailedResultOutcome;
         }
 
         public void EndTest(string testRunId, string testId, bool success, string stdout, List<string> additionalFiles, string errorMessage, string stackTrace)
@@ -253,12 +256,12 @@ namespace Microsoft.PowerApps.TestEngine.Reporting
             if (success)
             {
                 testRun.ResultSummary.Counters.Passed++;
-                testResult.Outcome = "Passed";
+                testResult.Outcome = PassedResultOutcome;
             }
             else
             {
                 testRun.ResultSummary.Counters.Failed++;
-                testResult.Outcome = "Failed";
+                testResult.Outcome = FailedResultOutcome;
                 testResult.Output.ErrorInfo = new TestErrorInfo();
                 testResult.Output.ErrorInfo.Message = errorMessage;
                 testResult.Output.ErrorInfo.StackTrace = stackTrace;

--- a/src/Microsoft.PowerApps.TestEngine/SingleTestRunner.cs
+++ b/src/Microsoft.PowerApps.TestEngine/SingleTestRunner.cs
@@ -201,7 +201,7 @@ namespace Microsoft.PowerApps.TestEngine
 
                 if (allTestsSkipped)
                 {
-                    // Run test case one by one, mark it as skipped
+                    // Run test case one by one, mark it as failed
                     foreach (var testCase in _testState.GetTestSuiteDefinition().TestCases)
                     {
                         var testId = _testReporter.CreateTest(testRunId, testSuiteId, $"{testCase.TestCaseName}", "TODO");

--- a/src/Microsoft.PowerApps.TestEngine/SingleTestRunner.cs
+++ b/src/Microsoft.PowerApps.TestEngine/SingleTestRunner.cs
@@ -205,7 +205,7 @@ namespace Microsoft.PowerApps.TestEngine
                     foreach (var testCase in _testState.GetTestSuiteDefinition().TestCases)
                     {
                         var testId = _testReporter.CreateTest(testRunId, testSuiteId, $"{testCase.TestCaseName}", "TODO");
-                        _testReporter.SkipTest(testRunId, testId);
+                        _testReporter.FailTest(testRunId, testId);
                     }
                 }
 


### PR DESCRIPTION
Previous fix handled not executed tests as skipped but handle it as failed.
https://github.com/microsoft/PowerApps-TestEngine/pull/203

## Checklist

- [x] The code change is covered by unit tests.
- [x] I have performed end-to-end test locally.
- [x] New and existing unit tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I used clear names for everything
- [x] I have performed a self-review of my own code
