### PR TITLE
Changed unspecified locale log message from INFO to WARN

### DIFF
--- a/docs/Yaml/testSettings.md
+++ b/docs/Yaml/testSettings.md
@@ -6,7 +6,7 @@ This is used to define settings for the tests in the test plan
 
 | Property | Required | Description |
 | -- | -- | -- |
-| locale | Yes | The locale/culture syntax in which the test cases or test steps are written in. See [Global Support in Microsoft PowerFx](https://learn.microsoft.com/en-us/power-platform/power-fx/global) for more info. If unspecified, `CultureInfo.CurrentCulture` will be used for the locale by default for parsing the test steps. |
+| locale | Yes | The locale/culture syntax in which the test cases or test steps are written in. See [Global Support in Microsoft Power Fx](https://learn.microsoft.com/en-us/power-platform/power-fx/global) for more info. If unspecified, `CultureInfo.CurrentCulture` will be used for the locale by default for parsing the test steps. |
 | browserConfigurations | Yes | A list of browser configurations to be tested. At least one browser must be specified. |
 | recordVideo | No | Default is false. If set to true, a video recording of the test is captured. |
 | headless | No | Default is true. If set to false, the browser will show up during test execution. |

--- a/src/Microsoft.PowerApps.TestEngine.Tests/TestEngineTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/TestEngineTests.cs
@@ -45,8 +45,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
         {
             var testSettings = new TestSettings()
             {
-                // Empty string in locale field is supported and handled appropriately
-                Locale = string.Empty,
+                Locale = "en-US",
                 WorkerCount = 2,
                 BrowserConfigurations = new List<BrowserConfiguration>()
                 {
@@ -138,6 +137,57 @@ namespace Microsoft.PowerApps.TestEngine.Tests
             var testEngine = new TestEngine(MockState.Object, ServiceProvider, MockTestReporter.Object, MockFileSystem.Object, MockLoggerFactory.Object);
 
             await Assert.ThrowsAsync<CultureNotFoundException>(() => testEngine.RunTestAsync(testConfigFile, environmentId, tenantId, "", domain, ""));
+        }
+
+        [Fact]
+        public async Task TestEngineWithUnspecifiedLocaleShowsWarning()
+        {
+            var testSettings = new TestSettings()
+            {
+                WorkerCount = 2,
+                BrowserConfigurations = new List<BrowserConfiguration>()
+                {
+                    new BrowserConfiguration()
+                    {
+                        Browser = "Chromium"
+                    }
+                }
+            };
+            var testSuiteDefinition = new TestSuiteDefinition()
+            {
+                TestSuiteName = "Test1",
+                TestSuiteDescription = "First test",
+                AppLogicalName = "logicalAppName1",
+                Persona = "User1",
+                TestCases = new List<TestCase>()
+                {
+                    new TestCase
+                    {
+                        TestCaseName = "Test Case Name",
+                        TestCaseDescription = "Test Case Description",
+                        TestSteps = "Assert(1 + 1 = 2, \"1 + 1 should be 2 \")"
+                    }
+                }
+            };
+            var testConfigFile = "C:\\testPlan.fx.yaml";
+            var environmentId = "defaultEnviroment";
+            var tenantId = "tenantId";
+            var testRunId = Guid.NewGuid().ToString();
+            var expectedOutputDirectory = "TestOutput";
+            var testRunDirectory = Path.Combine(expectedOutputDirectory, testRunId.Substring(0, 6));
+            var domain = "apps.powerapps.com";
+
+            var expectedTestReportPath = "C:\\test.trx";
+
+            SetupMocks(expectedOutputDirectory, testSettings, testSuiteDefinition, testRunId, expectedTestReportPath);
+
+            var testEngine = new TestEngine(MockState.Object, ServiceProvider, MockTestReporter.Object, MockFileSystem.Object, MockLoggerFactory.Object);
+            var testReportPath = await testEngine.RunTestAsync(testConfigFile, environmentId, tenantId, "", domain, "");
+
+            Assert.Equal(expectedTestReportPath, testReportPath);
+            LoggingTestHelper.VerifyLogging(MockLogger, $"Locale property not specified in testSettings. Using current system locale: {CultureInfo.CurrentCulture.Name}", LogLevel.Warning, Times.Once());
+
+            Verify(testConfigFile, environmentId, tenantId, domain, "", expectedOutputDirectory, testRunId, testRunDirectory, testSuiteDefinition, testSettings);
         }
 
         [Theory]

--- a/src/Microsoft.PowerApps.TestEngine/TestEngine.cs
+++ b/src/Microsoft.PowerApps.TestEngine/TestEngine.cs
@@ -156,7 +156,7 @@ namespace Microsoft.PowerApps.TestEngine
             {
                 if (string.IsNullOrEmpty(strLocale))
                 {
-                    Logger.LogInformation($"Locale unspecified in Test Suite Definition, using system locale {locale.Name}");
+                    Logger.LogWarning($"Locale unspecified in Test Suite Definition, using system locale {locale.Name}");
                 }
                 else
                 {

--- a/src/Microsoft.PowerApps.TestEngine/TestEngine.cs
+++ b/src/Microsoft.PowerApps.TestEngine/TestEngine.cs
@@ -156,7 +156,7 @@ namespace Microsoft.PowerApps.TestEngine
             {
                 if (string.IsNullOrEmpty(strLocale))
                 {
-                    Logger.LogWarning($"Locale unspecified in Test Suite Definition, using system locale {locale.Name}");
+                    Logger.LogWarning($"Locale property not specified in testSettings. Using current system locale: {locale.Name}");
                 }
                 else
                 {


### PR DESCRIPTION
# Description

This is a very small log message change. For the log message that informs the user when the locale field is missing in the test plan file, the log type has been changed from INFO to WARN to better indicate the nature of the message. I have added one more unit test to specifically look for this, as this is a "required" user facing change.

This now looks like this - 
![image](https://user-images.githubusercontent.com/1485950/219424182-ba2737b8-a4cb-41e9-9d7c-0af10499e681.png)

Also a small branding related correction has been made to the `testSettings.md` readme - changed phrase `PowerFx` to `Power Fx` to comply with the correct terminology.

## Checklist

- [X] The code change is covered by unit tests. I have added tests that prove my fix is effective or that my feature works
- [X] I have performed end-to-end test locally.
- [X] New and existing unit tests pass locally with my changes
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I used clear names for everything
- [X] I have performed a self-review of my own code
