### PR TITLE
Removing typeOf powerappstestengine logtrace

### DIFF
--- a/src/Microsoft.PowerApps.TestEngine/PowerApps/PowerAppFunctions.cs
+++ b/src/Microsoft.PowerApps.TestEngine/PowerApps/PowerAppFunctions.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-using System.Security.Cryptography.X509Certificates;
 using Microsoft.Extensions.Logging;
 using Microsoft.PowerApps.TestEngine.Config;
 using Microsoft.PowerApps.TestEngine.Helpers;

--- a/src/Microsoft.PowerApps.TestEngine/PowerApps/PowerAppFunctions.cs
+++ b/src/Microsoft.PowerApps.TestEngine/PowerApps/PowerAppFunctions.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+using System.Security.Cryptography.X509Certificates;
 using Microsoft.Extensions.Logging;
 using Microsoft.PowerApps.TestEngine.Config;
 using Microsoft.PowerApps.TestEngine.Helpers;
@@ -21,6 +22,8 @@ namespace Microsoft.PowerApps.TestEngine.PowerApps
         private readonly ITestState _testState;
 
         public static string PublishedAppIframeName = "fullscreen-app-host";
+        public static string CheckPowerAppsTestEngineObject = "typeof PowerAppsTestEngine";
+
         private string GetItemCountErrorMessage = "Something went wrong when Test Engine tried to get item count.";
         private string GetPropertyValueErrorMessage = "Something went wrong when Test Engine tried to get property value.";
         private string LoadObjectModelErrorMessage = "Something went wrong when Test Engine tried to load object model.";
@@ -162,7 +165,7 @@ namespace Microsoft.PowerApps.TestEngine.PowerApps
 
             try
             {
-                result = await _testInfraFunctions.RunJavascriptAsync<string>("typeof PowerAppsTestEngine");
+                result = await _testInfraFunctions.RunJavascriptAsync<string>(CheckPowerAppsTestEngineObject);
             }
             catch (NullReferenceException) { }
 

--- a/src/Microsoft.PowerApps.TestEngine/TestInfra/PlaywrightTestInfraFunctions.cs
+++ b/src/Microsoft.PowerApps.TestEngine/TestInfra/PlaywrightTestInfraFunctions.cs
@@ -5,6 +5,7 @@ using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.Logging;
 using Microsoft.Playwright;
 using Microsoft.PowerApps.TestEngine.Config;
+using Microsoft.PowerApps.TestEngine.PowerApps;
 using Microsoft.PowerApps.TestEngine.System;
 
 namespace Microsoft.PowerApps.TestEngine.TestInfra
@@ -275,7 +276,9 @@ namespace Microsoft.PowerApps.TestEngine.TestInfra
         {
             ValidatePage();
 
-            _singleTestInstanceState.GetLogger().LogDebug("Run Javascript: " + jsExpression);
+            if (!jsExpression.Equals(PowerAppFunctions.CheckPowerAppsTestEngineObject)) {
+                _singleTestInstanceState.GetLogger().LogDebug("Run Javascript: " + jsExpression);
+            }            
 
             return await Page.EvaluateAsync<T>(jsExpression);
         }


### PR DESCRIPTION
# Pull Request Template

## Description

typeOf PowerAppsTestEngine returning verbosely in TestEngine

## Checklist
- [ ] I have performed end-to-end test locally.
- [ ] New and existing unit tests pass locally with my changes
- [ ] My changes generate no new warnings
- [ ] I used clear names for everything
- [ ] I have performed a self-review of my own code
