### PR TITLE
Targetting console app to net6.0

### DIFF
--- a/src/PowerAppsTestEngine/PowerAppsTestEngine.csproj
+++ b/src/PowerAppsTestEngine/PowerAppsTestEngine.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net48;net6.0</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <EnforceCodeStyleInBuild>True</EnforceCodeStyleInBuild>


### PR DESCRIPTION
## Description
Currently console app targets two versions and for every dotnet run you would need to pass -f with version explicitly.
 ` dotnet run -f net6.0 `
Console app targets to net6.0. but the project dll can run on multiple versions. After this change
you can run testengine using just `dotnet run` 


## Checklist
- [x] I have performed end-to-end test locally.
- [x] My changes generate no new warnings
- [x] I used clear names for everything
- [x] I have performed a self-review of my own code
