### PR TITLE
Unit tests non-discoverable running locally.

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,6 @@
 <Project>
     <PropertyGroup>
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-        <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
         <LangVersion>10.0</LangVersion>
     </PropertyGroup>
 


### PR DESCRIPTION
## Problem
When run locally, unittests are non-discoverable.

## Solution
The output directory for each project needs to have the target attribute.cs file generated. 
Setting ` GenerateTargetFrameworkAttribute` to false in the Directory.Build.props would result in this C# source file not generated. Previously, the below marked file was not generated. 

<img width="500" alt="image" src="https://user-images.githubusercontent.com/98551644/230969402-fd31af7e-46dc-44e5-ba8e-5a4ba83db154.png">

This would have adverse effect when targeting the right version. 
- Earlier xUnit.net was targetting .NET 4.0 
- And with the change it targets or points to the correct version .NET 6.0.
<img width="448" alt="image" src="https://user-images.githubusercontent.com/98551644/230970967-3bf7335c-9b3e-4540-8e0d-b81922292aa4.png">

Thus, the tests are discovered correctly solving this issue.

## Checklist
- [x] My changes generate no new warnings
- [x] I used clear names for everything
- [x] I have performed a self-review of my own code
