### PR TITLE
Ignore samples folder when running clean.cmd

### DIFF
--- a/clean.cmd
+++ b/clean.cmd
@@ -1,4 +1,4 @@
 @if "%_echo%"=="" echo off
 pushd "%~dp0"
-git clean -fdx -e *.dev.json
+git clean -fdx -e [*.dev.json]||[\samples]
 popd


### PR DESCRIPTION
Ignore samples folder when running clean.cmd

## Checklist
- [x] My changes generate no new warnings
- [x] I used clear names for everything
- [x] I have performed a self-review of my own code
