### PR TITLE
Print assertion message in the case of assertion failure

### DIFF
--- a/src/Microsoft.PowerApps.TestEngine.Tests/PowerFx/Functions/AssertFunctionTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/PowerFx/Functions/AssertFunctionTests.cs
@@ -37,7 +37,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx.Functions
             LoggingTestHelper.SetupMock(MockLogger);
             var assertFunction = new AssertFunction(MockLogger.Object);
             var message = "This should fail";
-            Assert.Throws<InvalidOperationException>(() => assertFunction.Execute(BooleanValue.New(false), StringValue.New(message)));
+            Assert.Throws<Exception>(() => assertFunction.Execute(BooleanValue.New(false), StringValue.New(message)));
             LoggingTestHelper.VerifyLogging(MockLogger, "Assert failed. Property is not equal to the specified value.", LogLevel.Error, Times.Once());
         }
     }

--- a/src/Microsoft.PowerApps.TestEngine/PowerFx/Functions/AssertFunction.cs
+++ b/src/Microsoft.PowerApps.TestEngine/PowerFx/Functions/AssertFunction.cs
@@ -29,7 +29,7 @@ namespace Microsoft.PowerApps.TestEngine.PowerFx.Functions
             {
                 _logger.LogTrace($"{message.Value}");
                 _logger.LogError("Assert failed. Property is not equal to the specified value.");
-                throw new InvalidOperationException();
+                throw new Exception($"  Assertion failed: {message.Value}");
             }
 
             _logger.LogTrace(message.Value);

--- a/src/Microsoft.PowerApps.TestEngine/SingleTestRunner.cs
+++ b/src/Microsoft.PowerApps.TestEngine/SingleTestRunner.cs
@@ -171,7 +171,16 @@ namespace Microsoft.PowerApps.TestEngine
                         }
                         catch (Exception ex)
                         {
-                            Console.Out.WriteLine($"  {ex.Message}");
+                            // Print assertion if exception is the result of an Assert failure
+                            if (ex?.InnerException?.InnerException?.Message?.Contains("Assertion failed") == true)
+                            {
+                                Console.Out.WriteLine(ex.InnerException.InnerException.Message);
+                            }
+                            else
+                            {
+                                Console.Out.WriteLine($"  {ex.Message}");
+                            }
+
                             Console.Out.WriteLine("  Result: Failed");
 
                             caseException = ex.ToString();


### PR DESCRIPTION
## Description

The intended assertion message should print instead of a long exception, in the case that it's the assert function that fails.

## Checklist

- [x] The code change is covered by unit tests. I have added tests that prove my fix is effective or that my feature works
- [x] I have performed end-to-end test locally.
- [x] New and existing unit tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I used clear names for everything
- [x] I have performed a self-review of my own code
