### PR TITLE
Fixed Relative Path for Embedded JSSDK

### DIFF
--- a/src/Microsoft.PowerApps.TestEngine/PowerApps/PowerAppFunctions.cs
+++ b/src/Microsoft.PowerApps.TestEngine/PowerApps/PowerAppFunctions.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+using System.Reflection;
 using Microsoft.Extensions.Logging;
 using Microsoft.PowerApps.TestEngine.Config;
 using Microsoft.PowerApps.TestEngine.Helpers;
@@ -27,6 +28,7 @@ namespace Microsoft.PowerApps.TestEngine.PowerApps
         private string GetItemCountErrorMessage = "Something went wrong when Test Engine tried to get item count.";
         private string GetPropertyValueErrorMessage = "Something went wrong when Test Engine tried to get property value.";
         private string LoadObjectModelErrorMessage = "Something went wrong when Test Engine tried to load object model.";
+        private string FileNotFoundErrorMessage = "Something went wrong when Test Engine tried to load required dependencies.";
         private TypeMapping TypeMapping = new TypeMapping();
 
         public PowerAppFunctions(ITestInfraFunctions testInfraFunctions, ISingleTestInstanceState singleTestInstanceState, ITestState testState)
@@ -63,14 +65,17 @@ namespace Microsoft.PowerApps.TestEngine.PowerApps
 
         private string GetFilePath(string file)
         {
-            var currentDirectory = Directory.GetCurrentDirectory();
-            var fullFilePath = Path.Combine(currentDirectory, file);
+            var assemblyLocation = Assembly.GetEntryAssembly().Location;
+            var assemblyDirectory = Path.GetDirectoryName(assemblyLocation);
+            var fullFilePath = Path.Combine(assemblyDirectory, file);
             if (File.Exists(fullFilePath))
             {
                 return fullFilePath;
             }
-
-            return Path.Combine(Directory.GetParent(currentDirectory).FullName, "Microsoft.PowerApps.TestEngine", file);
+            else
+            {
+                throw new FileNotFoundException(FileNotFoundErrorMessage, file);
+            }
         }
 
         public async Task<bool> CheckIfAppIsIdleAsync()

--- a/src/Microsoft.PowerApps.TestEngine/PowerApps/PowerAppFunctions.cs
+++ b/src/Microsoft.PowerApps.TestEngine/PowerApps/PowerAppFunctions.cs
@@ -65,7 +65,7 @@ namespace Microsoft.PowerApps.TestEngine.PowerApps
 
         private string GetFilePath(string file)
         {
-            var assemblyLocation = Assembly.GetEntryAssembly().Location;
+            var assemblyLocation = Assembly.GetExecutingAssembly().Location;
             var assemblyDirectory = Path.GetDirectoryName(assemblyLocation);
             var fullFilePath = Path.Combine(assemblyDirectory, file);
             if (File.Exists(fullFilePath))


### PR DESCRIPTION
# Description
The current logic for getting the relative path for the embedded JSSDK (`JS\CanvasAppSdk.js` and `JS\PublishedAppTesting.js`) returns the current working directory path and therefore does not account for the application running from any directory (i.e., executable path added to the PATH variable and invoked from anywhere on the computer). Due to this, when executed from outside the source code default build output, the application looks for the embedded JSSDK within the directory from where the command was invoked (e.g., `C:\Users\{username}\Desktop\JS\CanvasAppSdk.js`) which is clearly incorrect.

This logic has now been changed wherein we will now compute the path to the executing assembly so that irrespective of where the application is invoked from, the relative path to the embedded JSSDK will always remain relative to the assembly location (where it is expected that the embedded JSSDK files will live alongside the assembly binary).

# Checklist

- [x] The code change is covered by unit tests. I have added tests that prove my fix is effective or that my feature works
- [x] I have performed end-to-end test locally.
- [x] New and existing unit tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I used clear names for everything
- [x] I have performed a self-review of my own code
