### PR TITLE
updated preview version packages to use stable release versions

### DIFF
--- a/src/Microsoft.PowerApps.TestEngine/Microsoft.PowerApps.TestEngine.csproj
+++ b/src/Microsoft.PowerApps.TestEngine/Microsoft.PowerApps.TestEngine.csproj
@@ -27,11 +27,11 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Playwright" Version="1.22.0" />
     <PackageReference Include="Microsoft.PowerFx.Interpreter" Version="0.2.3-preview" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageReference Include="YamlDotNet" Version="11.2.1" />
   </ItemGroup>
   

--- a/src/Microsoft.PowerApps.TestEngine/Microsoft.PowerApps.TestEngine.csproj
+++ b/src/Microsoft.PowerApps.TestEngine/Microsoft.PowerApps.TestEngine.csproj
@@ -27,8 +27,8 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0-preview.3.22175.4" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0-preview.3.22175.4" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
     <PackageReference Include="Microsoft.Playwright" Version="1.22.0" />
     <PackageReference Include="Microsoft.PowerFx.Interpreter" Version="0.2.3-preview" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />


### PR DESCRIPTION
## Description

This is a minor change made to dependent packages for compatibility reasons - 
- Some packages were in preview versions and these have been corrected to use versions that align with consuming applications (e.g. PAC CLI) for compatibility (e.g. DependencyInjection has to be 6.0 to be compatible with net5.0 of PAC CLI)
- Few others were also changed just so that they align with the versions used in PAC CLI as well
- Full set of tests were run and no test failures were observed - i.e. no code changes or changes in functionality.

## Checklist

- [x] The code change is covered by unit tests. I have added tests that prove my fix is effective or that my feature works
- [x] I have performed end-to-end test locally.
- [x] New and existing unit tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I used clear names for everything
- [x] I have performed a self-review of my own code
