### PR TITLE
Revert "Changed NuGet Feed URL for PowerFx Packages and Updated PowerFx.Interpreter version"

### DIFF
--- a/src/Microsoft.PowerApps.TestEngine/Microsoft.PowerApps.TestEngine.csproj
+++ b/src/Microsoft.PowerApps.TestEngine/Microsoft.PowerApps.TestEngine.csproj
@@ -30,7 +30,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Playwright" Version="1.22.0" />
-    <PackageReference Include="Microsoft.PowerFx.Interpreter" Version="0.2.3-preview.20221117-001" />
+    <PackageReference Include="Microsoft.PowerFx.Interpreter" Version="0.2.3-preview" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageReference Include="YamlDotNet" Version="11.2.1" />
   </ItemGroup>

--- a/src/nuget.config
+++ b/src/nuget.config
@@ -1,8 +1,7 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <packageSources>
         <clear />
         <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />        
-        <add key="PowerFx" value="https://pkgs.dev.azure.com/Power-Fx/7dd30b4a-31be-4ac9-a649-e6addd4d5b0a/_packaging/PowerFx/nuget/v3/index.json" />
     </packageSources>
 </configuration>


### PR DESCRIPTION
Reverts microsoft/PowerApps-TestEngine#246 - 

- This change was originally intended for pulling this dependency from an alternate source to mitigate an underlying bug - this is no longer required.
- We have an alternate mitigation in the consuming application to work around this bug so this PR is being reverted.