### PR TITLE
Add AssertionFailureException

### DIFF
--- a/src/Microsoft.PowerApps.TestEngine.Tests/PowerFx/Functions/AssertFunctionTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/PowerFx/Functions/AssertFunctionTests.cs
@@ -5,6 +5,7 @@ using System;
 using Microsoft.Extensions.Logging;
 using Microsoft.PowerApps.TestEngine.PowerFx.Functions;
 using Microsoft.PowerApps.TestEngine.Tests.Helpers;
+using Microsoft.PowerApps.TestEngine.System;
 using Microsoft.PowerFx.Types;
 using Moq;
 using Xunit;
@@ -37,7 +38,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx.Functions
             LoggingTestHelper.SetupMock(MockLogger);
             var assertFunction = new AssertFunction(MockLogger.Object);
             var message = "This should fail";
-            Assert.Throws<Exception>(() => assertFunction.Execute(BooleanValue.New(false), StringValue.New(message)));
+            Assert.Throws<AssertionFailureException>(() => assertFunction.Execute(BooleanValue.New(false), StringValue.New(message)));
             LoggingTestHelper.VerifyLogging(MockLogger, "Assert failed. Property is not equal to the specified value.", LogLevel.Error, Times.Once());
         }
     }

--- a/src/Microsoft.PowerApps.TestEngine/PowerFx/Functions/AssertFunction.cs
+++ b/src/Microsoft.PowerApps.TestEngine/PowerFx/Functions/AssertFunction.cs
@@ -2,9 +2,9 @@
 // Licensed under the MIT license.
 
 using Microsoft.Extensions.Logging;
+using Microsoft.PowerApps.TestEngine.System;
 using Microsoft.PowerFx;
 using Microsoft.PowerFx.Types;
-using Microsoft.PowerApps.TestEngine.System;
 
 namespace Microsoft.PowerApps.TestEngine.PowerFx.Functions
 {

--- a/src/Microsoft.PowerApps.TestEngine/PowerFx/Functions/AssertFunction.cs
+++ b/src/Microsoft.PowerApps.TestEngine/PowerFx/Functions/AssertFunction.cs
@@ -4,6 +4,7 @@
 using Microsoft.Extensions.Logging;
 using Microsoft.PowerFx;
 using Microsoft.PowerFx.Types;
+using Microsoft.PowerApps.TestEngine.System;
 
 namespace Microsoft.PowerApps.TestEngine.PowerFx.Functions
 {
@@ -29,7 +30,7 @@ namespace Microsoft.PowerApps.TestEngine.PowerFx.Functions
             {
                 _logger.LogTrace($"{message.Value}");
                 _logger.LogError("Assert failed. Property is not equal to the specified value.");
-                throw new Exception($"  Assertion failed: {message.Value}");
+                throw new AssertionFailureException(message.Value);
             }
 
             _logger.LogTrace(message.Value);

--- a/src/Microsoft.PowerApps.TestEngine/System/AssertionFailureException.cs
+++ b/src/Microsoft.PowerApps.TestEngine/System/AssertionFailureException.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+
+namespace Microsoft.PowerApps.TestEngine.System
+{
+    public class AssertionFailureException : Exception
+    {
+        public AssertionFailureException(string message)
+            : base(message)
+        {
+        }
+    }
+}


### PR DESCRIPTION
## Description

Right now, this exception is being handled on the PAC CLI by being a generic exception with "Assertion failed" appended to it. However, we want the PAC CLI to be able to identify it by the exception, not by the string. In addition, after localization, this may fail. This is also coupling the two code-bases together.

## Checklist

- [x] The code change is covered by unit tests. I have added tests that prove my fix is effective or that my feature works
- [x] I have performed end-to-end test locally.
- [x] New and existing unit tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I used clear names for everything
- [x] I have performed a self-review of my own code
