### PR TITLE
Fix unit tests

### DIFF
--- a/src/Microsoft.PowerApps.TestEngine.Tests/ConsoleOutputTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/ConsoleOutputTests.cs
@@ -56,7 +56,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
             var expected = $"Running test suite: TestSuiteName";
             expected += $"\n   Test results will be stored in: ./testDirectory";
             expected += $"\n   Browser: Chromium";
-            expected += $"\n   App URL: make.powerapps.com/testapp\n";
+            expected += $"\n   App URL: make.powerapps.com/testapp";
 
             var printer = new StringWriter();
 

--- a/src/Microsoft.PowerApps.TestEngine.Tests/ConsoleOutputTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/ConsoleOutputTests.cs
@@ -52,12 +52,6 @@ namespace Microsoft.PowerApps.TestEngine.Tests
         [Fact]
         public void TestSuiteBegin()
         {
-            // Specify expected result and output object
-            var expected = $"Running test suite: TestSuiteName";
-            expected += $"\n   Test results will be stored in: ./testDirectory";
-            expected += $"\n   Browser: Chromium";
-            expected += $"\n   App URL: make.powerapps.com/testapp";
-
             var printer = new StringWriter();
 
             // Set output
@@ -67,18 +61,15 @@ namespace Microsoft.PowerApps.TestEngine.Tests
             _testEngineEventHandler.SuiteBegin("TestSuiteName", "./testDirectory", "Chromium", "make.powerapps.com/testapp&source=testengine");
 
             // Assert that the expected output matches the console output of the function
-            Assert.Contains(expected, printer.ToString());
+            Assert.Contains("Running test suite: TestSuiteName", printer.ToString());
+            Assert.Contains("\n   Test results will be stored in: ./testDirectory", printer.ToString());
+            Assert.Contains("\n   Browser: Chromium", printer.ToString());
+            Assert.Contains("\n   App URL: make.powerapps.com/testapp", printer.ToString());
         }
 
         [Fact]
         public void TestSuiteEnd()
         {
-            // Specify expected result and output object
-            var expected = "\nTest suite summary";
-            expected += $"Total cases: 11";
-            expected += $"Cases passed: 6";
-            expected += $"Cases failed: 5";
-            
             var printer = new StringWriter();
 
             // Set output
@@ -91,7 +82,10 @@ namespace Microsoft.PowerApps.TestEngine.Tests
             _testEngineEventHandler.SuiteEnd();
 
             // Assert that the expected output matches the console output of the function
-            Assert.Contains(expected, printer.ToString());
+            Assert.Contains("\nTest suite summary", printer.ToString());
+            Assert.Contains("Total cases: 11", printer.ToString());
+            Assert.Contains("Cases passed: 6", printer.ToString());
+            Assert.Contains("Cases failed: 5", printer.ToString());
         }
 
         [Fact]

--- a/src/Microsoft.PowerApps.TestEngine.Tests/ConsoleOutputTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/ConsoleOutputTests.cs
@@ -35,7 +35,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
         public void TestEncounteredException()
         {
             // Specify expected result and output object
-            var expected = "   Message\n";
+            var expected = "   Message";
             var printer = new StringWriter();
             Exception ex = new Exception("Message");
 
@@ -46,7 +46,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
             _testEngineEventHandler.EncounteredException(ex);
 
             // Assert that the expected output matches the console output of the function
-            Assert.Equal(expected, printer.ToString());
+            Assert.Contains(expected, printer.ToString());
         }
         
         [Fact]
@@ -67,17 +67,17 @@ namespace Microsoft.PowerApps.TestEngine.Tests
             _testEngineEventHandler.SuiteBegin("TestSuiteName", "./testDirectory", "Chromium", "make.powerapps.com/testapp&source=testengine");
 
             // Assert that the expected output matches the console output of the function
-            Assert.Equal(expected, printer.ToString());
+            Assert.Contains(expected, printer.ToString());
         }
 
         [Fact]
         public void TestSuiteEnd()
         {
             // Specify expected result and output object
-            var expected = "\nTest suite summary\n";
-            expected += $"Total cases: 11\n";
-            expected += $"Cases passed: 6\n";
-            expected += $"Cases failed: 5\n";
+            var expected = "\nTest suite summary";
+            expected += $"Total cases: 11";
+            expected += $"Cases passed: 6";
+            expected += $"Cases failed: 5";
             
             var printer = new StringWriter();
 
@@ -91,14 +91,14 @@ namespace Microsoft.PowerApps.TestEngine.Tests
             _testEngineEventHandler.SuiteEnd();
 
             // Assert that the expected output matches the console output of the function
-            Assert.Equal(expected, printer.ToString());
+            Assert.Contains(expected, printer.ToString());
         }
 
         [Fact]
         public void TestTestCaseBegin()
         {
             // Specify expected result and output object
-            var expected = "Test case: MyCase\n";
+            var expected = "Test case: MyCase";
             var printer = new StringWriter();
 
             // Set output
@@ -108,14 +108,14 @@ namespace Microsoft.PowerApps.TestEngine.Tests
             _testEngineEventHandler.TestCaseBegin("MyCase");
 
             // Assert that the expected output matches the console output of the function
-            Assert.Equal(expected, printer.ToString());
+            Assert.Contains(expected, printer.ToString());
         }
 
         [Fact]
         public void TestTestCaseEndPassed()
         {
              // Specify expected result and output object
-            var expected = "   Result: Passed\n";
+            var expected = "   Result: Passed";
             var printer = new StringWriter();
 
             // Set output
@@ -125,14 +125,14 @@ namespace Microsoft.PowerApps.TestEngine.Tests
             _testEngineEventHandler.TestCaseEnd(true);
 
             // Assert that the expected output matches the console output of the function
-            Assert.Equal(expected, printer.ToString());
+            Assert.Contains(expected, printer.ToString());
         }
         
         [Fact]
         public void TestTestCaseEndFailed()
         {
             // Specify expected result and output object
-            var expected = "   Result: Failed\n";
+            var expected = "   Result: Failed";
             var printer = new StringWriter();
 
             // Set output
@@ -142,7 +142,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
             _testEngineEventHandler.TestCaseEnd(false);
 
             // Assert that the expected output matches the console output of the function
-            Assert.Equal(expected, printer.ToString());
+            Assert.Contains(expected, printer.ToString());
         }
     }
 }

--- a/src/Microsoft.PowerApps.TestEngine.Tests/ConsoleOutputTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/ConsoleOutputTests.cs
@@ -24,9 +24,11 @@ using Xunit;
 namespace Microsoft.PowerApps.TestEngine.Tests
 {
     public class ConsoleOutputTests
-    {   TestEngineEventHandler _testEngineEventHandler;
+    {
+        TestEngineEventHandler _testEngineEventHandler;
 
-        public ConsoleOutputTests() {
+        public ConsoleOutputTests()
+        {
             _testEngineEventHandler = new TestEngineEventHandler();
         }
 
@@ -48,7 +50,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
             // Assert that the expected output matches the console output of the function
             Assert.Contains(expected, printer.ToString());
         }
-        
+
         [Fact]
         public void TestSuiteBegin()
         {
@@ -108,7 +110,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
         [Fact]
         public void TestTestCaseEndPassed()
         {
-             // Specify expected result and output object
+            // Specify expected result and output object
             var expected = "   Result: Passed";
             var printer = new StringWriter();
 
@@ -121,7 +123,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
             // Assert that the expected output matches the console output of the function
             Assert.Contains(expected, printer.ToString());
         }
-        
+
         [Fact]
         public void TestTestCaseEndFailed()
         {

--- a/src/Microsoft.PowerApps.TestEngine.Tests/ConsoleOutputTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/ConsoleOutputTests.cs
@@ -32,7 +32,6 @@ namespace Microsoft.PowerApps.TestEngine.Tests
             _testEngineEventHandler = new TestEngineEventHandler();
         }
 
-
         [Fact]
         public void TestEncounteredException()
         {


### PR DESCRIPTION
## Description

A unit test issue was introduced to a pipeline in a previous commit. Linux and Windows use different characters for newlines. The unit tests pass (linux) but the pipeline fails (windows)

## Checklist

- [x] The code change is covered by unit tests. I have added tests that prove my fix is effective or that my feature works
- [x] I have performed end-to-end test locally.
- [x] New and existing unit tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I used clear names for everything
- [x] I have performed a self-review of my own code
