### PR TITLE
Ignore unmatched properties during deserialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,18 +43,21 @@ cd PowerApps-TestEngine\src\PowerAppsTestEngine
 # Build
 dotnet build
 
-# Install browsers required by Playwright - replace <net-version> with actual output folder name, eg. net6.0.
-.\bin\Debug\<net-version>\playwright.ps1 install
+# Install browsers required by Playwright
+..\..\bin\Debug\\PowerAppsTestEngine\playwright.ps1 install
 ```
+
 If you face trouble running dotnet build try [Clean locally](https://github.com/microsoft/PowerApps-TestEngine#clean-locally) first.
 
 ### Clean locally
 
 Run the command below in PowerShell to clean untracked files. Please make sure to run this in the root folder.
+
 ```bash
 # Clean
 .\clean.cmd
 ```
+
 Once done, continue following [Build locally](https://github.com/microsoft/PowerApps-TestEngine#build-locally)
 
 ### Using the provided samples
@@ -77,12 +80,15 @@ Create a `config.dev.json` file inside the `PowerAppsTestEngine` folder.
 
 Here is an example of its contents (a file `config.json` is provided in the repo as an example):
 
-```
+```json
 {
   "environmentId": "",
   "tenantId": "",
   "testPlanFile": "",
-  "outputDirectory": ""
+  "outputDirectory": "",
+  "logLevel": "",
+  "domain": "",
+  "queryParams": ""
 }
 ```
 
@@ -234,7 +240,7 @@ You are invited to contribute corrections to both code and documentation. See th
 
 ## Contributing to Test Engine code and documentation
 
-This project welcomes contributions and suggestions to both code and documentation. Most contributions require you to agree to a Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us the rights to use your contribution. For details, visit https://cla.opensource.microsoft.com.
+This project welcomes contributions and suggestions to both code and documentation. Most contributions require you to agree to a Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us the rights to use your contribution. For details, visit <https://cla.opensource.microsoft.com>.
 
 > **Note:** We are not accepting contributions for content within the [JS folder](https://github.com/microsoft/PowerApps-TestEngine/tree/main/src/Microsoft.PowerApps.TestEngine/JS).
 

--- a/src/Microsoft.PowerApps.TestEngine.Tests/Config/YamlTestConfigParserTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/Config/YamlTestConfigParserTests.cs
@@ -241,7 +241,58 @@ environmentVariables:
             Assert.Equal("User1", testPlan.EnvironmentVariables?.Users[0].PersonaName);
             Assert.Equal("user1Email", testPlan.EnvironmentVariables?.Users[0].EmailKey);
             Assert.Equal("user1Password", testPlan.EnvironmentVariables?.Users[0].PasswordKey);
+        }
 
+        // Ensure that the serializer will ignore any properties which don't deserialize into a TestPlanDefinition
+        [Fact]
+        public void YamlTestConfigParserParseTestPlanWithUnsupportedTestSettingSuccess()
+        {
+            var mockFileSystem = new Mock<IFileSystem>(MockBehavior.Strict);
+            var parser = new YamlTestConfigParser(mockFileSystem.Object);
+            var yamlFile = $@"testSuite:
+  testSuiteName: Button Clicker
+  testSuiteDescription: Verifies that counter increments when the button is clicked
+  persona: User1
+  appId: 1253535
+
+  testCases:
+    - testCaseName: Case1
+      testCaseDescription: Optional
+      testSteps: |
+        = Screenshot(""buttonclicker_loaded.png"");;
+          // Wait for the label to be set to 0
+          //Wait(Label1.Text = ""0"");;
+          Wait(Label1; ""Text""; ""0"");;
+          // Click the button
+          Select(Button1);;
+          Assert(Text(Label1.Text) = ""1""; ""Counter should be incremented to 1"");;
+          Screenshot(""buttonclicker_end.png"");;
+      invalidProp: 10
+
+testSettings:
+    recordVideo: true
+    browserConfigurations:
+        - browser: Chromium
+        - browser: Firefox
+    headless: false
+    enablePowerFxOverlay: false
+    invalidProp: 10
+
+environmentVariables:
+    users:
+        - personaName: User1
+          emailKey: user1Email
+          passwordKey: user1Password
+          invalidProp: 10
+
+invalidProp: 10";
+
+            var filePath = "testplan.fx.yaml";
+            mockFileSystem.Setup(f => f.ReadAllText(It.IsAny<string>())).Returns(yamlFile);
+            var testPlan = parser.ParseTestConfig<TestPlanDefinition>(filePath);
+
+            // Just confirm we did not throw an exception and a test plan was generated
+            Assert.NotNull(testPlan);
         }
 
         [Fact]

--- a/src/Microsoft.PowerApps.TestEngine/Config/YamlTestConfigParser.cs
+++ b/src/Microsoft.PowerApps.TestEngine/Config/YamlTestConfigParser.cs
@@ -26,6 +26,7 @@ namespace Microsoft.PowerApps.TestEngine.Config
             }
 
             var deserializer = new YamlDotNet.Serialization.DeserializerBuilder()
+            .IgnoreUnmatchedProperties()
             .WithNamingConvention(CamelCaseNamingConvention.Instance)
             .Build();
 

--- a/src/Microsoft.PowerApps.TestEngine/TestEngine.cs
+++ b/src/Microsoft.PowerApps.TestEngine/TestEngine.cs
@@ -96,19 +96,20 @@ namespace Microsoft.PowerApps.TestEngine
                     Logger.LogDebug($"Using query: {queryParams}");
                 }
 
-                _state.ParseAndSetTestState(testConfigFile.FullName);
-                _state.SetEnvironment(environmentId);
-                _state.SetTenant(tenantId.ToString());
-
-                _state.SetDomain(domain);
-                Logger.LogDebug($"Using domain: {domain}");
-
+                // Create the output directory as early as possible so that any exceptions can be logged.
                 _state.SetOutputDirectory(outputDirectory.FullName);
                 Logger.LogDebug($"Using output directory: {outputDirectory.FullName}");
 
                 testRunDirectory = Path.Combine(_state.GetOutputDirectory(), testRunId.Substring(0, 6));
                 _fileSystem.CreateDirectory(testRunDirectory);
                 Logger.LogInformation($"Test results will be stored in: {testRunDirectory}");
+
+                _state.ParseAndSetTestState(testConfigFile.FullName);
+                _state.SetEnvironment(environmentId);
+                _state.SetTenant(tenantId.ToString());
+
+                _state.SetDomain(domain);
+                Logger.LogDebug($"Using domain: {domain}");
 
                 await RunTestByBrowserAsync(testRunId, testRunDirectory, domain, queryParams);
                 _testReporter.EndTestRun(testRunId);


### PR DESCRIPTION
## Description

This change updates the deserialization of the `TestPlanDefinition` so that any unmatched properties will be ignored, rather than throwing an exception. This should help with future supportability for the YAML files, so that the `TestPlanDefinition` object can be updated independently from the actual files.

I also fixed a few very minor things:
- Moved the creation of the output directory info a bit earlier. Today, if you run Test Engine with a YAML file that is not present, you don't get a helpful error message.
- Updated the `README` to be more accurate for setup.

## Checklist

- [x] The code change is covered by unit tests. I have added tests that prove my fix is effective or that my feature works
- [x] I have performed end-to-end test locally.
- [x] New and existing unit tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I used clear names for everything
- [x] I have performed a self-review of my own code
