### PR TITLE
Dispose PW instance after running the TestEngine

### DIFF
--- a/src/Microsoft.PowerApps.TestEngine.Tests/SingleTestRunnerTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/SingleTestRunnerTests.cs
@@ -108,6 +108,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
             MockTestInfraFunctions.Setup(x => x.SetupNetworkRequestMockAsync()).Returns(Task.CompletedTask);
             MockTestInfraFunctions.Setup(x => x.GoToUrlAsync(It.IsAny<string>())).Returns(Task.CompletedTask);
             MockTestInfraFunctions.Setup(x => x.EndTestRunAsync()).Returns(Task.CompletedTask);
+            MockTestInfraFunctions.Setup(x => x.DisposeAsync()).Returns(Task.CompletedTask);
 
             MockUserManager.Setup(x => x.LoginAsUserAsync(appUrl)).Returns(Task.CompletedTask);
 
@@ -149,6 +150,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
             MockFileSystem.Verify(x => x.CreateDirectory(testResultDirectory), Times.Once());
             MockTestLogger.Verify(x => x.WriteToLogsFile(testResultDirectory, testId), Times.Once());
             MockFileSystem.Verify(x => x.GetFiles(testResultDirectory), Times.Once());
+            MockTestInfraFunctions.Verify(x => x.DisposeAsync(), Times.Once());
             var additionalFilesList = new List<string>();
             if (additionalFiles != null)
             {

--- a/src/Microsoft.PowerApps.TestEngine.Tests/TestInfra/PlaywrightTestInfraFunctionTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/TestInfra/PlaywrightTestInfraFunctionTests.cs
@@ -619,7 +619,6 @@ namespace Microsoft.PowerApps.TestEngine.Tests.TestInfra
             MockRoute.Verify(x => x.ContinueAsync(It.IsAny<RouteContinueOptions>()), Times.Once);
         }
 
-
         [Fact]
         public async Task DisposeAsyncTest()
         {

--- a/src/Microsoft.PowerApps.TestEngine/SingleTestRunner.cs
+++ b/src/Microsoft.PowerApps.TestEngine/SingleTestRunner.cs
@@ -260,6 +260,8 @@ namespace Microsoft.PowerApps.TestEngine
                     var testLogger = TestLoggerProvider.TestLoggers[testSuiteId];
                     testLogger.WriteExceptionToDebugLogsFile(testResultDirectory, suiteException);
                 }
+
+                await _testInfraFunctions.DisposeAsync(); 
             }
         }
     }

--- a/src/Microsoft.PowerApps.TestEngine/SingleTestRunner.cs
+++ b/src/Microsoft.PowerApps.TestEngine/SingleTestRunner.cs
@@ -260,8 +260,7 @@ namespace Microsoft.PowerApps.TestEngine
                     var testLogger = TestLoggerProvider.TestLoggers[testSuiteId];
                     testLogger.WriteExceptionToDebugLogsFile(testResultDirectory, suiteException);
                 }
-
-                await _testInfraFunctions.DisposeAsync(); 
+                await _testInfraFunctions.DisposeAsync();
             }
         }
     }

--- a/src/Microsoft.PowerApps.TestEngine/TestInfra/ITestInfraFunctions.cs
+++ b/src/Microsoft.PowerApps.TestEngine/TestInfra/ITestInfraFunctions.cs
@@ -37,6 +37,12 @@ namespace Microsoft.PowerApps.TestEngine.TestInfra
         public Task EndTestRunAsync();
 
         /// <summary>
+        /// Dispose the instances
+        /// </summary>
+        /// <returns>Task</returns>
+        public Task DisposeAsync();
+
+        /// <summary>
         /// Takes a screenshot
         /// </summary>
         /// <param name="screenshotFilePath">Path for screenshot file</param>

--- a/src/Microsoft.PowerApps.TestEngine/TestInfra/PlaywrightTestInfraFunctions.cs
+++ b/src/Microsoft.PowerApps.TestEngine/TestInfra/PlaywrightTestInfraFunctions.cs
@@ -228,6 +228,13 @@ namespace Microsoft.PowerApps.TestEngine.TestInfra
             }
         }
 
+        public async Task DisposeAsync()
+        {
+            Page = null;
+            BrowserContext = null;
+            PlaywrightObject = null;
+        }
+
         private void ValidatePage()
         {
             if (Page == null)

--- a/src/Microsoft.PowerApps.TestEngine/TestInfra/PlaywrightTestInfraFunctions.cs
+++ b/src/Microsoft.PowerApps.TestEngine/TestInfra/PlaywrightTestInfraFunctions.cs
@@ -233,14 +233,13 @@ namespace Microsoft.PowerApps.TestEngine.TestInfra
             if (BrowserContext != null)
             {
                 await BrowserContext.DisposeAsync();
+                BrowserContext = null;
             }
             if (PlaywrightObject != null)
             {
                 PlaywrightObject.Dispose();
-            }
-
-            PlaywrightObject = null;
-            BrowserContext = null;
+                PlaywrightObject = null;
+            }       
         }
 
         private void ValidatePage()

--- a/src/Microsoft.PowerApps.TestEngine/TestInfra/PlaywrightTestInfraFunctions.cs
+++ b/src/Microsoft.PowerApps.TestEngine/TestInfra/PlaywrightTestInfraFunctions.cs
@@ -232,7 +232,7 @@ namespace Microsoft.PowerApps.TestEngine.TestInfra
         {
             if (BrowserContext != null)
             {
-               await BrowserContext.DisposeAsync();
+                await BrowserContext.DisposeAsync();
             }
             if (PlaywrightObject != null)
             {

--- a/src/Microsoft.PowerApps.TestEngine/TestInfra/PlaywrightTestInfraFunctions.cs
+++ b/src/Microsoft.PowerApps.TestEngine/TestInfra/PlaywrightTestInfraFunctions.cs
@@ -239,7 +239,7 @@ namespace Microsoft.PowerApps.TestEngine.TestInfra
             {
                 PlaywrightObject.Dispose();
                 PlaywrightObject = null;
-            }       
+            }
         }
 
         private void ValidatePage()

--- a/src/Microsoft.PowerApps.TestEngine/TestInfra/PlaywrightTestInfraFunctions.cs
+++ b/src/Microsoft.PowerApps.TestEngine/TestInfra/PlaywrightTestInfraFunctions.cs
@@ -230,9 +230,8 @@ namespace Microsoft.PowerApps.TestEngine.TestInfra
 
         public async Task DisposeAsync()
         {
-            Page = null;
-            BrowserContext = null;
-            PlaywrightObject = null;
+            PlaywrightObject.Dispose();
+            await BrowserContext.CloseAsync();            
         }
 
         private void ValidatePage()

--- a/src/Microsoft.PowerApps.TestEngine/TestInfra/PlaywrightTestInfraFunctions.cs
+++ b/src/Microsoft.PowerApps.TestEngine/TestInfra/PlaywrightTestInfraFunctions.cs
@@ -231,7 +231,7 @@ namespace Microsoft.PowerApps.TestEngine.TestInfra
         public async Task DisposeAsync()
         {
             PlaywrightObject.Dispose();
-            await BrowserContext.CloseAsync();            
+            await BrowserContext.DisposeAsync();            
         }
 
         private void ValidatePage()

--- a/src/Microsoft.PowerApps.TestEngine/TestInfra/PlaywrightTestInfraFunctions.cs
+++ b/src/Microsoft.PowerApps.TestEngine/TestInfra/PlaywrightTestInfraFunctions.cs
@@ -231,7 +231,10 @@ namespace Microsoft.PowerApps.TestEngine.TestInfra
         public async Task DisposeAsync()
         {
             PlaywrightObject.Dispose();
-            await BrowserContext.DisposeAsync();            
+            await BrowserContext.DisposeAsync();
+
+            PlaywrightObject = null;
+            BrowserContext = null;
         }
 
         private void ValidatePage()

--- a/src/Microsoft.PowerApps.TestEngine/TestInfra/PlaywrightTestInfraFunctions.cs
+++ b/src/Microsoft.PowerApps.TestEngine/TestInfra/PlaywrightTestInfraFunctions.cs
@@ -230,8 +230,14 @@ namespace Microsoft.PowerApps.TestEngine.TestInfra
 
         public async Task DisposeAsync()
         {
-            PlaywrightObject.Dispose();
-            await BrowserContext.DisposeAsync();
+            if (BrowserContext != null)
+            {
+               await BrowserContext.DisposeAsync();
+            }
+            if (PlaywrightObject != null)
+            {
+                PlaywrightObject.Dispose();
+            }
 
             PlaywrightObject = null;
             BrowserContext = null;


### PR DESCRIPTION
## Description

Disposing playwright assets .Additionally check for disposing the browser instance as well if not already done in any case.

## Checklist

- [x] The code change is covered by unit tests. I have added tests that prove my fix is effective or that my feature works
- [x] I have performed end-to-end test locally.
- [x] New and existing unit tests pass locally with my changes
- [x] My changes generate no new warnings
- [x] I used clear names for everything
- [x] I have performed a self-review of my own code
