### PR TITLE
Fixing how test steps are extracted in case we need to go step by step

### DIFF
--- a/src/Microsoft.PowerApps.TestEngine.Tests/PowerFx/PowerFxEngineTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/PowerFx/PowerFxEngineTests.cs
@@ -431,7 +431,6 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx
             MockTestState.Setup(x => x.GetTestSettings()).Returns(testSettings);
             var expression = "Select(Label1/*Label;;22*/);;\"Just stirng \n;literal\";;Select(Label2)\n;;Select(Label3);;Assert(1=1; \"Supposed to pass;;\");;Max(1,2)";
 
-
             // Act 
 
             // Engine.Eval should throw an exception when none of the used first names exist in the underlying symbol table yet.

--- a/src/Microsoft.PowerApps.TestEngine.Tests/PowerFx/PowerFxEngineTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/PowerFx/PowerFxEngineTests.cs
@@ -28,8 +28,8 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx
         private Mock<IPowerAppFunctions> MockPowerAppFunctions;
         private Mock<IFileSystem> MockFileSystem;
         private Mock<ISingleTestInstanceState> MockSingleTestInstanceState;
+        private Mock<ILogger> MockLogger;
 
-        protected Mock<ILogger> MockLogger;
         public PowerFxEngineTests()
         {
             MockTestInfraFunctions = new Mock<ITestInfraFunctions>(MockBehavior.Strict);

--- a/src/Microsoft.PowerApps.TestEngine.Tests/PowerFx/PowerFxEngineTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/PowerFx/PowerFxEngineTests.cs
@@ -423,18 +423,18 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx
                 await powerFxEngine.UpdatePowerFxModelAsync();
             }).Returns(Task.FromResult(true));
 
-            powerFxEngine.Setup(new CultureInfo("fr"));
+            powerFxEngine.Setup(It.IsAny<CultureInfo>());
             var testSettings = new TestSettings() { Timeout = 3000 };
             MockTestState.Setup(x => x.GetTestSettings()).Returns(testSettings);
             await powerFxEngine.UpdatePowerFxModelAsync();
 
             // Assert
-            var result = powerFxEngine.Execute("Select(Label1/*Label;;22*/);;\"Just stirng \n;;literal\";;Select(Label2)\n;;Select(Label3);;Assert(1=1; \"Supposed to pass;;\");;Max(1,2)");
+            var result = powerFxEngine.Execute("Select(Label1/*Label;;22*/);\"Just stirng \n;literal\";Select(Label2)\n;Select(Label3);Assert(1=1, \"Supposed to pass;;\");Max(1,2)");
 
             // Assert
             Assert.Equal(2, stepCounter);
             Assert.Equal(FormulaType.Number, result.Type);
-            Assert.Equal(1.2, (result as NumberValue).Value);
+            Assert.Equal(2, (result as NumberValue).Value);
         }
 
         private PowerFxEngine GetPowerFxEngine()

--- a/src/Microsoft.PowerApps.TestEngine.Tests/PowerFx/PowerFxHelperTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/PowerFx/PowerFxHelperTests.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System.Globalization;
+using Microsoft.PowerApps.TestEngine.PowerFx;
+using Microsoft.PowerFx;
+using Xunit;
+
+namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx
+{
+    public class PowerFxHelperTests
+    {
+        public PowerFxHelperTests() 
+        {
+        }
+
+        [Theory]
+        [InlineData("en-US", "1#1;/*comment;;*/2+2", "1#1", "/*comment;;*/2+2")]
+        [InlineData("fr", "1#1;2+2;;/*comment;;*/3+3;;Max(1;2;3)", "1#1;2+2", "/*comment;;*/3+3", "Max(1;2;3)")]
+        [InlineData("fr", ";;", "")]
+        [InlineData("fr", "1;;;;2", "1", "", "2")]
+        [InlineData("fr", "Select(Button1);;Assert(Button1.Text=\"semicolons;;;;semicolons\");;1+2;;Max(1,2,3)", "Select(Button1)", "Assert(Button1.Text=\"semicolons;;;;semicolons\")", "1+2", "Max(1,2,3)")]
+        [InlineData("en-US", "Select(Button1);Assert(Button1.Text=\"semicolons;;;;semicolons\");1+2;Max(1;2;3)", "Select(Button1)", "Assert(Button1.Text=\"semicolons;;;;semicolons\")", "1+2", "Max(1", "2", "3)")]
+        [InlineData("en-US", "1 + 2", "1 + 2")]
+        [InlineData("en-US", "1;;;2;;", "1", "", "", "2", "")]
+        [InlineData("fr","\"string \n;;String\";;1+2\n\n\n;;Max(\n1;2;\n3);;", "\"string \n;;String\"", "1+2\n\n\n", "Max(\n1;2;\n3)")]
+        public void TestFormulasSeparatedByChainingOpAreExtractedCorrectly(string locale, string expression, params string[] expectedFormulas)
+        {
+            // Arrange
+            var engine = GetEngine(locale);
+      
+            // Act
+            var actualFormulas = PowerFxHelper.ExtractFormulasSeparatedByChainingOperator(engine, expression);
+
+            // Assert
+            Assert.Equal(expectedFormulas, actualFormulas);
+        }
+
+        private static Engine GetEngine(string locale)
+        {
+            var recalcEngine = new RecalcEngine(new PowerFxConfig(new CultureInfo(locale)));
+            return recalcEngine;
+        }
+    }
+}

--- a/src/Microsoft.PowerApps.TestEngine.Tests/PowerFx/PowerFxHelperTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/PowerFx/PowerFxHelperTests.cs
@@ -10,7 +10,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx
 {
     public class PowerFxHelperTests
     {
-        public PowerFxHelperTests() 
+        public PowerFxHelperTests()
         {
         }
 
@@ -23,12 +23,12 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx
         [InlineData("en-US", "Select(Button1);Assert(Button1.Text=\"semicolons;;;;semicolons\");1+2;Max(1;2;3)", "Select(Button1)", "Assert(Button1.Text=\"semicolons;;;;semicolons\")", "1+2", "Max(1", "2", "3)")]
         [InlineData("en-US", "1 + 2", "1 + 2")]
         [InlineData("en-US", "1;;;2;;", "1", "", "", "2", "")]
-        [InlineData("fr","\"string \n;;String\";;1+2\n\n\n;;Max(\n1;2;\n3);;", "\"string \n;;String\"", "1+2\n\n\n", "Max(\n1;2;\n3)")]
+        [InlineData("fr", "\"string \n;;String\";;1+2\n\n\n;;Max(\n1;2;\n3);;", "\"string \n;;String\"", "1+2\n\n\n", "Max(\n1;2;\n3)")]
         public void TestFormulasSeparatedByChainingOpAreExtractedCorrectly(string locale, string expression, params string[] expectedFormulas)
         {
             // Arrange
             var engine = GetEngine(locale);
-      
+
             // Act
             var actualFormulas = PowerFxHelper.ExtractFormulasSeparatedByChainingOperator(engine, expression);
 

--- a/src/Microsoft.PowerApps.TestEngine/PowerFx/PowerFxEngine.cs
+++ b/src/Microsoft.PowerApps.TestEngine/PowerFx/PowerFxEngine.cs
@@ -115,8 +115,6 @@ namespace Microsoft.PowerApps.TestEngine.PowerFx
 
             if (goStepByStep)
             {
-                // TODO: This is a temporary hack to allow for multiple screens
-                // Will need to come up with a better solution
                 var splitSteps = PowerFxHelper.ExtractFormulasSeparatedByChainingOperator(Engine, testSteps);
                 FormulaValue result = FormulaValue.NewBlank();
 

--- a/src/Microsoft.PowerApps.TestEngine/PowerFx/PowerFxEngine.cs
+++ b/src/Microsoft.PowerApps.TestEngine/PowerFx/PowerFxEngine.cs
@@ -11,6 +11,7 @@ using Microsoft.PowerApps.TestEngine.PowerFx.Functions;
 using Microsoft.PowerApps.TestEngine.System;
 using Microsoft.PowerApps.TestEngine.TestInfra;
 using Microsoft.PowerFx;
+using Microsoft.PowerFx.Syntax;
 using Microsoft.PowerFx.Types;
 
 namespace Microsoft.PowerApps.TestEngine.PowerFx
@@ -116,8 +117,9 @@ namespace Microsoft.PowerApps.TestEngine.PowerFx
             {
                 // TODO: This is a temporary hack to allow for multiple screens
                 // Will need to come up with a better solution
-                var splitSteps = testSteps.Split(';');
+                var splitSteps = PowerFxHelper.ExtractFormulasSeparatedByChainingOperator(Engine, testSteps);
                 FormulaValue result = FormulaValue.NewBlank();
+
                 foreach (var step in splitSteps)
                 {
                     Logger.LogTrace($"Attempting:{step.Replace("\n", "").Replace("\r", "")}");

--- a/src/Microsoft.PowerApps.TestEngine/PowerFx/PowerFxHelper.cs
+++ b/src/Microsoft.PowerApps.TestEngine/PowerFx/PowerFxHelper.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Microsoft.PowerFx;
+using Microsoft.PowerFx.Syntax;
+
+namespace Microsoft.PowerApps.TestEngine.PowerFx
+{
+    /// <summary>
+    /// Static entity with methods to help with any powerfx related operations
+    /// </summary>
+    public static class PowerFxHelper
+    {
+        /// <summary>
+        /// Extracts the formulas separated by chaining/variadic operator.
+        /// Operator is ";" when decimal separator for the locale is "." and is ";;" when decimal separator is ","
+        /// </summary>
+        /// <param name="engine">Instance of an engine configured with the desired locale</param>
+        /// <param name="expression">Expression from which formulas separated by chaining operator would be extracted</param>
+        /// <returns>An enumerable of formulas extracted from the expression that are separated by chaining operator</returns>
+        public static IEnumerable<string> ExtractFormulasSeparatedByChainingOperator(Engine engine, string expression)
+        {
+            if (string.IsNullOrWhiteSpace(expression))
+            {
+                return new string[0];
+            }
+
+            var chainOperatorTokens = engine.Tokenize(expression).Where(tok => tok.Kind == TokKind.Semicolon).OrderBy(tok => tok.Span.Min);
+            var formulas = new List<string>();
+            var lowerBound = 0;
+
+            foreach (var chainOpToken in chainOperatorTokens) 
+            {
+                if (lowerBound < expression.Length)
+                {
+                    var upperBound = chainOpToken.Span.Min;
+                    var formula = expression.Substring(lowerBound, upperBound - lowerBound);
+                    formulas.Add(formula);  
+                }
+
+                lowerBound = chainOpToken.Span.Lim;
+            }
+
+            if (lowerBound < expression.Length)
+            {
+                formulas.Add(expression.Substring(lowerBound));
+            }
+
+            return formulas;
+        }
+
+    }
+}

--- a/src/Microsoft.PowerApps.TestEngine/PowerFx/PowerFxHelper.cs
+++ b/src/Microsoft.PowerApps.TestEngine/PowerFx/PowerFxHelper.cs
@@ -28,7 +28,6 @@ namespace Microsoft.PowerApps.TestEngine.PowerFx
             var chainOperatorTokens = engine.Tokenize(expression).Where(tok => tok.Kind == TokKind.Semicolon).OrderBy(tok => tok.Span.Min);
             var formulas = new List<string>();
             var lowerBound = 0;
-
             foreach (var chainOpToken in chainOperatorTokens) 
             {
                 if (lowerBound < expression.Length)
@@ -37,7 +36,6 @@ namespace Microsoft.PowerApps.TestEngine.PowerFx
                     var formula = expression.Substring(lowerBound, upperBound - lowerBound);
                     formulas.Add(formula);  
                 }
-
                 lowerBound = chainOpToken.Span.Lim;
             }
 

--- a/src/Microsoft.PowerApps.TestEngine/PowerFx/PowerFxHelper.cs
+++ b/src/Microsoft.PowerApps.TestEngine/PowerFx/PowerFxHelper.cs
@@ -28,13 +28,13 @@ namespace Microsoft.PowerApps.TestEngine.PowerFx
             var chainOperatorTokens = engine.Tokenize(expression).Where(tok => tok.Kind == TokKind.Semicolon).OrderBy(tok => tok.Span.Min);
             var formulas = new List<string>();
             var lowerBound = 0;
-            foreach (var chainOpToken in chainOperatorTokens) 
+            foreach (var chainOpToken in chainOperatorTokens)
             {
                 if (lowerBound < expression.Length)
                 {
                     var upperBound = chainOpToken.Span.Min;
                     var formula = expression.Substring(lowerBound, upperBound - lowerBound);
-                    formulas.Add(formula);  
+                    formulas.Add(formula);
                 }
                 lowerBound = chainOpToken.Span.Lim;
             }


### PR DESCRIPTION
# Pull Request Template

## Description
Splitting by semicolon is not the right way to extract out the test steps from the whole expression as it could be present anywhere in comments, string literals, or interpolated strings. This pr utilizes PowerFx lexer to attempt to correctly compute the test steps in the formula. The logic is locale specific. 

## Checklist

- [X] The code change is covered by unit tests. I have added tests that prove my fix is effective or that my feature works
- [X] I have performed end-to-end test locally.
- [X] New and existing unit tests pass locally with my changes
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I used clear names for everything
- [X] I have performed a self-review of my own code
