### PR TITLE
Rewriting logic to compute formulas separated by chaining operator and consider nested formula separation.

### DIFF
--- a/src/Microsoft.PowerApps.TestEngine.Tests/PowerFx/PowerFxHelperTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/PowerFx/PowerFxHelperTests.cs
@@ -4,6 +4,7 @@
 using System.Globalization;
 using Microsoft.PowerApps.TestEngine.PowerFx;
 using Microsoft.PowerFx;
+using Microsoft.PowerFx.Preview;
 using Xunit;
 
 namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx
@@ -16,21 +17,46 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx
 
         [Theory]
         [InlineData("en-US", "1#1;/*comment;;*/2+2", "1#1", "/*comment;;*/2+2")]
+        [InlineData("en-US", "1+1;/*comment;;*/2+2", "1+1", "/*comment;;*/2+2")]
         [InlineData("fr", "1#1;2+2;;/*comment;;*/3+3;;Max(1;2;3)", "1#1;2+2", "/*comment;;*/3+3", "Max(1;2;3)")]
         [InlineData("fr", ";;", "")]
         [InlineData("fr", "1;;;;2", "1", "", "2")]
         [InlineData("fr", "Select(Button1);;Assert(Button1.Text=\"semicolons;;;;semicolons\");;1+2;;Max(1,2,3)", "Select(Button1)", "Assert(Button1.Text=\"semicolons;;;;semicolons\")", "1+2", "Max(1,2,3)")]
-        [InlineData("en-US", "Select(Button1);Assert(Button1.Text=\"semicolons;;;;semicolons\");1+2;Max(1;2;3)", "Select(Button1)", "Assert(Button1.Text=\"semicolons;;;;semicolons\")", "1+2", "Max(1", "2", "3)")]
+        [InlineData("en-US", "Select(Button1);Assert(Button1.Text=\"semicolons;;;;semicolons\");1+2;Max(1;2;3)", "Select(Button1)", "Assert(Button1.Text=\"semicolons;;;;semicolons\")", "1+2", "Max(1;2;3)")]
         [InlineData("en-US", "1 + 2", "1 + 2")]
         [InlineData("en-US", "1;;;2;;", "1", "", "", "2", "")]
         [InlineData("fr", "\"string \n;;String\";;1+2\n\n\n;;Max(\n1;2;\n3);;", "\"string \n;;String\"", "1+2\n\n\n", "Max(\n1;2;\n3)")]
+        [InlineData("en-US", "$\";{1;2;3;Max(1;2;30,40)}\";Max(1;20;3)", "$\";{1;2;3;Max(1;2;30,40)}\"", "Max(1;20;3)")]
+        [InlineData("fr", "$\";;;;{1;;2;;\n\n3;;Max(1;;2;;30,3;40)}\"\n\n\n;;Max(1;;20;;3);;1+1", "$\";;;;{1;;2;;\n\n3;;Max(1;;2;;30,3;40)}\"\n\n\n", "Max(1;;20;;3)", "1+1")]
+        [InlineData("en-US", "$\";{1;2;3;Max(1;2;30#########<>><>>#3,40)}\";Max(1;20;3)", "$\";{1;2;3;Max(1;2;30#########<>><>>#3,40)}\"", "Max(1;20;3)")]
+        [InlineData("en-US", "$\";{1;2;3;Max(1;2;30#########<>><>>#3,40)}\"", "$\";{1;2;3;Max(1;2;30#########<>><>>#3,40)}\"")]
+        [InlineData("en-US", "Max(1;2;3)", "Max(1;2;3)")]
+        [InlineData("it", "$\";;;;{1;;2;;3;;;;Max(1;;2;;;;30,3;40)}\";;;;", "$\";;;;{1;;2;;3;;;;Max(1;;2;;;;30,3;40)}\"", "")]
+        [InlineData("en-US", "Max(1;2;Max(22;34;Sum(1;2,2)), 40);1+1;/*Comment;*/", "Max(1;2;Max(22;34;Sum(1;2,2)), 40)", "1+1", "/*Comment;*/")]
+        [InlineData("en-US", "Max(1;2;Max(22;34;Sum(1;>?2,2)), 40);1+1;/*Comment;*/", "Max(1;2;Max(22;34;Sum(1;>?2,2)), 40)", "1+1", "/*Comment;*/")]
+        [InlineData("en-US", "##Max(1;2;Max(22;34;Sum(1;>?2,2)), 40);1+1;/*Comment;*/", "##Max(1", "2", "Max(22", "34", "Sum(1", ">?2,2)), 40)", "1+1", "/*Comment;*/")]
+        [InlineData("fr", "Max(1;;2;;3;30;;Max(230;;23;;33);;3);;Select(Button1;;Button2;;Button3);;", "Max(1;;2;;3;30;;Max(230;;23;;33);;3)", "Select(Button1;;Button2;;Button3)")]
+        [InlineData("fr", "Max(1;;2;;3;30;;Max(230;;23;;33);;3);;Select(Button1;;Button2;;Button3;;;;;;);;", "Max(1;;2;;3;30;;Max(230;;23;;33);;3)", "Select(Button1;;Button2;;Button3;;;;", ")")]
+        [InlineData("en-US", "Max(;;;1,2)", "Max(;;;1,2)")]
+        [InlineData("en-US", ";;;;", "", "", "", "")]
+        [InlineData("en-US", "")]
+        [InlineData("en-US", "Max(;22)", "Max(", "22)")]
+        [InlineData("en-US", "Select(Button1/*Selecting button 1;;;*/);Assert(Button1.Text = Text(\"Ab\";\"Abcd\"))", "Select(Button1/*Selecting button 1;;;*/)", "Assert(Button1.Text = Text(\"Ab\";\"Abcd\"))")]
+        [InlineData("en-US", "Select(Button1)", "Select(Button1)")]
+        [InlineData("fr", "Max(1;;2;;3;30;;Max(230;;23;;33);;3)", "Max(1;;2;;3;30;;Max(230;;23;;33);;3)")]
+        // Once new powerfx version is consumed, this would fail due to recent PowerFx Lexer changes
+        // Fix would be to this to InlineData("en-US", "'Test;2212", "'Test", "2212")
+        [InlineData("en-US", "'Test;2212", "'Test;2212")]
+        [InlineData("en-US", "'Test;;2333';Max(1;'Button1;Button2';23;/*\n\n;;Comment\n\n*/33,100;Max(100;200,20;30)))", "'Test;;2333'", "Max(1;'Button1;Button2';23;/*\n\n;;Comment\n\n*/33,100;Max(100;200,20;30)))")]
+        [InlineData("en-US", "'Test;;2333';Max(1;'Button1;Button2';23;/*\n\n;;Comment\n\n33,100;Max(100;200,20;30)))", "'Test;;2333'", "Max(1;'Button1;Button2';23;/*\n\n;;Comment\n\n33,100;Max(100;200,20;30)))")]
         public void TestFormulasSeparatedByChainingOpAreExtractedCorrectly(string locale, string expression, params string[] expectedFormulas)
         {
             // Arrange
-            var engine = GetEngine(locale);
+            FeatureFlags.StringInterpolation = true;
+            var (result, engine) = GetCheckResultAndEngine(expression, locale);
 
             // Act
-            var actualFormulas = PowerFxHelper.ExtractFormulasSeparatedByChainingOperator(engine, expression);
+            var actualFormulas = PowerFxHelper.ExtractFormulasSeparatedByChainingOperator(engine, result);
 
             // Assert
             Assert.Equal(expectedFormulas, actualFormulas);
@@ -40,6 +66,12 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx
         {
             var recalcEngine = new RecalcEngine(new PowerFxConfig(new CultureInfo(locale)));
             return recalcEngine;
+        }
+
+        private static (CheckResult result, Engine engine) GetCheckResultAndEngine(string expression, string locale)
+        {
+            var engine = GetEngine(locale);
+            return (engine.Check(expression, new ParserOptions { AllowsSideEffects = true }), engine);
         }
     }
 }

--- a/src/Microsoft.PowerApps.TestEngine.Tests/PowerFx/PowerFxHelperTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/PowerFx/PowerFxHelperTests.cs
@@ -53,12 +53,23 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx
         {
             // Arrange
             FeatureFlags.StringInterpolation = true;
+            var oldUICulture = CultureInfo.CurrentUICulture;
+            var culture = new CultureInfo(locale);
+            CultureInfo.CurrentUICulture = culture;
             var (result, engine) = GetCheckResultAndEngine(expression, locale);
 
             // Act
             var actualFormulas = PowerFxHelper.ExtractFormulasSeparatedByChainingOperator(engine, result);
 
             // Assert
+            try
+            {
+                CultureInfo.CurrentUICulture = oldUICulture;
+            }
+            catch
+            {
+                // no op
+            }
             Assert.Equal(expectedFormulas, actualFormulas);
         }
 

--- a/src/Microsoft.PowerApps.TestEngine/PowerFx/PowerFxEngine.cs
+++ b/src/Microsoft.PowerApps.TestEngine/PowerFx/PowerFxEngine.cs
@@ -115,7 +115,7 @@ namespace Microsoft.PowerApps.TestEngine.PowerFx
 
             if (goStepByStep)
             {
-                var splitSteps = PowerFxHelper.ExtractFormulasSeparatedByChainingOperator(Engine, testSteps);
+                var splitSteps = PowerFxHelper.ExtractFormulasSeparatedByChainingOperator(Engine, checkResult);
                 FormulaValue result = FormulaValue.NewBlank();
 
                 foreach (var step in splitSteps)

--- a/src/Microsoft.PowerApps.TestEngine/PowerFx/PowerFxHelper.cs
+++ b/src/Microsoft.PowerApps.TestEngine/PowerFx/PowerFxHelper.cs
@@ -31,7 +31,7 @@ namespace Microsoft.PowerApps.TestEngine.PowerFx
                 return spansForFormulasSeparatedAcrossMultipleDepths.Select(span => result.Parse.Text.Substring(span.Start, span.End - span.Start));
             }
 
-            var spansForTopMostSeparatedFormulas = DetermineNearestFormulaSeparationForSpansVisitor.GetSpansForTopMostSeparatorFormulas(spansForFormulasSeparatedAcrossMultipleDepths, result.Parse.Root);
+            var spansForTopMostSeparatedFormulas = DetermineNearestFormulaSeparationForSpansVisitor.GetSpansForFormulasSeparatedAtTopMostLevel(spansForFormulasSeparatedAcrossMultipleDepths, result.Parse.Root);
             return spansForTopMostSeparatedFormulas.Select(span => result.Parse.Text.Substring(span.Start, span.End - span.Start));
         }
 

--- a/src/Microsoft.PowerApps.TestEngine/PowerFx/PowerFxHelper.cs
+++ b/src/Microsoft.PowerApps.TestEngine/PowerFx/PowerFxHelper.cs
@@ -16,36 +16,54 @@ namespace Microsoft.PowerApps.TestEngine.PowerFx
         /// Operator is ";" when decimal separator for the locale is "." and is ";;" when decimal separator is ","
         /// </summary>
         /// <param name="engine">Instance of an engine configured with the desired locale</param>
-        /// <param name="expression">Expression from which formulas separated by chaining operator would be extracted</param>
+        /// <param name="result">Check result instance created after processing the expression</param>
         /// <returns>An enumerable of formulas extracted from the expression that are separated by chaining operator</returns>
-        public static IEnumerable<string> ExtractFormulasSeparatedByChainingOperator(Engine engine, string expression)
+        public static IEnumerable<string> ExtractFormulasSeparatedByChainingOperator(Engine engine, CheckResult result)
         {
-            if (string.IsNullOrWhiteSpace(expression))
+            if (string.IsNullOrEmpty(result?.Parse?.Text))
             {
                 return new string[0];
             }
 
+            var spansForFormulasSeparatedAcrossMultipleDepths = ExtractSpansOfFormulasSeparatedByChainingOperator(engine, result?.Parse.Text);
+            if (result?.Parse?.Root == null)
+            {
+                return spansForFormulasSeparatedAcrossMultipleDepths.Select(span => result.Parse.Text.Substring(span.Start, span.End - span.Start));
+            }
+
+            var spansForTopMostSeparatedFormulas = DetermineNearestFormulaSeparationForSpansVisitor.GetSpansForTopMostSeparatorFormulas(spansForFormulasSeparatedAcrossMultipleDepths, result.Parse.Root);
+            return spansForTopMostSeparatedFormulas.Select(span => result.Parse.Text.Substring(span.Start, span.End - span.Start));
+        }
+
+        /// <summary>
+        /// Extracts the span that represent formulas separated by chaining operator at multiple levels and depths
+        /// </summary>
+        /// <param name="engine">Instance of an engine configured with the desired locale</param>
+        /// <param name="expression">Expression from which formulas separated by chaining operator would be extracted</param>
+        /// <returns>Spans that represent formulas separated by chaining operator at multiple levels and depths</returns>
+        private static IEnumerable<Span> ExtractSpansOfFormulasSeparatedByChainingOperator(Engine engine, string expression)
+        {
             var chainOperatorTokens = engine.Tokenize(expression).Where(tok => tok.Kind == TokKind.Semicolon).OrderBy(tok => tok.Span.Min);
-            var formulas = new List<string>();
+            var formulas = new List<Span>();
             var lowerBound = 0;
+
             foreach (var chainOpToken in chainOperatorTokens)
             {
                 if (lowerBound < expression.Length)
                 {
                     var upperBound = chainOpToken.Span.Min;
                     var formula = expression.Substring(lowerBound, upperBound - lowerBound);
-                    formulas.Add(formula);
+                    formulas.Add(new Span(lowerBound, upperBound));
                 }
                 lowerBound = chainOpToken.Span.Lim;
             }
 
             if (lowerBound < expression.Length)
             {
-                formulas.Add(expression.Substring(lowerBound));
+                formulas.Add(new Span(lowerBound, expression.Length));
             }
 
             return formulas;
         }
-
     }
 }

--- a/src/Microsoft.PowerApps.TestEngine/PowerFx/Span.cs
+++ b/src/Microsoft.PowerApps.TestEngine/PowerFx/Span.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+namespace Microsoft.PowerApps.TestEngine.PowerFx
+{
+    /// <summary>
+    /// Represents a span with start and end
+    /// Note: PowerFx Span object model is internal so we need our own span object model
+    /// </summary>
+    internal class Span
+    {
+        public int Start { get; }
+
+        public int End { get; }
+
+        public Span(int min, int lim)
+        {
+            Start = min;
+            End = lim;
+        }
+
+        public Span(Span span)
+        {
+            Start = span.Start;
+            End = span.End;
+        }
+    }
+}

--- a/src/Microsoft.PowerApps.TestEngine/PowerFx/Visitors/DetermineNearestFormulaSeparationForSpansVisitor.cs
+++ b/src/Microsoft.PowerApps.TestEngine/PowerFx/Visitors/DetermineNearestFormulaSeparationForSpansVisitor.cs
@@ -211,7 +211,7 @@ namespace Microsoft.PowerApps.TestEngine.PowerFx
         /// <returns>Spans representing formulas  separated at the top most level. 
         ///          Spans for formulas separated at depth > 1 are merged into nearest spans that represent formulas separated at the top most level.
         /// </returns>
-        public static IEnumerable<Span> GetSpansForTopMostSeparatorFormulas(IEnumerable<Span> separatedFormulaSpansIncludingNested, TexlNode root)
+        public static IEnumerable<Span> GetSpansForFormulasSeparatedAtTopMostLevel(IEnumerable<Span> separatedFormulaSpansIncludingNested, TexlNode root)
         {
             var visitor = new DetermineNearestFormulaSeparationForSpansVisitor(separatedFormulaSpansIncludingNested, root);
             root.Accept(visitor);

--- a/src/Microsoft.PowerApps.TestEngine/PowerFx/Visitors/DetermineNearestFormulaSeparationForSpansVisitor.cs
+++ b/src/Microsoft.PowerApps.TestEngine/PowerFx/Visitors/DetermineNearestFormulaSeparationForSpansVisitor.cs
@@ -1,0 +1,248 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Microsoft.PowerFx.Syntax;
+
+namespace Microsoft.PowerApps.TestEngine.PowerFx
+{
+    /// <summary>
+    /// Visitor to determine the nearest variadic op node (formula separation) that consumes each span
+    /// </summary>
+    internal class DetermineNearestFormulaSeparationForSpansVisitor : IdentityTexlVisitor
+    {
+        private readonly IEnumerator<Span> _spans;
+
+        private bool _hasMoreSpans = false;
+
+        private readonly Stack<TexlNode> _variadicOpNodeStack = new();
+
+        private readonly Dictionary<Span, bool> _isNestedSpan = new();
+
+        private readonly TexlNode _root;
+
+        public DetermineNearestFormulaSeparationForSpansVisitor(IEnumerable<Span> spans, TexlNode root)
+        {
+            // spans are assumed to be ordered by the start
+            _spans = spans.GetEnumerator();
+            _hasMoreSpans = _spans.MoveNext();
+            _root = root;
+        }
+
+        #region Overridden Visit* functions
+        public override bool PreVisit(VariadicOpNode node)
+        {
+            CaptureSpansThatAreCapturedByTopMostVariadicOpNode(node);
+            if (node.Op == VariadicOp.Chain)
+            {
+                _variadicOpNodeStack.Push(node);
+            }
+            return true;
+        }
+
+        public override bool PreVisit(AsNode node)
+        {
+            CaptureSpansThatAreCapturedByTopMostVariadicOpNode(node);
+            return true;
+        }
+
+        public override bool PreVisit(BinaryOpNode node)
+        {
+            CaptureSpansThatAreCapturedByTopMostVariadicOpNode(node);
+            return true;
+        }
+
+        public override bool PreVisit(CallNode node)
+        {
+            CaptureSpansThatAreCapturedByTopMostVariadicOpNode(node);
+            return true;
+        }
+
+        public override bool PreVisit(DottedNameNode node)
+        {
+            CaptureSpansThatAreCapturedByTopMostVariadicOpNode(node);
+            return true;
+        }
+
+        public override bool PreVisit(ListNode node)
+        {
+            CaptureSpansThatAreCapturedByTopMostVariadicOpNode(node);
+            return true;
+        }
+
+        public override bool PreVisit(RecordNode node)
+        {
+            CaptureSpansThatAreCapturedByTopMostVariadicOpNode(node);
+            return true;
+        }
+
+        public override bool PreVisit(StrInterpNode node)
+        {
+            CaptureSpansThatAreCapturedByTopMostVariadicOpNode(node);
+            return true;
+        }
+
+        public override bool PreVisit(TableNode node)
+        {
+            CaptureSpansThatAreCapturedByTopMostVariadicOpNode(node);
+            return true;
+        }
+
+        public override bool PreVisit(UnaryOpNode node)
+        {
+            CaptureSpansThatAreCapturedByTopMostVariadicOpNode(node);
+            return true;
+        }
+
+        public override void PostVisit(VariadicOpNode node)
+        {
+
+            if (_variadicOpNodeStack.Count > 0 && ReferenceEquals(_variadicOpNodeStack.Peek(), node))
+            {
+                // Consume any trailing tokens that are captured by this variadic op node
+                var nodeSpan = node.GetSourceBasedSpan();
+                while (_hasMoreSpans)
+                {
+                    if (_spans.Current.Start >= nodeSpan.Min && _spans.Current.Start < nodeSpan.Lim)
+                    {
+                        _isNestedSpan.Add(_spans.Current, !ReferenceEquals(node, _root));
+                        _hasMoreSpans = _spans.MoveNext();
+                    }
+                    else
+                    {
+                        break;
+                    }
+                }
+                _variadicOpNodeStack.Pop();
+            }
+        }
+
+        public override void Visit(ErrorNode node)
+        {
+            CaptureSpansThatAreCapturedByTopMostVariadicOpNode(node);
+        }
+
+        public override void Visit(BlankNode node)
+        {
+            CaptureSpansThatAreCapturedByTopMostVariadicOpNode(node);
+        }
+
+        public override void Visit(BoolLitNode node)
+        {
+            CaptureSpansThatAreCapturedByTopMostVariadicOpNode(node);
+        }
+
+        public override void Visit(StrLitNode node)
+        {
+            CaptureSpansThatAreCapturedByTopMostVariadicOpNode(node);
+        }
+
+        public override void Visit(NumLitNode node)
+        {
+            CaptureSpansThatAreCapturedByTopMostVariadicOpNode(node);
+        }
+
+        public override void Visit(FirstNameNode node)
+        {
+            CaptureSpansThatAreCapturedByTopMostVariadicOpNode(node);
+        }
+
+        public override void Visit(ParentNode node)
+        {
+            CaptureSpansThatAreCapturedByTopMostVariadicOpNode(node);
+        }
+
+        public override void Visit(SelfNode node)
+        {
+            CaptureSpansThatAreCapturedByTopMostVariadicOpNode(node);
+        }
+        #endregion
+
+        /// <summary>
+        /// Before visiting the direct child of a bottom most VariadicOpNode (top most on the stack) and its descendants, 
+        /// determine which spans from the left are consumed by the parent variadic op node
+        /// </summary>
+        /// <param name="mayBeDirectChildOfTopMostVariadicOpNode">Direct child of the bottom most VariadicOpNode (top most on the stack)</param>
+        private void CaptureSpansThatAreCapturedByTopMostVariadicOpNode(TexlNode mayBeDirectChildOfTopMostVariadicOpNode)
+        {
+            if (_variadicOpNodeStack.Count > 0 && !ReferenceEquals(mayBeDirectChildOfTopMostVariadicOpNode.Parent, _variadicOpNodeStack.Peek()))
+            {
+                return;
+            }
+
+            var nodeSpan = mayBeDirectChildOfTopMostVariadicOpNode.GetSourceBasedSpan();
+            var parentNodeSpan = _variadicOpNodeStack.Count == 0 ? null : mayBeDirectChildOfTopMostVariadicOpNode.Parent?.GetSourceBasedSpan();
+
+            while (_hasMoreSpans && _spans.Current.Start <= nodeSpan.Min)
+            {
+                // empty stack indicates that there's no formula separation (root node is not variadic op node)
+                // in this case, no variadic op node consumes the left most span
+                if (parentNodeSpan == null)
+                {
+                    _hasMoreSpans = _spans.MoveNext();
+                }
+                // see if the current leftmost span is consumed by the parent variadic op node
+                else if (_spans.Current.Start >= parentNodeSpan.Min && _spans.Current.Start < parentNodeSpan.Lim)
+                {
+                    // If the parent variadic op node consumes this leftmost span and it is not the root node, 
+                    // then we are looking at the span that represents formula separated at depth > 1 (nested separation)
+                    _isNestedSpan.Add(_spans.Current, !ReferenceEquals(mayBeDirectChildOfTopMostVariadicOpNode.Parent, _root));
+                    _hasMoreSpans = _spans.MoveNext();
+                }
+                else
+                {
+                    break;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Given the spans for formulas that are separated by chaining operator across different depths, 
+        /// filters out the spans that represent formulas separated at depths > 1 
+        /// by merging them into the spans that represent formulas separated at the top most level
+        /// <para>
+        /// Note: Spans must be ordered by their start indices
+        /// </para>
+        /// </summary>
+        /// <param name="separatedFormulaSpansIncludingNested">
+        ///     Ordered Spans for formulas that are separated by chaining operator across different depths.
+        ///     Spans must be ordered by their start indices
+        /// </param>
+        /// <param name="root">Root of the parse tree</param>
+        /// <returns>Spans representing formulas  separated at the top most level. 
+        ///          Spans for formulas separated at depth > 1 are merged into nearest spans that represent formulas separated at the top most level.
+        /// </returns>
+        public static IEnumerable<Span> GetSpansForTopMostSeparatorFormulas(IEnumerable<Span> separatedFormulaSpansIncludingNested, TexlNode root)
+        {
+            var visitor = new DetermineNearestFormulaSeparationForSpansVisitor(separatedFormulaSpansIncludingNested, root);
+            root.Accept(visitor);
+            var topMostSeparatedFormulasSpans = new List<Span>();
+            Span lastSpan = null;
+
+            foreach (var span in separatedFormulaSpansIncludingNested)
+            {
+                if (visitor._isNestedSpan.TryGetValue(span, out var isNestedSpan) && isNestedSpan)
+                {
+                    // if the span is nested (represents formula that is separated at depth > 1)
+                    // merge it with the last span as formulas that are separated at depth > 1
+                    // are on the same path so they appear in the consecutively in the separatedFormulaSpansIncludingNested 
+                    // assuming that separatedFormulaSpansIncludingNested is sorted by theit start indices
+                    lastSpan = lastSpan == null ? span : new Span(lastSpan.Start, span.End);
+                }
+                else
+                {
+                    if (lastSpan != null)
+                    {
+                        topMostSeparatedFormulasSpans.Add(lastSpan);
+                    }
+                    lastSpan = span;
+                }
+            }
+
+            if (lastSpan != null)
+            {
+                topMostSeparatedFormulasSpans.Add(lastSpan);
+            }
+            return topMostSeparatedFormulasSpans;
+        }
+    }
+}


### PR DESCRIPTION
# Pull Request Template

## Description

Rewriting the logic to extract formulas separated by semicolon (chaining operator). Takes the nested formula separation into account. When parse tree has syntax errors (not the binding errors, which are resolved by going step by step), a best effort is made to extract the test steps as accurately as possible. Firstly, an expression is tokenized if there's a need to go step by step and the spans for formulas between tokens that represent semicolons or chaining operators are computed. These spans are the formulas separated by semicolon. Some of these spans represent formulas that are separated somewhere down the tree (depth > 1, nested separation). Parse tree is used to merge these nested spans into spans that represent formulas separated at the top most level. This logic relies on a property of these spans that they are sorted by their start indices and since they are ordered, the nested spans appear on the same path and consecutively in the spans list created after tokenization. For each span, nearest node that represents formula separation (VariadicOpNode) is found. If this nearest node is not the root then we are looking at nested formula separation. This span is then merged to the root formula separation node based on the non root nearest formula separation node. If the parse tree has syntactic error nodes then the best attempt is made to extract the formulas as correctly as possible. However a lot depends on PowerFx and which parsing algorithm it uses. This is better than what we had previously but it is not 100% correct when there are syntax errors. This is fine as syntax errors would fail the test run even if we go step by step. I've added good amount of tests

## Checklist

- [X] The code change is covered by unit tests. I have added tests that prove my fix is effective or that my feature works
- [X] I have performed end-to-end test locally.
- [X] New and existing unit tests pass locally with my changes
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I used clear names for everything
- [X] I have performed a self-review of my own code
