### PR TITLE
Avoid GoToUrlAsync from Timing Out Due To Network Idle

### DIFF
--- a/src/Microsoft.PowerApps.TestEngine.Tests/TestInfra/PlaywrightTestInfraFunctionTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/TestInfra/PlaywrightTestInfraFunctionTests.cs
@@ -3,12 +3,10 @@
 
 using System;
 using System.Collections.Generic;
-using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Playwright;
 using Microsoft.PowerApps.TestEngine.Config;
-using Microsoft.PowerApps.TestEngine.Reporting.Format;
 using Microsoft.PowerApps.TestEngine.System;
 using Microsoft.PowerApps.TestEngine.TestInfra;
 using Microsoft.PowerApps.TestEngine.Tests.Helpers;
@@ -418,12 +416,12 @@ namespace Microsoft.PowerApps.TestEngine.Tests.TestInfra
             await playwrightTestInfraFunctions.GoToUrlAsync(urlToVisit);
 
             MockBrowserContext.Verify(x => x.NewPageAsync(), Times.Once);
-            MockPage.Verify(x => x.GotoAsync(urlToVisit, It.Is<PageGotoOptions>((options) => options.WaitUntil == WaitUntilState.NetworkIdle)), Times.Once);
+            MockPage.Verify(x => x.GotoAsync(urlToVisit, It.Is<PageGotoOptions>((options) => options.WaitUntil == WaitUntilState.DOMContentLoaded)), Times.Once);
 
             var secondUrlToVisit = "https://powerapps.com";
             await playwrightTestInfraFunctions.GoToUrlAsync(secondUrlToVisit);
             MockBrowserContext.Verify(x => x.NewPageAsync(), Times.Once, "Should only create a new page once");
-            MockPage.Verify(x => x.GotoAsync(secondUrlToVisit, It.Is<PageGotoOptions>((options) => options.WaitUntil == WaitUntilState.NetworkIdle)), Times.Once);
+            MockPage.Verify(x => x.GotoAsync(secondUrlToVisit, It.Is<PageGotoOptions>((options) => options.WaitUntil == WaitUntilState.DOMContentLoaded)), Times.Once);
         }
 
         [Theory]
@@ -637,7 +635,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.TestInfra
             };
 
             MockSingleTestInstanceState.Setup(x => x.GetBrowserConfig()).Returns(browserConfig);
-            MockPlaywrightObject.SetupGet(x => x[It.IsAny<string>()]).Returns(MockBrowserType.Object);  
+            MockPlaywrightObject.SetupGet(x => x[It.IsAny<string>()]).Returns(MockBrowserType.Object);
             MockBrowserType.Setup(x => x.LaunchAsync(It.IsAny<BrowserTypeLaunchOptions>())).Returns(Task.FromResult(MockBrowser.Object));
             MockTestState.Setup(x => x.GetTestSettings()).Returns(testSettings);
             MockSingleTestInstanceState.Setup(x => x.GetLogger()).Returns(MockLogger.Object);
@@ -647,7 +645,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.TestInfra
 
             // Mock Dispose methods
             MockPlaywrightObject.Setup(x => x.Dispose());
-            MockBrowserContext.Setup(x => x.DisposeAsync()).Returns(ValueTask.CompletedTask);            
+            MockBrowserContext.Setup(x => x.DisposeAsync()).Returns(ValueTask.CompletedTask);
 
             var playwrightTestInfraFunctions = new PlaywrightTestInfraFunctions(MockTestState.Object, MockSingleTestInstanceState.Object,
                 MockFileSystem.Object, MockPlaywrightObject.Object, MockBrowserContext.Object);

--- a/src/Microsoft.PowerApps.TestEngine.Tests/TestInfra/PlaywrightTestInfraFunctionTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/TestInfra/PlaywrightTestInfraFunctionTests.cs
@@ -416,12 +416,12 @@ namespace Microsoft.PowerApps.TestEngine.Tests.TestInfra
             await playwrightTestInfraFunctions.GoToUrlAsync(urlToVisit);
 
             MockBrowserContext.Verify(x => x.NewPageAsync(), Times.Once);
-            MockPage.Verify(x => x.GotoAsync(urlToVisit, It.Is<PageGotoOptions>((options) => options.WaitUntil == WaitUntilState.DOMContentLoaded)), Times.Once);
+            MockPage.Verify(x => x.GotoAsync(urlToVisit, It.IsAny<PageGotoOptions>()), Times.Once);
 
             var secondUrlToVisit = "https://powerapps.com";
             await playwrightTestInfraFunctions.GoToUrlAsync(secondUrlToVisit);
             MockBrowserContext.Verify(x => x.NewPageAsync(), Times.Once, "Should only create a new page once");
-            MockPage.Verify(x => x.GotoAsync(secondUrlToVisit, It.Is<PageGotoOptions>((options) => options.WaitUntil == WaitUntilState.DOMContentLoaded)), Times.Once);
+            MockPage.Verify(x => x.GotoAsync(secondUrlToVisit, It.IsAny<PageGotoOptions>()), Times.Once);
         }
 
         [Theory]

--- a/src/Microsoft.PowerApps.TestEngine/TestInfra/PlaywrightTestInfraFunctions.cs
+++ b/src/Microsoft.PowerApps.TestEngine/TestInfra/PlaywrightTestInfraFunctions.cs
@@ -205,8 +205,7 @@ namespace Microsoft.PowerApps.TestEngine.TestInfra
                 Page = await BrowserContext.NewPageAsync();
             }
 
-            // TODO: consider whether to make waiting for network idle state part of the function input
-            var response = await Page.GotoAsync(url, new PageGotoOptions() { WaitUntil = WaitUntilState.DOMContentLoaded });
+            var response = await Page.GotoAsync(url);
 
             // The response might be null because "The method either throws an error or returns a main resource response.
             // The only exceptions are navigation to about:blank or navigation to the same URL with a different hash, which would succeed and return null."

--- a/src/Microsoft.PowerApps.TestEngine/TestInfra/PlaywrightTestInfraFunctions.cs
+++ b/src/Microsoft.PowerApps.TestEngine/TestInfra/PlaywrightTestInfraFunctions.cs
@@ -206,7 +206,7 @@ namespace Microsoft.PowerApps.TestEngine.TestInfra
             }
 
             // TODO: consider whether to make waiting for network idle state part of the function input
-            var response = await Page.GotoAsync(url, new PageGotoOptions() { WaitUntil = WaitUntilState.NetworkIdle });
+            var response = await Page.GotoAsync(url, new PageGotoOptions() { WaitUntil = WaitUntilState.DOMContentLoaded });
 
             // The response might be null because "The method either throws an error or returns a main resource response.
             // The only exceptions are navigation to about:blank or navigation to the same URL with a different hash, which would succeed and return null."


### PR DESCRIPTION
## Description

Due to frequent instances of timeouts during test execution, we've decided to remove the `WaitUntil = WaitUntilState.NetworkIdle` property from the `GotoAsync` invocation. From the [Playwright documentation](https://playwright.dev/docs/api/class-page#page-wait-for-url-option-wait-until), it has been suggested NOT to use the `NetworkIdle` property due to its nature of timing out explicitly at 500ms which is undesirable in a real-world scenario (since we can never expect real world network reliability within such tight tolerances).

By removing the explicit setting, the `WaitUntil` property defaults to the [JavaScript `Window.Load`](https://developer.mozilla.org/en-US/docs/Web/API/Window/load_event) event. This makes this function call more robust as it waits until the entire page loads and will timeout only at the predefined default timeout.

## Checklist

- [x] The code change is covered by unit tests. I have added tests that prove my fix is effective or that my feature works
- [x] I have performed end-to-end test locally.
- [x] New and existing unit tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [N/A] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I used clear names for everything
- [x] I have performed a self-review of my own code
