### PR TITLE
Fix multiplebrowser suitesummary

### DIFF
--- a/src/Microsoft.PowerApps.TestEngine.Tests/ConsoleOutputTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/ConsoleOutputTests.cs
@@ -149,7 +149,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
             Console.SetOut(printer);
 
             // Run tests on first Browser
-            _testEngineEventHandler.setAndInitializeCounters(2);
+            _testEngineEventHandler.SetAndInitializeCounters(2);
             _testEngineEventHandler.SuiteBegin("TestSuiteName", "./testDirectory", "Chromium", "make.powerapps.com/testapp&source=testengine");
             _testEngineEventHandler.TestCaseBegin("Case1");
             _testEngineEventHandler.TestCaseEnd(true);
@@ -164,7 +164,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
             Assert.Contains("Cases failed: 1", printer.ToString());
 
             // Run tests on first Browser
-            _testEngineEventHandler.setAndInitializeCounters(2);
+            _testEngineEventHandler.SetAndInitializeCounters(2);
             _testEngineEventHandler.SuiteBegin("TestSuiteName", "./testDirectory", "Firefox", "make.powerapps.com/testapp&source=testengine");
             _testEngineEventHandler.TestCaseBegin("Case1");
             _testEngineEventHandler.TestCaseEnd(true);

--- a/src/Microsoft.PowerApps.TestEngine.Tests/ConsoleOutputTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/ConsoleOutputTests.cs
@@ -139,5 +139,44 @@ namespace Microsoft.PowerApps.TestEngine.Tests
             // Assert that the expected output matches the console output of the function
             Assert.Contains(expected, printer.ToString());
         }
+
+        [Fact]
+        public void TestMultipleBrowserRuns()
+        {
+            var printer = new StringWriter();
+
+            // Set output
+            Console.SetOut(printer);
+
+            // Run tests on first Browser
+            _testEngineEventHandler.setAndInitializeCounters(2);
+            _testEngineEventHandler.SuiteBegin("TestSuiteName", "./testDirectory", "Chromium", "make.powerapps.com/testapp&source=testengine");
+            _testEngineEventHandler.TestCaseBegin("Case1");
+            _testEngineEventHandler.TestCaseEnd(true);
+            _testEngineEventHandler.TestCaseBegin("Case2");
+            _testEngineEventHandler.TestCaseEnd(false);
+            _testEngineEventHandler.SuiteEnd();
+
+            // Assert that the expected console output matches for this browser run
+            Assert.Contains("\nTest suite summary", printer.ToString());
+            Assert.Contains("Total cases: 2", printer.ToString());
+            Assert.Contains("Cases passed: 1", printer.ToString());
+            Assert.Contains("Cases failed: 1", printer.ToString());
+
+            // Run tests on first Browser
+            _testEngineEventHandler.setAndInitializeCounters(2);
+            _testEngineEventHandler.SuiteBegin("TestSuiteName", "./testDirectory", "Firefox", "make.powerapps.com/testapp&source=testengine");
+            _testEngineEventHandler.TestCaseBegin("Case1");
+            _testEngineEventHandler.TestCaseEnd(true);
+            _testEngineEventHandler.TestCaseBegin("Case2");
+            _testEngineEventHandler.TestCaseEnd(false);
+            _testEngineEventHandler.SuiteEnd();
+
+            // Assert that the expected console output matches for this browser run
+            Assert.Contains("\nTest suite summary", printer.ToString());
+            Assert.Contains("Total cases: 2", printer.ToString());
+            Assert.Contains("Cases passed: 1", printer.ToString());
+            Assert.Contains("Cases failed: 1", printer.ToString());
+        }
     }
 }

--- a/src/Microsoft.PowerApps.TestEngine.Tests/ConsoleOutputTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/ConsoleOutputTests.cs
@@ -157,13 +157,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
             _testEngineEventHandler.TestCaseEnd(false);
             _testEngineEventHandler.SuiteEnd();
 
-            // Assert that the expected console output matches for this browser run
-            Assert.Contains("\nTest suite summary", printer.ToString());
-            Assert.Contains("Total cases: 2", printer.ToString());
-            Assert.Contains("Cases passed: 1", printer.ToString());
-            Assert.Contains("Cases failed: 1", printer.ToString());
-
-            // Run tests on first Browser
+            // Run tests on second Browser
             _testEngineEventHandler.SetAndInitializeCounters(2);
             _testEngineEventHandler.SuiteBegin("TestSuiteName", "./testDirectory", "Firefox", "make.powerapps.com/testapp&source=testengine");
             _testEngineEventHandler.TestCaseBegin("Case1");
@@ -172,11 +166,14 @@ namespace Microsoft.PowerApps.TestEngine.Tests
             _testEngineEventHandler.TestCaseEnd(false);
             _testEngineEventHandler.SuiteEnd();
 
-            // Assert that the expected console output matches for this browser run
+            // Assert that the expected console output matches 
             Assert.Contains("\nTest suite summary", printer.ToString());
             Assert.Contains("Total cases: 2", printer.ToString());
             Assert.Contains("Cases passed: 1", printer.ToString());
             Assert.Contains("Cases failed: 1", printer.ToString());
+
+            // Assert none of the browser runs failed to show incorrect failed cases
+            Assert.DoesNotContain("Cases failed: 0", printer.ToString());
         }
     }
 }

--- a/src/Microsoft.PowerApps.TestEngine.Tests/ConsoleOutputTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/ConsoleOutputTests.cs
@@ -76,8 +76,8 @@ namespace Microsoft.PowerApps.TestEngine.Tests
             // Set output
             Console.SetOut(printer);
 
-            _testEngineEventHandler._casesTotal = 11;
-            _testEngineEventHandler._casesPassed = 6;
+            _testEngineEventHandler.CasesTotal = 11;
+            _testEngineEventHandler.CasesPassed = 6;
 
             // Run function
             _testEngineEventHandler.SuiteEnd();

--- a/src/Microsoft.PowerApps.TestEngine.Tests/SingleTestRunnerTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/SingleTestRunnerTests.cs
@@ -87,7 +87,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
             MockPowerFxEngine.Setup(x => x.UpdatePowerFxModelAsync()).Returns(Task.CompletedTask);
             MockPowerFxEngine.Setup(x => x.Execute(It.IsAny<string>())).Returns(FormulaValue.NewBlank());
 
-            MockTestEngineEventHandler.Setup(x => x.SetNumberOfTotalCases(It.IsAny<int>()));
+            MockTestEngineEventHandler.Setup(x => x.setAndInitializeCounters(It.IsAny<int>()));
             MockTestEngineEventHandler.Setup(x => x.EncounteredException(It.IsAny<Exception>()));
             MockTestEngineEventHandler.Setup(x => x.SuiteBegin(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()));
             MockTestEngineEventHandler.Setup(x => x.SuiteEnd());

--- a/src/Microsoft.PowerApps.TestEngine.Tests/SingleTestRunnerTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/SingleTestRunnerTests.cs
@@ -87,7 +87,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
             MockPowerFxEngine.Setup(x => x.UpdatePowerFxModelAsync()).Returns(Task.CompletedTask);
             MockPowerFxEngine.Setup(x => x.Execute(It.IsAny<string>())).Returns(FormulaValue.NewBlank());
 
-            MockTestEngineEventHandler.Setup(x => x.setAndInitializeCounters(It.IsAny<int>()));
+            MockTestEngineEventHandler.Setup(x => x.SetAndInitializeCounters(It.IsAny<int>()));
             MockTestEngineEventHandler.Setup(x => x.EncounteredException(It.IsAny<Exception>()));
             MockTestEngineEventHandler.Setup(x => x.SuiteBegin(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()));
             MockTestEngineEventHandler.Setup(x => x.SuiteEnd());

--- a/src/Microsoft.PowerApps.TestEngine/ITestEngineEvents.cs
+++ b/src/Microsoft.PowerApps.TestEngine/ITestEngineEvents.cs
@@ -12,9 +12,9 @@ namespace Microsoft.PowerApps.TestEngine
     public interface ITestEngineEvents
     {
         /// <summary>
-        /// Sets number of total cases to expect
+        /// Sets number of total cases to expect and resets number of passed cases to 0
         /// </summary>
-        public void SetNumberOfTotalCases(int numCases);
+        public void setAndInitializeCounters(int numCases);
 
         /// <summary>
         /// Handles logging for an exception

--- a/src/Microsoft.PowerApps.TestEngine/ITestEngineEvents.cs
+++ b/src/Microsoft.PowerApps.TestEngine/ITestEngineEvents.cs
@@ -14,7 +14,7 @@ namespace Microsoft.PowerApps.TestEngine
         /// <summary>
         /// Sets number of total cases to expect and resets number of passed cases to 0
         /// </summary>
-        public void setAndInitializeCounters(int numCases);
+        public void SetAndInitializeCounters(int numCases);
 
         /// <summary>
         /// Handles logging for an exception

--- a/src/Microsoft.PowerApps.TestEngine/SingleTestRunner.cs
+++ b/src/Microsoft.PowerApps.TestEngine/SingleTestRunner.cs
@@ -89,7 +89,9 @@ namespace Microsoft.PowerApps.TestEngine
             _testState.SetTestResultsDirectory(testResultDirectory);
 
             casesTotal = _testState.GetTestSuiteDefinition().TestCases.Count();
-            _eventHandler.SetNumberOfTotalCases(casesTotal);
+
+            // Number of total cases are recorded and also initialize the passed cases to 0 for this test run
+            _eventHandler.setAndInitializeCounters(casesTotal);
 
             string suiteException = null;
 

--- a/src/Microsoft.PowerApps.TestEngine/SingleTestRunner.cs
+++ b/src/Microsoft.PowerApps.TestEngine/SingleTestRunner.cs
@@ -91,7 +91,7 @@ namespace Microsoft.PowerApps.TestEngine
             casesTotal = _testState.GetTestSuiteDefinition().TestCases.Count();
 
             // Number of total cases are recorded and also initialize the passed cases to 0 for this test run
-            _eventHandler.setAndInitializeCounters(casesTotal);
+            _eventHandler.SetAndInitializeCounters(casesTotal);
 
             string suiteException = null;
 

--- a/src/Microsoft.PowerApps.TestEngine/TestEngineEventHandler.cs
+++ b/src/Microsoft.PowerApps.TestEngine/TestEngineEventHandler.cs
@@ -12,16 +12,20 @@ namespace Microsoft.PowerApps.TestEngine
     /// </summary>
     public class TestEngineEventHandler : ITestEngineEvents
     {
-        public int _casesTotal = 0;
-        public int _casesPassed = 0;
+        private int _casesTotal = 0;
+        private int _casesPassed = 0;
+
+        public int CasesPassed { get => _casesPassed; set => _casesPassed = value; }
+        public int CasesTotal { get => _casesTotal; set => _casesTotal = value; }
 
         public TestEngineEventHandler()
         {
         }
 
-        public void SetNumberOfTotalCases(int numCases)
+        public void setAndInitializeCounters(int numCases)
         {
             _casesTotal = numCases;
+            _casesPassed = 0;
         }
 
         public void EncounteredException(Exception ex)

--- a/src/Microsoft.PowerApps.TestEngine/TestEngineEventHandler.cs
+++ b/src/Microsoft.PowerApps.TestEngine/TestEngineEventHandler.cs
@@ -22,7 +22,7 @@ namespace Microsoft.PowerApps.TestEngine
         {
         }
 
-        public void setAndInitializeCounters(int numCases)
+        public void SetAndInitializeCounters(int numCases)
         {
             _casesTotal = numCases;
             _casesPassed = 0;


### PR DESCRIPTION
## Description
Console TestSuite summary is wrong when run with multiple browser config .
<img width="400" alt="image" src="https://github.com/microsoft/PowerApps-TestEngine/assets/98551644/f42060a3-815d-45e8-8927-484b0da4ad1f">

**After fix:**
<img width="400" alt="image" src="https://github.com/microsoft/PowerApps-TestEngine/assets/98551644/c2430f29-2061-4560-9c5d-cb34d3f9f01c">

## Checklist

- [x] The code change is covered by unit tests. I have added tests that prove my fix is effective or that my feature works
- [x] I have performed end-to-end test locally.
- [x] New and existing unit tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I used clear names for everything
- [x] I have performed a self-review of my own code
