### PR TITLE
Remove ErrorInfo stacktrace from trx

### DIFF
--- a/src/Microsoft.PowerApps.TestEngine.Tests/Reporting/TestReporterTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/Reporting/TestReporterTests.cs
@@ -39,7 +39,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Reporting
             Assert.Throws<ArgumentException>(() => testReporter.EndTestRun(testRunId));
             Assert.Throws<ArgumentException>(() => testReporter.CreateTest(testRunId, Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), "c:\\testplan.fx.yaml"));
             Assert.Throws<ArgumentException>(() => testReporter.StartTest(testRunId, Guid.NewGuid().ToString()));
-            Assert.Throws<ArgumentException>(() => testReporter.EndTest(testRunId, Guid.NewGuid().ToString(), true, "", new List<string>(), null, null));
+            Assert.Throws<ArgumentException>(() => testReporter.EndTest(testRunId, Guid.NewGuid().ToString(), true, "", new List<string>(), null));
             Assert.Throws<ArgumentException>(() => testReporter.GenerateTestReport(testRunId, "c:\\results"));
         }
 
@@ -268,12 +268,11 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Reporting
         }
 
         [Theory]
-        [InlineData(true, "some logs", new string[] { }, null, null)]
-        [InlineData(true, "some logs", new string[] { "file1.txt", "file2.txt", "file3.txt" }, null, null)]
-        [InlineData(false, "some logs", new string[] { }, null, null)]
-        [InlineData(true, "some logs", new string[] { }, "error message", null)]
-        [InlineData(true, "some logs", new string[] { }, "error message", "stack trace")]
-        public void EndTestTest(bool success, string stdout, string[] additionalFiles, string errorMessage, string stackTrace)
+        [InlineData(true, "some logs", new string[] { }, null)]
+        [InlineData(true, "some logs", new string[] { "file1.txt", "file2.txt", "file3.txt" }, null)]
+        [InlineData(false, "some logs", new string[] { }, null)]
+        [InlineData(true, "some logs", new string[] { }, "error message")]
+        public void EndTestTest(bool success, string stdout, string[] additionalFiles, string errorMessage)
         {
             var testRunName = "testRunName";
             var testUser = "testUser";

--- a/src/Microsoft.PowerApps.TestEngine.Tests/Reporting/TestReporterTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/Reporting/TestReporterTests.cs
@@ -287,12 +287,12 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Reporting
             var testSuiteId = testReporter.CreateTestSuite(testRunId, "testSuite");
             var testId = testReporter.CreateTest(testRunId, testSuiteId, testName, testLocation);
 
-            Assert.Throws<InvalidOperationException>(() => testReporter.EndTest(testRunId, testId, success, stdout, additionalFiles.ToList(), errorMessage, stackTrace));
+            Assert.Throws<InvalidOperationException>(() => testReporter.EndTest(testRunId, testId, success, stdout, additionalFiles.ToList(), errorMessage));
 
             testReporter.StartTest(testRunId, testId);
 
             var before = DateTime.Now;
-            testReporter.EndTest(testRunId, testId, success, stdout, additionalFiles.ToList(), errorMessage, stackTrace);
+            testReporter.EndTest(testRunId, testId, success, stdout, additionalFiles.ToList(), errorMessage);
             var after = DateTime.Now;
 
             var testRun = testReporter.GetTestRun(testRunId);
@@ -326,7 +326,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Reporting
                 Assert.Equal(errorMessage, testRun.Results.UnitTestResults[0].Output.ErrorInfo.Message);
             }
 
-            Assert.Throws<InvalidOperationException>(() => testReporter.EndTest(testRunId, testId, success, stdout, additionalFiles.ToList(), errorMessage, stackTrace));
+            Assert.Throws<InvalidOperationException>(() => testReporter.EndTest(testRunId, testId, success, stdout, additionalFiles.ToList(), errorMessage));
         }
 
         [Fact]
@@ -374,7 +374,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Reporting
 
             testReporter.StartTest(testRunId, testId);
 
-            testReporter.EndTest(testRunId, testId, success, stdout, additionalFiles, null, null);
+            testReporter.EndTest(testRunId, testId, success, stdout, additionalFiles, null);
 
             testReporter.EndTestRun(testRunId);
 

--- a/src/Microsoft.PowerApps.TestEngine.Tests/Reporting/TestReporterTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/Reporting/TestReporterTests.cs
@@ -324,7 +324,6 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Reporting
                 Assert.Equal(1, testRun.ResultSummary.Counters.Failed);
                 Assert.Equal(TestReporter.FailedResultOutcome, testRun.Results.UnitTestResults[0].Outcome);
                 Assert.Equal(errorMessage, testRun.Results.UnitTestResults[0].Output.ErrorInfo.Message);
-                Assert.Equal(stackTrace, testRun.Results.UnitTestResults[0].Output.ErrorInfo.StackTrace);
             }
 
             Assert.Throws<InvalidOperationException>(() => testReporter.EndTest(testRunId, testId, success, stdout, additionalFiles.ToList(), errorMessage, stackTrace));

--- a/src/Microsoft.PowerApps.TestEngine.Tests/SingleTestRunnerTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/SingleTestRunnerTests.cs
@@ -63,7 +63,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
             MockTestReporter.Setup(x => x.CreateTest(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>())).Returns(testId);
             MockTestReporter.Setup(x => x.CreateTestSuite(It.IsAny<string>(), It.IsAny<string>())).Returns(testSuiteId);
             MockTestReporter.Setup(x => x.StartTest(It.IsAny<string>(), It.IsAny<string>()));
-            MockTestReporter.Setup(x => x.EndTest(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<string>(), It.IsAny<List<string>>(), It.IsAny<string>(), It.IsAny<string>()));
+            MockTestReporter.Setup(x => x.EndTest(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<string>(), It.IsAny<List<string>>(), It.IsAny<string>()));
             MockTestReporter.Setup(x => x.FailTest(It.IsAny<string>(), It.IsAny<string>()));
 
             MockLoggerFactory.Setup(x => x.CreateLogger(It.IsAny<string>())).Returns(MockLogger.Object);
@@ -156,7 +156,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
             {
                 additionalFilesList = additionalFiles.ToList();
             }
-            MockTestReporter.Verify(x => x.EndTest(testRunId, testId, testSuccess, It.Is<string>(x => x.Contains(testSuiteDefinition.TestCases[0].TestCaseName) && x.Contains(browserConfig.Browser)), additionalFilesList, errorMessage, stackTrace), Times.Once());
+            MockTestReporter.Verify(x => x.EndTest(testRunId, testId, testSuccess, It.Is<string>(x => x.Contains(testSuiteDefinition.TestCases[0].TestCaseName) && x.Contains(browserConfig.Browser)), additionalFilesList, errorMessage), Times.Once());
         }
 
         private void VerifyFinallyExecution(string testResultDirectory, int total, int pass, int fail)

--- a/src/Microsoft.PowerApps.TestEngine/Reporting/Format/TestErrorInfo.cs
+++ b/src/Microsoft.PowerApps.TestEngine/Reporting/Format/TestErrorInfo.cs
@@ -9,7 +9,5 @@ namespace Microsoft.PowerApps.TestEngine.Reporting.Format
     {
         [XmlElement(ElementName = "Message")]
         public string Message { get; set; }
-        [XmlElement(ElementName = "StackTrace")]
-        public string StackTrace { get; set; }
     }
 }

--- a/src/Microsoft.PowerApps.TestEngine/Reporting/Format/TestOutput.cs
+++ b/src/Microsoft.PowerApps.TestEngine/Reporting/Format/TestOutput.cs
@@ -9,5 +9,8 @@ namespace Microsoft.PowerApps.TestEngine.Reporting.Format
     {
         [XmlElement(ElementName = "StdOut")]
         public string StdOut { get; set; }
+
+        [XmlElement(ElementName = "ErrorInfo")]
+        public TestErrorInfo ErrorInfo { get; set; }
     }
 }

--- a/src/Microsoft.PowerApps.TestEngine/Reporting/Format/TestOutput.cs
+++ b/src/Microsoft.PowerApps.TestEngine/Reporting/Format/TestOutput.cs
@@ -9,8 +9,5 @@ namespace Microsoft.PowerApps.TestEngine.Reporting.Format
     {
         [XmlElement(ElementName = "StdOut")]
         public string StdOut { get; set; }
-
-        [XmlElement(ElementName = "ErrorInfo")]
-        public TestErrorInfo ErrorInfo { get; set; }
     }
 }

--- a/src/Microsoft.PowerApps.TestEngine/Reporting/ITestReporter.cs
+++ b/src/Microsoft.PowerApps.TestEngine/Reporting/ITestReporter.cs
@@ -55,8 +55,7 @@ namespace Microsoft.PowerApps.TestEngine.Reporting
         /// <param name="stdout">Standard output</param>
         /// <param name="additionalFiles">Any additional test files</param>
         /// <param name="errorMessage">Error message if test was unsuccessful</param>
-        /// <param name="stackTrace">Stack trace if test was unsuccessful</param>
-        public void EndTest(string testRunId, string testId, bool success, string stdout, List<string> additionalFiles, string errorMessage, string stackTrace);
+        public void EndTest(string testRunId, string testId, bool success, string stdout, List<string> additionalFiles, string errorMessage);
 
         /// <summary>
         /// End test.

--- a/src/Microsoft.PowerApps.TestEngine/Reporting/TestReporter.cs
+++ b/src/Microsoft.PowerApps.TestEngine/Reporting/TestReporter.cs
@@ -264,7 +264,6 @@ namespace Microsoft.PowerApps.TestEngine.Reporting
                 testResult.Outcome = FailedResultOutcome;
                 testResult.Output.ErrorInfo = new TestErrorInfo();
                 testResult.Output.ErrorInfo.Message = errorMessage;
-                testResult.Output.ErrorInfo.StackTrace = stackTrace;
             }
         }
 

--- a/src/Microsoft.PowerApps.TestEngine/Reporting/TestReporter.cs
+++ b/src/Microsoft.PowerApps.TestEngine/Reporting/TestReporter.cs
@@ -226,7 +226,7 @@ namespace Microsoft.PowerApps.TestEngine.Reporting
             testResult.Outcome = FailedResultOutcome;
         }
 
-        public void EndTest(string testRunId, string testId, bool success, string stdout, List<string> additionalFiles, string errorMessage, string stackTrace)
+        public void EndTest(string testRunId, string testId, bool success, string stdout, List<string> additionalFiles, string errorMessage)
         {
             var testRun = GetTestRun(testRunId);
             var testResult = testRun.Results.UnitTestResults.Where(x => x.TestId == testId).First();

--- a/src/Microsoft.PowerApps.TestEngine/SingleTestRunner.cs
+++ b/src/Microsoft.PowerApps.TestEngine/SingleTestRunner.cs
@@ -206,7 +206,7 @@ namespace Microsoft.PowerApps.TestEngine
                             }
 
                             var message = $"{{ \"TestName\": {testCase.TestCaseName}, \"BrowserConfiguration\": {JsonConvert.SerializeObject(browserConfig)}}}";
-                            _testReporter.EndTest(testRunId, testId, TestSuccess, message, additionalFiles, TestException?.Message, TestException?.StackTrace);
+                            _testReporter.EndTest(testRunId, testId, TestSuccess, message, additionalFiles, TestException?.Message);
                         }
                     }
                 }


### PR DESCRIPTION
As an effort to improve the TRX. file >> removing errorinfo stacktrace from .trx
<img width="284" alt="image" src="https://github.com/microsoft/PowerApps-TestEngine/assets/98551644/50aea78c-a6a5-4eb9-a273-b8c9a7d65ba5">


## Checklist

- [x] The code change is covered by unit tests. I have added tests that prove my fix is effective or that my feature works
- [x] I have performed end-to-end test locally.
- [x] New and existing unit tests pass locally with my changes
- [x] My changes generate no new warnings
- [x] I used clear names for everything
- [x] I have performed a self-review of my own code
