### PR TITLE
Adding test results path and app url to TRX

### DIFF
--- a/src/Microsoft.PowerApps.TestEngine.Tests/Reporting/TestReporterTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/Reporting/TestReporterTests.cs
@@ -128,6 +128,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Reporting
             Assert.Equal("Completed", testRun.ResultSummary.Outcome);
 
             Assert.Throws<InvalidOperationException>(() => testReporter.EndTestRun(testRunId));
+            Assert.Equal("{ \"AppURL\": \"\", \"TestResults\": \"\"}", testRun.ResultSummary.Output.StdOut);
         }
 
         [Fact]
@@ -365,6 +366,8 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Reporting
             var resultDirectory = "C:\\results";
             var testReporter = new TestReporter(MockFileSystem.Object);
             var testRunId = testReporter.CreateTestRun(testRunName, testUser);
+            testReporter.TestRunAppURL = "someAppURL";
+            testReporter.TestResultsDirectory = "someResultsDirectory";
 
             testReporter.StartTestRun(testRunId);
 
@@ -397,9 +400,11 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Reporting
 
                 Assert.Equal(JsonConvert.SerializeObject(testRun), JsonConvert.SerializeObject(deserializedTestRun));
 
+                // test the setting of result summary
+                Assert.Equal("{ \"AppURL\": \"someAppURL\", \"TestResults\": \"someResultsDirectory\"}", testRun.ResultSummary.Output.StdOut);
                 return true;
             };
             MockFileSystem.Verify(x => x.WriteTextToFile(expectedTrxPath, It.Is<string>(y => validateTestResults(y))), Times.Once());
         }
-    }
+    }  
 }

--- a/src/Microsoft.PowerApps.TestEngine.Tests/Reporting/TestReporterTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/Reporting/TestReporterTests.cs
@@ -37,7 +37,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Reporting
             Assert.Throws<ArgumentException>(() => testReporter.GetTestRun(testRunId));
             Assert.Throws<ArgumentException>(() => testReporter.StartTestRun(testRunId));
             Assert.Throws<ArgumentException>(() => testReporter.EndTestRun(testRunId));
-            Assert.Throws<ArgumentException>(() => testReporter.CreateTest(testRunId, Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), "c:\\testplan.fx.yaml", ""));
+            Assert.Throws<ArgumentException>(() => testReporter.CreateTest(testRunId, Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), "c:\\testplan.fx.yaml"));
             Assert.Throws<ArgumentException>(() => testReporter.StartTest(testRunId, Guid.NewGuid().ToString()));
             Assert.Throws<ArgumentException>(() => testReporter.EndTest(testRunId, Guid.NewGuid().ToString(), true, "", new List<string>(), null));
             Assert.Throws<ArgumentException>(() => testReporter.GenerateTestReport(testRunId, "c:\\results"));
@@ -166,17 +166,16 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Reporting
             var testLocation = "C:\\testplan.fx.yaml";
             var testReporter = new TestReporter(MockFileSystem.Object);
             var testRunId = testReporter.CreateTestRun(testRunName, testUser);
-            var resultOutputMessage = $"{{ \"AppURL\": testURL, \"TestResults\": testresultpath}}";
 
-            Assert.Throws<InvalidOperationException>(() => testReporter.CreateTest(testRunId, Guid.NewGuid().ToString(), testName, testLocation, resultOutputMessage));
+            Assert.Throws<InvalidOperationException>(() => testReporter.CreateTest(testRunId, Guid.NewGuid().ToString(), testName, testLocation));
 
             testReporter.StartTestRun(testRunId);
 
-            Assert.Throws<InvalidOperationException>(() => testReporter.CreateTest(testRunId, Guid.NewGuid().ToString(), testName, testLocation, resultOutputMessage));
+            Assert.Throws<InvalidOperationException>(() => testReporter.CreateTest(testRunId, Guid.NewGuid().ToString(), testName, testLocation));
 
             var testSuiteId = testReporter.CreateTestSuite(testRunId, testSuiteName);
 
-            var testId = testReporter.CreateTest(testRunId, testSuiteId, testName, testLocation, resultOutputMessage);
+            var testId = testReporter.CreateTest(testRunId, testSuiteId, testName, testLocation);
 
             var testRun = testReporter.GetTestRun(testRunId);
 
@@ -204,11 +203,10 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Reporting
             Assert.Equal(DefaultDateTime, testRun.Results.UnitTestResults[0].EndTime);
             Assert.True(testRun.Results.UnitTestResults[0].ResultFiles.ResultFile.Count == 0);
             Assert.Equal(1, testRun.ResultSummary.Counters.Total);
-            Assert.Equal("{ \"AppURL\": testURL, \"TestResults\": testresultpath}", testRun.ResultSummary.Output.StdOut);
 
             var testName2 = "testName2";
             var testLocation2 = "C:\\testplan2.fx.yaml";
-            var testId2 = testReporter.CreateTest(testRunId, testSuiteId, testName2, testLocation2, resultOutputMessage);
+            var testId2 = testReporter.CreateTest(testRunId, testSuiteId, testName2, testLocation2);
 
             testRun = testReporter.GetTestRun(testRunId);
 
@@ -236,10 +234,9 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Reporting
             Assert.Equal(DefaultDateTime, testRun.Results.UnitTestResults[0].EndTime);
             Assert.True(testRun.Results.UnitTestResults[1].ResultFiles.ResultFile.Count == 0);
             Assert.Equal(2, testRun.ResultSummary.Counters.Total);
-            Assert.Equal("{ \"AppURL\": testURL, \"TestResults\": testresultpath}", testRun.ResultSummary.Output.StdOut);
 
             testReporter.EndTestRun(testRunId);
-            Assert.Throws<InvalidOperationException>(() => testReporter.CreateTest(testRunId, Guid.NewGuid().ToString(), testName, testLocation,""));
+            Assert.Throws<InvalidOperationException>(() => testReporter.CreateTest(testRunId, Guid.NewGuid().ToString(), testName, testLocation));
         }
 
         [Fact]
@@ -255,7 +252,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Reporting
             testReporter.StartTestRun(testRunId);
 
             var testSuiteId = testReporter.CreateTestSuite(testRunId, "testSuite");
-            var testId = testReporter.CreateTest(testRunId, testSuiteId, testName, testLocation,"");
+            var testId = testReporter.CreateTest(testRunId, testSuiteId, testName, testLocation);
 
             var before = DateTime.Now;
             testReporter.StartTest(testRunId, testId);
@@ -287,7 +284,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Reporting
             testReporter.StartTestRun(testRunId);
 
             var testSuiteId = testReporter.CreateTestSuite(testRunId, "testSuite");
-            var testId = testReporter.CreateTest(testRunId, testSuiteId, testName, testLocation,"");
+            var testId = testReporter.CreateTest(testRunId, testSuiteId, testName, testLocation);
 
             Assert.Throws<InvalidOperationException>(() => testReporter.EndTest(testRunId, testId, success, stdout, additionalFiles.ToList(), errorMessage));
 
@@ -344,7 +341,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Reporting
             testReporter.StartTestRun(testRunId);
 
             var testSuiteId = testReporter.CreateTestSuite(testRunId, "testSuite");
-            var testId = testReporter.CreateTest(testRunId, testSuiteId, testName, testLocation,"");
+            var testId = testReporter.CreateTest(testRunId, testSuiteId, testName, testLocation);
 
             testReporter.FailTest(testRunId, testId);
 
@@ -368,12 +365,11 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Reporting
             var resultDirectory = "C:\\results";
             var testReporter = new TestReporter(MockFileSystem.Object);
             var testRunId = testReporter.CreateTestRun(testRunName, testUser);
-            var resultOutputMessage = $"{{ \"AppURL\": testURL, \"TestResults\": testresultpath}}";
 
             testReporter.StartTestRun(testRunId);
 
             var testSuiteId = testReporter.CreateTestSuite(testRunId, "testSuite");
-            var testId = testReporter.CreateTest(testRunId, testSuiteId, testName, testLocation, resultOutputMessage);
+            var testId = testReporter.CreateTest(testRunId, testSuiteId, testName, testLocation);
 
             testReporter.StartTest(testRunId, testId);
 

--- a/src/Microsoft.PowerApps.TestEngine.Tests/Reporting/TestReporterTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/Reporting/TestReporterTests.cs
@@ -37,7 +37,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Reporting
             Assert.Throws<ArgumentException>(() => testReporter.GetTestRun(testRunId));
             Assert.Throws<ArgumentException>(() => testReporter.StartTestRun(testRunId));
             Assert.Throws<ArgumentException>(() => testReporter.EndTestRun(testRunId));
-            Assert.Throws<ArgumentException>(() => testReporter.CreateTest(testRunId, Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), "c:\\testplan.fx.yaml"));
+            Assert.Throws<ArgumentException>(() => testReporter.CreateTest(testRunId, Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), "c:\\testplan.fx.yaml", ""));
             Assert.Throws<ArgumentException>(() => testReporter.StartTest(testRunId, Guid.NewGuid().ToString()));
             Assert.Throws<ArgumentException>(() => testReporter.EndTest(testRunId, Guid.NewGuid().ToString(), true, "", new List<string>(), null));
             Assert.Throws<ArgumentException>(() => testReporter.GenerateTestReport(testRunId, "c:\\results"));
@@ -166,16 +166,17 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Reporting
             var testLocation = "C:\\testplan.fx.yaml";
             var testReporter = new TestReporter(MockFileSystem.Object);
             var testRunId = testReporter.CreateTestRun(testRunName, testUser);
+            var resultOutputMessage = $"{{ \"AppURL\": testURL, \"TestResults\": testresultpath}}";
 
-            Assert.Throws<InvalidOperationException>(() => testReporter.CreateTest(testRunId, Guid.NewGuid().ToString(), testName, testLocation));
+            Assert.Throws<InvalidOperationException>(() => testReporter.CreateTest(testRunId, Guid.NewGuid().ToString(), testName, testLocation, resultOutputMessage));
 
             testReporter.StartTestRun(testRunId);
 
-            Assert.Throws<InvalidOperationException>(() => testReporter.CreateTest(testRunId, Guid.NewGuid().ToString(), testName, testLocation));
+            Assert.Throws<InvalidOperationException>(() => testReporter.CreateTest(testRunId, Guid.NewGuid().ToString(), testName, testLocation, resultOutputMessage));
 
             var testSuiteId = testReporter.CreateTestSuite(testRunId, testSuiteName);
 
-            var testId = testReporter.CreateTest(testRunId, testSuiteId, testName, testLocation);
+            var testId = testReporter.CreateTest(testRunId, testSuiteId, testName, testLocation, resultOutputMessage);
 
             var testRun = testReporter.GetTestRun(testRunId);
 
@@ -203,10 +204,11 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Reporting
             Assert.Equal(DefaultDateTime, testRun.Results.UnitTestResults[0].EndTime);
             Assert.True(testRun.Results.UnitTestResults[0].ResultFiles.ResultFile.Count == 0);
             Assert.Equal(1, testRun.ResultSummary.Counters.Total);
+            Assert.Equal("{ \"AppURL\": testURL, \"TestResults\": testresultpath}", testRun.ResultSummary.Output.StdOut);
 
             var testName2 = "testName2";
             var testLocation2 = "C:\\testplan2.fx.yaml";
-            var testId2 = testReporter.CreateTest(testRunId, testSuiteId, testName2, testLocation2);
+            var testId2 = testReporter.CreateTest(testRunId, testSuiteId, testName2, testLocation2, resultOutputMessage);
 
             testRun = testReporter.GetTestRun(testRunId);
 
@@ -234,9 +236,10 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Reporting
             Assert.Equal(DefaultDateTime, testRun.Results.UnitTestResults[0].EndTime);
             Assert.True(testRun.Results.UnitTestResults[1].ResultFiles.ResultFile.Count == 0);
             Assert.Equal(2, testRun.ResultSummary.Counters.Total);
+            Assert.Equal("{ \"AppURL\": testURL, \"TestResults\": testresultpath}", testRun.ResultSummary.Output.StdOut);
 
             testReporter.EndTestRun(testRunId);
-            Assert.Throws<InvalidOperationException>(() => testReporter.CreateTest(testRunId, Guid.NewGuid().ToString(), testName, testLocation));
+            Assert.Throws<InvalidOperationException>(() => testReporter.CreateTest(testRunId, Guid.NewGuid().ToString(), testName, testLocation,""));
         }
 
         [Fact]
@@ -252,7 +255,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Reporting
             testReporter.StartTestRun(testRunId);
 
             var testSuiteId = testReporter.CreateTestSuite(testRunId, "testSuite");
-            var testId = testReporter.CreateTest(testRunId, testSuiteId, testName, testLocation);
+            var testId = testReporter.CreateTest(testRunId, testSuiteId, testName, testLocation,"");
 
             var before = DateTime.Now;
             testReporter.StartTest(testRunId, testId);
@@ -284,7 +287,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Reporting
             testReporter.StartTestRun(testRunId);
 
             var testSuiteId = testReporter.CreateTestSuite(testRunId, "testSuite");
-            var testId = testReporter.CreateTest(testRunId, testSuiteId, testName, testLocation);
+            var testId = testReporter.CreateTest(testRunId, testSuiteId, testName, testLocation,"");
 
             Assert.Throws<InvalidOperationException>(() => testReporter.EndTest(testRunId, testId, success, stdout, additionalFiles.ToList(), errorMessage));
 
@@ -341,7 +344,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Reporting
             testReporter.StartTestRun(testRunId);
 
             var testSuiteId = testReporter.CreateTestSuite(testRunId, "testSuite");
-            var testId = testReporter.CreateTest(testRunId, testSuiteId, testName, testLocation);
+            var testId = testReporter.CreateTest(testRunId, testSuiteId, testName, testLocation,"");
 
             testReporter.FailTest(testRunId, testId);
 
@@ -365,11 +368,12 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Reporting
             var resultDirectory = "C:\\results";
             var testReporter = new TestReporter(MockFileSystem.Object);
             var testRunId = testReporter.CreateTestRun(testRunName, testUser);
+            var resultOutputMessage = $"{{ \"AppURL\": testURL, \"TestResults\": testresultpath}}";
 
             testReporter.StartTestRun(testRunId);
 
             var testSuiteId = testReporter.CreateTestSuite(testRunId, "testSuite");
-            var testId = testReporter.CreateTest(testRunId, testSuiteId, testName, testLocation);
+            var testId = testReporter.CreateTest(testRunId, testSuiteId, testName, testLocation, resultOutputMessage);
 
             testReporter.StartTest(testRunId, testId);
 

--- a/src/Microsoft.PowerApps.TestEngine.Tests/SingleTestRunnerTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/SingleTestRunnerTests.cs
@@ -60,7 +60,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
             LoggingTestHelper.SetupMock(MockLogger);
             MockLogger.Setup(x => x.BeginScope(It.IsAny<string>())).Returns(new TestLoggerScope("", () => { }));
 
-            MockTestReporter.Setup(x => x.CreateTest(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>())).Returns(testId);
+            MockTestReporter.Setup(x => x.CreateTest(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>())).Returns(testId);
             MockTestReporter.Setup(x => x.CreateTestSuite(It.IsAny<string>(), It.IsAny<string>())).Returns(testSuiteId);
             MockTestReporter.Setup(x => x.StartTest(It.IsAny<string>(), It.IsAny<string>()));
             MockTestReporter.Setup(x => x.EndTest(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<string>(), It.IsAny<List<string>>(), It.IsAny<string>()));
@@ -141,7 +141,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
             MockUrlMapper.Verify(x => x.GenerateTestUrl("", ""), Times.Once());
             MockTestInfraFunctions.Verify(x => x.GoToUrlAsync(appUrl), Times.Once());
             MockTestState.Verify(x => x.GetTestSuiteDefinition(), Times.Exactly(2));
-            MockTestReporter.Verify(x => x.CreateTest(testRunId, testSuiteId, testSuiteDefinition.TestCases[0].TestCaseName, "TODO"), Times.Once());
+            MockTestReporter.Verify(x => x.CreateTest(testRunId, testSuiteId, testSuiteDefinition.TestCases[0].TestCaseName, "TODO", It.IsAny<string>()), Times.Once());
             MockTestReporter.Verify(x => x.StartTest(testRunId, testId), Times.Once());
             MockTestState.Verify(x => x.SetTestId(testId), Times.Once());
             MockLoggerFactory.Verify(x => x.CreateLogger(testSuiteId), Times.Once());

--- a/src/Microsoft.PowerApps.TestEngine.Tests/SingleTestRunnerTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/SingleTestRunnerTests.cs
@@ -156,7 +156,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
             {
                 additionalFilesList = additionalFiles.ToList();
             }
-            MockTestReporter.Verify(x => x.EndTest(testRunId, testId, testSuccess, It.Is<string>(x => x.Contains(testSuiteDefinition.TestCases[0].TestCaseName) && x.Contains(browserConfig.Browser)), additionalFilesList, errorMessage), Times.Once());
+            MockTestReporter.Verify(x => x.EndTest(testRunId, testId, testSuccess, It.Is<string>(x => x.Contains(browserConfig.Browser)), additionalFilesList, errorMessage), Times.Once());
         }
 
         private void VerifyFinallyExecution(string testResultDirectory, int total, int pass, int fail)

--- a/src/Microsoft.PowerApps.TestEngine.Tests/SingleTestRunnerTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/SingleTestRunnerTests.cs
@@ -65,11 +65,9 @@ namespace Microsoft.PowerApps.TestEngine.Tests
             MockTestReporter.Setup(x => x.StartTest(It.IsAny<string>(), It.IsAny<string>()));
             MockTestReporter.Setup(x => x.EndTest(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<string>(), It.IsAny<List<string>>(), It.IsAny<string>()));
             MockTestReporter.Setup(x => x.FailTest(It.IsAny<string>(), It.IsAny<string>()));
-            // MockTestReporter.SetupGet(x => x.TestResultsDirectory).Equals("");
             
             MockTestReporter.SetupSet(x => x.TestResultsDirectory = "TestRunDirectory");
             MockTestReporter.SetupGet(x => x.TestResultsDirectory).Returns("TestRunDirectory");
-            // MockTestReporter.SetupGet(x => x.TestRunAppURL).Equals("");
             MockTestReporter.SetupSet(x => x.TestRunAppURL = "https://fake-app-url.com");
             MockTestReporter.SetupGet(x => x.TestRunAppURL).Returns("https://fake-app-url.com");
 

--- a/src/Microsoft.PowerApps.TestEngine.Tests/SingleTestRunnerTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/SingleTestRunnerTests.cs
@@ -60,11 +60,18 @@ namespace Microsoft.PowerApps.TestEngine.Tests
             LoggingTestHelper.SetupMock(MockLogger);
             MockLogger.Setup(x => x.BeginScope(It.IsAny<string>())).Returns(new TestLoggerScope("", () => { }));
 
-            MockTestReporter.Setup(x => x.CreateTest(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>())).Returns(testId);
+            MockTestReporter.Setup(x => x.CreateTest(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>())).Returns(testId);
             MockTestReporter.Setup(x => x.CreateTestSuite(It.IsAny<string>(), It.IsAny<string>())).Returns(testSuiteId);
             MockTestReporter.Setup(x => x.StartTest(It.IsAny<string>(), It.IsAny<string>()));
             MockTestReporter.Setup(x => x.EndTest(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<string>(), It.IsAny<List<string>>(), It.IsAny<string>()));
             MockTestReporter.Setup(x => x.FailTest(It.IsAny<string>(), It.IsAny<string>()));
+            // MockTestReporter.SetupGet(x => x.TestResultsDirectory).Equals("");
+            
+            MockTestReporter.SetupSet(x => x.TestResultsDirectory = "TestRunDirectory");
+            MockTestReporter.SetupGet(x => x.TestResultsDirectory).Returns("TestRunDirectory");
+            // MockTestReporter.SetupGet(x => x.TestRunAppURL).Equals("");
+            MockTestReporter.SetupSet(x => x.TestRunAppURL = "https://fake-app-url.com");
+            MockTestReporter.SetupGet(x => x.TestRunAppURL).Returns("https://fake-app-url.com");
 
             MockLoggerFactory.Setup(x => x.CreateLogger(It.IsAny<string>())).Returns(MockLogger.Object);
 
@@ -141,7 +148,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
             MockUrlMapper.Verify(x => x.GenerateTestUrl("", ""), Times.Once());
             MockTestInfraFunctions.Verify(x => x.GoToUrlAsync(appUrl), Times.Once());
             MockTestState.Verify(x => x.GetTestSuiteDefinition(), Times.Exactly(2));
-            MockTestReporter.Verify(x => x.CreateTest(testRunId, testSuiteId, testSuiteDefinition.TestCases[0].TestCaseName, "TODO", It.IsAny<string>()), Times.Once());
+            MockTestReporter.Verify(x => x.CreateTest(testRunId, testSuiteId, testSuiteDefinition.TestCases[0].TestCaseName, "TODO"), Times.Once());
             MockTestReporter.Verify(x => x.StartTest(testRunId, testId), Times.Once());
             MockTestState.Verify(x => x.SetTestId(testId), Times.Once());
             MockLoggerFactory.Verify(x => x.CreateLogger(testSuiteId), Times.Once());

--- a/src/Microsoft.PowerApps.TestEngine/Reporting/ITestReporter.cs
+++ b/src/Microsoft.PowerApps.TestEngine/Reporting/ITestReporter.cs
@@ -8,7 +8,12 @@ namespace Microsoft.PowerApps.TestEngine.Reporting
     /// </summary>
     public interface ITestReporter
     {
+        /// <summary>
+        /// Test Run App URL
         public string TestRunAppURL { get; set; }
+
+        /// <summary>
+        /// Test Results Directory
         public string TestResultsDirectory { get; set; }
 
         /// <summary>

--- a/src/Microsoft.PowerApps.TestEngine/Reporting/ITestReporter.cs
+++ b/src/Microsoft.PowerApps.TestEngine/Reporting/ITestReporter.cs
@@ -8,6 +8,9 @@ namespace Microsoft.PowerApps.TestEngine.Reporting
     /// </summary>
     public interface ITestReporter
     {
+        public string TestRunAppURL { get; set; }
+        public string TestResultsDirectory { get; set; }
+
         /// <summary>
         /// Creates a test run
         /// </summary>
@@ -34,11 +37,11 @@ namespace Microsoft.PowerApps.TestEngine.Reporting
         /// Creates a test in a test run
         /// </summary>
         /// <param name="testRunId">Test run id</param>
+        /// <param name="testSuiteId">Test suite id</param>
         /// <param name="testName">Name of test</param>
         /// <param name="testLocation">Location of test file</param>
-        /// <param name="resultOutput">Result output message with appurl and testresults path</param>
         /// <returns>Test id</returns>
-        public string CreateTest(string testRunId, string testSuiteId, string testName, string testLocation, string resultOutput);
+        public string CreateTest(string testRunId, string testSuiteId, string testName, string testLocation);
 
         /// <summary>
         /// Starts test. This records the start time of the test.

--- a/src/Microsoft.PowerApps.TestEngine/Reporting/ITestReporter.cs
+++ b/src/Microsoft.PowerApps.TestEngine/Reporting/ITestReporter.cs
@@ -36,8 +36,9 @@ namespace Microsoft.PowerApps.TestEngine.Reporting
         /// <param name="testRunId">Test run id</param>
         /// <param name="testName">Name of test</param>
         /// <param name="testLocation">Location of test file</param>
+        /// <param name="resultOutput">Result output message with appurl and testresults path</param>
         /// <returns>Test id</returns>
-        public string CreateTest(string testRunId, string testSuiteId, string testName, string testLocation);
+        public string CreateTest(string testRunId, string testSuiteId, string testName, string testLocation, string resultOutput);
 
         /// <summary>
         /// Starts test. This records the start time of the test.

--- a/src/Microsoft.PowerApps.TestEngine/Reporting/TestReporter.cs
+++ b/src/Microsoft.PowerApps.TestEngine/Reporting/TestReporter.cs
@@ -48,7 +48,8 @@ namespace Microsoft.PowerApps.TestEngine.Reporting
                 ResultSummary = new TestResultSummary()
                 {
                     Outcome = "",
-                    Counters = new TestCounters()
+                    Counters = new TestCounters(),
+                    Output = new TestOutput()
                 },
                 TestLists = new TestLists()
                 {
@@ -130,7 +131,7 @@ namespace Microsoft.PowerApps.TestEngine.Reporting
             return testRun.TestLists.TestList.Where(x => x.Id == testSuiteId).Count() == 1;
         }
 
-        public string CreateTest(string testRunId, string testSuiteId, string testName, string testLocation)
+        public string CreateTest(string testRunId, string testSuiteId, string testName, string testLocation, string resultOutput)
         {
             var testRun = GetTestRun(testRunId);
 
@@ -195,6 +196,7 @@ namespace Microsoft.PowerApps.TestEngine.Reporting
             testRun.TestEntries.Entries.Add(testEntry);
             testRun.Results.UnitTestResults.Add(unitTestResult);
             testRun.ResultSummary.Counters.Total++;
+            testRun.ResultSummary.Output.StdOut = resultOutput;
 
             return unitTestDefinition.Id;
         }

--- a/src/Microsoft.PowerApps.TestEngine/Reporting/TestReporter.cs
+++ b/src/Microsoft.PowerApps.TestEngine/Reporting/TestReporter.cs
@@ -16,6 +16,11 @@ namespace Microsoft.PowerApps.TestEngine.Reporting
         public static string FailedResultOutcome = "Failed";
         public static string PassedResultOutcome = "Passed";
 
+        private string testRunAppURL;
+        private string testResultsDirectory;
+        public string TestRunAppURL { get => testRunAppURL; set => testRunAppURL = value; }     
+        public string TestResultsDirectory { get => testResultsDirectory; set => testResultsDirectory = value; }
+
         public TestReporter(IFileSystem fileSystem)
         {
             _fileSystem = fileSystem;
@@ -105,6 +110,15 @@ namespace Microsoft.PowerApps.TestEngine.Reporting
 
             testRun.Times.Finish = DateTime.Now;
             testRun.ResultSummary.Outcome = "Completed";
+
+            // Update the ResultSummary Output
+            _updateResultSummaryOutPut(testRun);
+        }
+
+        private void _updateResultSummaryOutPut(TestRun testRun)
+        {
+            var resultOutputMessage = $"{{ \"AppURL\": {testRunAppURL}, \"TestResults\": {testResultsDirectory}}}";
+            testRun.ResultSummary.Output.StdOut = resultOutputMessage;
         }
 
         public string CreateTestSuite(string testRunId, string testSuiteName)
@@ -131,7 +145,7 @@ namespace Microsoft.PowerApps.TestEngine.Reporting
             return testRun.TestLists.TestList.Where(x => x.Id == testSuiteId).Count() == 1;
         }
 
-        public string CreateTest(string testRunId, string testSuiteId, string testName, string testLocation, string resultOutput)
+        public string CreateTest(string testRunId, string testSuiteId, string testName, string testLocation)
         {
             var testRun = GetTestRun(testRunId);
 
@@ -196,7 +210,6 @@ namespace Microsoft.PowerApps.TestEngine.Reporting
             testRun.TestEntries.Entries.Add(testEntry);
             testRun.Results.UnitTestResults.Add(unitTestResult);
             testRun.ResultSummary.Counters.Total++;
-            testRun.ResultSummary.Output.StdOut = resultOutput;
 
             return unitTestDefinition.Id;
         }

--- a/src/Microsoft.PowerApps.TestEngine/Reporting/TestReporter.cs
+++ b/src/Microsoft.PowerApps.TestEngine/Reporting/TestReporter.cs
@@ -117,7 +117,7 @@ namespace Microsoft.PowerApps.TestEngine.Reporting
 
         private void _updateResultSummaryOutPut(TestRun testRun)
         {
-            var resultOutputMessage = $"{{ \"AppURL\": {testRunAppURL}, \"TestResults\": {testResultsDirectory}}}";
+            var resultOutputMessage = $"{{ \"AppURL\": \"{testRunAppURL}\", \"TestResults\": \"{testResultsDirectory}\"}}";
             testRun.ResultSummary.Output.StdOut = resultOutputMessage;
         }
 

--- a/src/Microsoft.PowerApps.TestEngine/Reporting/TestReporter.cs
+++ b/src/Microsoft.PowerApps.TestEngine/Reporting/TestReporter.cs
@@ -18,7 +18,7 @@ namespace Microsoft.PowerApps.TestEngine.Reporting
 
         private string testRunAppURL;
         private string testResultsDirectory;
-        public string TestRunAppURL { get => testRunAppURL; set => testRunAppURL = value; }     
+        public string TestRunAppURL { get => testRunAppURL; set => testRunAppURL = value; }
         public string TestResultsDirectory { get => testResultsDirectory; set => testResultsDirectory = value; }
 
         public TestReporter(IFileSystem fileSystem)

--- a/src/Microsoft.PowerApps.TestEngine/SingleTestRunner.cs
+++ b/src/Microsoft.PowerApps.TestEngine/SingleTestRunner.cs
@@ -206,7 +206,7 @@ namespace Microsoft.PowerApps.TestEngine
                                 }
                             }
 
-                            var message = $"{{ \"TestName\": {testCase.TestCaseName}, \"BrowserConfiguration\": {JsonConvert.SerializeObject(browserConfig)}}}";
+                            var message = $"{{ \"BrowserConfiguration\": {JsonConvert.SerializeObject(browserConfig)}}}";
                             _testReporter.EndTest(testRunId, testId, TestSuccess, message, additionalFiles, TestException?.Message);
                         }
                     }

--- a/src/Microsoft.PowerApps.TestEngine/SingleTestRunner.cs
+++ b/src/Microsoft.PowerApps.TestEngine/SingleTestRunner.cs
@@ -135,7 +135,8 @@ namespace Microsoft.PowerApps.TestEngine
                     _eventHandler.TestCaseBegin(testCase.TestCaseName);
 
                     TestSuccess = true;
-                    var testId = _testReporter.CreateTest(testRunId, testSuiteId, $"{testCase.TestCaseName}", "TODO");
+                    var resultOutputMessage = $"{{ \"AppURL\": {desiredUrl}, \"TestResults\": {testRunDirectory}}}";
+                    var testId = _testReporter.CreateTest(testRunId, testSuiteId, $"{testCase.TestCaseName}", "TODO", resultOutputMessage);
                     _testReporter.StartTest(testRunId, testId);
                     _testState.SetTestId(testId);
 
@@ -238,7 +239,8 @@ namespace Microsoft.PowerApps.TestEngine
                     // Run test case one by one, mark it as failed
                     foreach (var testCase in _testState.GetTestSuiteDefinition().TestCases)
                     {
-                        var testId = _testReporter.CreateTest(testRunId, testSuiteId, $"{testCase.TestCaseName}", "TODO");
+                        var resultOutputMessage = $"{{ \"AppURL\": {desiredUrl}, \"TestResults\": {testRunDirectory}}}";
+                        var testId = _testReporter.CreateTest(testRunId, testSuiteId, $"{testCase.TestCaseName}", "TODO", resultOutputMessage);
                         _testReporter.FailTest(testRunId, testId);
                     }
                 }

--- a/src/Microsoft.PowerApps.TestEngine/SingleTestRunner.cs
+++ b/src/Microsoft.PowerApps.TestEngine/SingleTestRunner.cs
@@ -117,8 +117,11 @@ namespace Microsoft.PowerApps.TestEngine
                 await _testInfraFunctions.GoToUrlAsync(desiredUrl);
                 Logger.LogInformation("Successfully navigated to target URL");
 
+                _testReporter.TestResultsDirectory = testRunDirectory;
+                _testReporter.TestRunAppURL = desiredUrl;
+
                 // Log in user
-                await _userManager.LoginAsUserAsync(desiredUrl);
+                await _userManager.LoginAsUserAsync(desiredUrl);                
 
                 // Set up network request mocking if any
                 await _testInfraFunctions.SetupNetworkRequestMockAsync();
@@ -135,8 +138,7 @@ namespace Microsoft.PowerApps.TestEngine
                     _eventHandler.TestCaseBegin(testCase.TestCaseName);
 
                     TestSuccess = true;
-                    var resultOutputMessage = $"{{ \"AppURL\": {desiredUrl}, \"TestResults\": {testRunDirectory}}}";
-                    var testId = _testReporter.CreateTest(testRunId, testSuiteId, $"{testCase.TestCaseName}", "TODO", resultOutputMessage);
+                    var testId = _testReporter.CreateTest(testRunId, testSuiteId, $"{testCase.TestCaseName}", "TODO");
                     _testReporter.StartTest(testRunId, testId);
                     _testState.SetTestId(testId);
 
@@ -239,8 +241,7 @@ namespace Microsoft.PowerApps.TestEngine
                     // Run test case one by one, mark it as failed
                     foreach (var testCase in _testState.GetTestSuiteDefinition().TestCases)
                     {
-                        var resultOutputMessage = $"{{ \"AppURL\": {desiredUrl}, \"TestResults\": {testRunDirectory}}}";
-                        var testId = _testReporter.CreateTest(testRunId, testSuiteId, $"{testCase.TestCaseName}", "TODO", resultOutputMessage);
+                        var testId = _testReporter.CreateTest(testRunId, testSuiteId, $"{testCase.TestCaseName}", "TODO");
                         _testReporter.FailTest(testRunId, testId);
                     }
                 }

--- a/src/Microsoft.PowerApps.TestEngine/SingleTestRunner.cs
+++ b/src/Microsoft.PowerApps.TestEngine/SingleTestRunner.cs
@@ -121,7 +121,7 @@ namespace Microsoft.PowerApps.TestEngine
                 _testReporter.TestRunAppURL = desiredUrl;
 
                 // Log in user
-                await _userManager.LoginAsUserAsync(desiredUrl);                
+                await _userManager.LoginAsUserAsync(desiredUrl);
 
                 // Set up network request mocking if any
                 await _testInfraFunctions.SetupNetworkRequestMockAsync();


### PR DESCRIPTION
Currently **app URL** and **test results** path is not specified in the .trx file.
In an attempt to improve .trx file >> adding these details.

**Proposed Solution**
- Add app url and test results path as part of ResultSummary within a test run. Keeping in mind the schema http://microsoft.com/schemas/VisualStudio/TeamTest/2010 
- XML change would look like this 
<img width="800" alt="image" src="https://github.com/microsoft/PowerApps-TestEngine/assets/98551644/928dde32-4f2a-4230-9ec9-6a6a4e498a21">

- TRX opened in Visual studio looks like this
<img width="800" alt="image" src="https://github.com/microsoft/PowerApps-TestEngine/assets/98551644/b7534500-3d60-4895-98f4-76d8a6095798">

Also removed Testcase name within the unittest results.
<img width="800" alt="image" src="https://github.com/microsoft/PowerApps-TestEngine/assets/98551644/0aa7f710-954e-49ee-8fb7-5356bfa9dcf1">
Since the testcase name is already present in the UnitTestResult attribute 
<img width="829" alt="image" src="https://github.com/microsoft/PowerApps-TestEngine/assets/98551644/b9761d54-5f2b-4e7e-8db6-cfb048b195df">

 
## Checklist

- [x] The code change is covered by unit tests. I have added tests that prove my fix is effective or that my feature works
- [x] I have performed end-to-end test locally.
- [x] New and existing unit tests pass locally with my changes
- [x] My changes generate no new warnings
- [x] I used clear names for everything
- [x] I have performed a self-review of my own code
