### PR TITLE
Refactor DateValue field and fix other compile time errors

### DIFF
--- a/src/Microsoft.PowerApps.TestEngine.Tests/PowerApps/PowerAppFunctionsTest.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/PowerApps/PowerAppFunctionsTest.cs
@@ -158,7 +158,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerApps
             var result = await powerAppFunctions.SetPropertyAsync(itemPath, DateValue.NewDateOnly(dt.Date));
 
             Assert.True(result);
-            MockTestInfraFunctions.Verify(x => x.RunJavascriptAsync<bool>($"PowerAppsTestEngine.setPropertyValue({itemPathString},{{\"SelectedDate\":Date.parse(\"{((DateValue)DateValue.NewDateOnly(dt.Date)).Value}\")}})"), Times.Once());
+            MockTestInfraFunctions.Verify(x => x.RunJavascriptAsync<bool>($"PowerAppsTestEngine.setPropertyValue({itemPathString},{{\"SelectedDate\":Date.parse(\"{((DateValue)DateValue.NewDateOnly(dt.Date)).GetConvertedValue(null)}\")}})"), Times.Once());
         }
 
         [Fact]
@@ -542,8 +542,8 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerApps
         {
             MockSingleTestInstanceState.Setup(x => x.GetLogger()).Returns(MockLogger.Object);
             MockTestInfraFunctions.Setup(x => x.AddScriptTagAsync(It.IsAny<string>(), It.IsAny<string>())).Returns(Task.CompletedTask);
-                        MockTestInfraFunctions.SetupSequence(x => x.RunJavascriptAsync<string>("typeof PowerAppsTestEngine"))
-                .Returns(Task.FromResult("object"));
+            MockTestInfraFunctions.SetupSequence(x => x.RunJavascriptAsync<string>("typeof PowerAppsTestEngine"))
+    .Returns(Task.FromResult("object"));
 
             MockTestInfraFunctions.Setup(x => x.RunJavascriptAsync<string>("PowerAppsTestEngine.buildObjectModel().then((objectModel) => JSON.stringify(objectModel))")).Returns(Task.FromResult("{}"));
             var testSettings = new TestSettings() { Timeout = 12000 };
@@ -570,7 +570,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerApps
 
             var powerAppFunctions = new PowerAppFunctions(MockTestInfraFunctions.Object, MockSingleTestInstanceState.Object, MockTestState.Object);
             await Assert.ThrowsAsync<TimeoutException>(async () => { await powerAppFunctions.LoadPowerAppsObjectModelAsync(); });
-            
+
             MockTestInfraFunctions.Verify(x => x.RunJavascriptAsync<string>("PowerAppsTestEngine.buildObjectModel().then((objectModel) => JSON.stringify(objectModel))"), Times.AtLeastOnce());
             LoggingTestHelper.VerifyLogging(MockLogger, "Start to load power apps object model", LogLevel.Debug, Times.Once());
         }
@@ -736,7 +736,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerApps
             var powerAppFunctions = new PowerAppFunctions(MockTestInfraFunctions.Object, MockSingleTestInstanceState.Object, MockTestState.Object);
             await Assert.ThrowsAsync<Exception>(async () => { await powerAppFunctions.SetPropertyDateAsync(itemPath, DateValue.NewDateOnly(dt.Date)); });
 
-            MockTestInfraFunctions.Verify(x => x.RunJavascriptAsync<bool>($"PowerAppsTestEngine.setPropertyValue({itemPathString},{{\"SelectedDate\":Date.parse(\"{((DateValue)DateValue.NewDateOnly(dt.Date)).Value}\")}})"), Times.Once());
+            MockTestInfraFunctions.Verify(x => x.RunJavascriptAsync<bool>($"PowerAppsTestEngine.setPropertyValue({itemPathString},{{\"SelectedDate\":Date.parse(\"{((DateValue)DateValue.NewDateOnly(dt.Date)).GetConvertedValue(null)}\")}})"), Times.Once());
             LoggingTestHelper.VerifyLogging(MockLogger, ExceptionHandlingHelper.PublishedAppWithoutJSSDKMessage, LogLevel.Error, Times.Once());
         }
 

--- a/src/Microsoft.PowerApps.TestEngine.Tests/PowerApps/PowerFXModel/ControlRecordValueTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/PowerApps/PowerFXModel/ControlRecordValueTests.cs
@@ -9,7 +9,6 @@ using Microsoft.PowerFx.Types;
 using Moq;
 using Newtonsoft.Json;
 using Xunit;
-using YamlDotNet.Core.Tokens;
 
 namespace Microsoft.PowerApps.TestEngine.Tests.PowerApps.PowerFXModel
 {
@@ -47,8 +46,8 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerApps.PowerFXModel
 
             Assert.Equal(propertyValue, (controlRecordValue.GetField("Text") as StringValue).Value);
             Assert.Equal(numberPropertyValue, (controlRecordValue.GetField("X") as NumberValue).Value);
-            Assert.Equal(datePropertyValue.ToString(), (controlRecordValue.GetField("SelectedDate") as DateValue).Value.ToString());
-            Assert.Equal(dateTimePropertyValue.ToString(), (controlRecordValue.GetField("DefaultDate") as DateTimeValue).Value.ToString());
+            Assert.Equal(datePropertyValue.ToString(), (controlRecordValue.GetField("SelectedDate") as DateValue).GetConvertedValue(null).ToString());
+            Assert.Equal(dateTimePropertyValue.ToString(), (controlRecordValue.GetField("DefaultDate") as DateTimeValue).GetConvertedValue(null).ToString());
 
             mockPowerAppFunctions.Verify(x => x.GetPropertyValueFromControl<string>(It.Is<ItemPath>((x) => x.PropertyName == "Text" && x.ControlName == controlName)), Times.Once());
             mockPowerAppFunctions.Verify(x => x.GetPropertyValueFromControl<string>(It.Is<ItemPath>((x) => x.PropertyName == "X" && x.ControlName == controlName)), Times.Once());

--- a/src/Microsoft.PowerApps.TestEngine.Tests/PowerFx/Functions/SetPropertyFunctionTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/PowerFx/Functions/SetPropertyFunctionTests.cs
@@ -8,7 +8,6 @@ using Microsoft.Extensions.Logging;
 using Microsoft.PowerApps.TestEngine.Config;
 using Microsoft.PowerApps.TestEngine.PowerApps;
 using Microsoft.PowerApps.TestEngine.PowerApps.PowerFxModel;
-using Microsoft.PowerApps.TestEngine.PowerFx;
 using Microsoft.PowerApps.TestEngine.PowerFx.Functions;
 using Microsoft.PowerApps.TestEngine.Tests.Helpers;
 using Microsoft.PowerFx.Types;
@@ -146,7 +145,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx.Functions
 
             // check to see if the value of DatePicker1's 'Value' property is the correct datetime (01/01/2030)
             Assert.IsType<BooleanValue>(result);
-            MockPowerAppFunctions.Verify(x => x.SetPropertyAsync(It.Is<ItemPath>((item) => item.ControlName == recordValue.Name), It.Is<DateValue>(dateVal => dateVal.Value == dt)), Times.Once());
+            MockPowerAppFunctions.Verify(x => x.SetPropertyAsync(It.Is<ItemPath>((item) => item.ControlName == recordValue.Name), It.Is<DateValue>(dateVal => dateVal.GetConvertedValue(null) == dt)), Times.Once());
         }
 
         [Fact]
@@ -157,7 +156,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx.Functions
 
             // Make setPropertyFunction contain a component called Dropdown1
             var recordType = RecordType.Empty().Add("Selected", RecordType.Empty());
-            var recordValue = new ControlRecordValue(recordType, MockPowerAppFunctions.Object,"Dropdown1");
+            var recordValue = new ControlRecordValue(recordType, MockPowerAppFunctions.Object, "Dropdown1");
             var setPropertyFunction = new SetPropertyFunction(MockPowerAppFunctions.Object, MockLogger.Object);
 
             // Set the value of Dropdown1's 'Selected' property to {"Value":"2"}

--- a/src/Microsoft.PowerApps.TestEngine.Tests/PowerFx/Functions/SomeOtherUntypedObject.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/PowerFx/Functions/SomeOtherUntypedObject.cs
@@ -26,12 +26,22 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx.Functions
             throw new global::System.NotImplementedException();
         }
 
+        public decimal GetDecimal()
+        {
+            throw new global::System.NotImplementedException();
+        }
+
         public double GetDouble()
         {
             throw new global::System.NotImplementedException();
         }
 
         public string GetString()
+        {
+            throw new global::System.NotImplementedException();
+        }
+
+        public string GetUntypedNumber()
         {
             throw new global::System.NotImplementedException();
         }

--- a/src/Microsoft.PowerApps.TestEngine.Tests/PowerFx/PowerFxHelperTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/PowerFx/PowerFxHelperTests.cs
@@ -4,7 +4,6 @@
 using System.Globalization;
 using Microsoft.PowerApps.TestEngine.PowerFx;
 using Microsoft.PowerFx;
-using Microsoft.PowerFx.Preview;
 using Xunit;
 
 namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx
@@ -52,7 +51,8 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx
         public void TestFormulasSeparatedByChainingOpAreExtractedCorrectly(string locale, string expression, params string[] expectedFormulas)
         {
             // Arrange
-            FeatureFlags.StringInterpolation = true;
+            // Setting this feature flag is no longer needed
+            //FeatureFlags.StringInterpolation = true;
             var oldUICulture = CultureInfo.CurrentUICulture;
             var culture = new CultureInfo(locale);
             CultureInfo.CurrentUICulture = culture;
@@ -75,7 +75,9 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx
 
         private static Engine GetEngine(string locale)
         {
-            var recalcEngine = new RecalcEngine(new PowerFxConfig(new CultureInfo(locale)));
+            //TODO: Temporarily removed the locale input parameter from PowerFxConfig(...), make sure to add it back
+            //var recalcEngine = new RecalcEngine(new PowerFxConfig(new CultureInfo(locale)));
+            var recalcEngine = new RecalcEngine(new PowerFxConfig());
             return recalcEngine;
         }
 

--- a/src/Microsoft.PowerApps.TestEngine/PowerApps/PowerAppFunctions.cs
+++ b/src/Microsoft.PowerApps.TestEngine/PowerApps/PowerAppFunctions.cs
@@ -272,7 +272,7 @@ namespace Microsoft.PowerApps.TestEngine.PowerApps
 
                 var itemPathString = JsonConvert.SerializeObject(itemPath);
                 var propertyNameString = JsonConvert.SerializeObject(itemPath.PropertyName);
-                var recordValue = value.Value;
+                var recordValue = value.GetConvertedValue(null);
 
                 // Date.parse() parses the date to unix timestamp
                 var expression = $"PowerAppsTestEngine.setPropertyValue({itemPathString},{{{propertyNameString}:Date.parse(\"{recordValue}\")}})";

--- a/src/Microsoft.PowerApps.TestEngine/PowerFx/Functions/WaitFunction.cs
+++ b/src/Microsoft.PowerApps.TestEngine/PowerFx/Functions/WaitFunction.cs
@@ -3,7 +3,6 @@
 
 using Microsoft.Extensions.Logging;
 using Microsoft.PowerApps.TestEngine.Helpers;
-using Microsoft.PowerApps.TestEngine.PowerApps;
 using Microsoft.PowerApps.TestEngine.PowerApps.PowerFxModel;
 using Microsoft.PowerFx;
 using Microsoft.PowerFx.Types;
@@ -206,17 +205,17 @@ namespace Microsoft.PowerApps.TestEngine.PowerFx.Functions
             // Handling in the case that the property is a DateTime
             if (propType.GetType() == typeof(DateTimeValue))
             {
-                PollingCondition<DateTime>((x) => x != value.Value, () =>
+                PollingCondition<DateTime>((x) => x != value.GetConvertedValue(null), () =>
                 {
-                    return ((DateTimeValue)controlModel.GetField(propName.Value)).Value;
+                    return ((DateTimeValue)controlModel.GetField(propName.Value)).GetConvertedValue(null);
                 }, _timeout);
             }
             // Otherwise, the property should be be a Date
             else
             {
-                PollingCondition<DateTime>((x) => x != value.Value, () =>
+                PollingCondition<DateTime>((x) => x != value.GetConvertedValue(null), () =>
                 {
-                    return ((DateValue)controlModel.GetField(propName.Value)).Value;
+                    return ((DateValue)controlModel.GetField(propName.Value)).GetConvertedValue(null);
                 }, _timeout);
             }
 
@@ -249,9 +248,9 @@ namespace Microsoft.PowerApps.TestEngine.PowerFx.Functions
             // Handling in the case that the property is a DateTime
             if (propType.GetType() == typeof(DateTimeValue))
             {
-                PollingCondition<DateTime>((x) => x != value.Value, () =>
+                PollingCondition<DateTime>((x) => x != value.GetConvertedValue(null), () =>
                 {
-                    return ((DateTimeValue)controlModel.GetField(propName.Value)).Value;
+                    return ((DateTimeValue)controlModel.GetField(propName.Value)).GetConvertedValue(null);
                 }, _timeout);
 
                 _logger.LogInformation("Successfully finished executing Wait function, condition was met.");
@@ -260,9 +259,9 @@ namespace Microsoft.PowerApps.TestEngine.PowerFx.Functions
             // Handling in the case that the property is a Date
             else if (propType.GetType() == typeof(DateValue))
             {
-                PollingCondition<DateTime>((x) => x != value.Value, () =>
+                PollingCondition<DateTime>((x) => x != value.GetConvertedValue(null), () =>
                 {
-                    return ((DateValue)controlModel.GetField(propName.Value)).Value;
+                    return ((DateValue)controlModel.GetField(propName.Value)).GetConvertedValue(null);
                 }, _timeout);
 
                 _logger.LogInformation("Successfully finished executing Wait function, condition was met.");

--- a/src/Microsoft.PowerApps.TestEngine/PowerFx/PowerFxEngine.cs
+++ b/src/Microsoft.PowerApps.TestEngine/PowerFx/PowerFxEngine.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-using System.Dynamic;
 using System.Globalization;
 using Microsoft.Extensions.Logging;
 using Microsoft.PowerApps.TestEngine.Config;
@@ -11,7 +10,6 @@ using Microsoft.PowerApps.TestEngine.PowerFx.Functions;
 using Microsoft.PowerApps.TestEngine.System;
 using Microsoft.PowerApps.TestEngine.TestInfra;
 using Microsoft.PowerFx;
-using Microsoft.PowerFx.Syntax;
 using Microsoft.PowerFx.Types;
 
 namespace Microsoft.PowerApps.TestEngine.PowerFx
@@ -46,7 +44,9 @@ namespace Microsoft.PowerApps.TestEngine.PowerFx
 
         public void Setup(CultureInfo locale)
         {
-            var powerFxConfig = new PowerFxConfig(locale);
+            //TODO: Temporarily removed the locale input parameter from PowerFxConfig(...), make sure to add it back
+            //var powerFxConfig = new PowerFxConfig(locale);
+            var powerFxConfig = new PowerFxConfig();
 
             powerFxConfig.AddFunction(new SelectOneParamFunction(_powerAppFunctions, async () => await UpdatePowerFxModelAsync(), Logger));
             powerFxConfig.AddFunction(new SelectTwoParamsFunction(_powerAppFunctions, async () => await UpdatePowerFxModelAsync(), Logger));


### PR DESCRIPTION
# Description

With the upgrade to PowerFx.Interpreter from 0.2.3-preview to 0.2.6-preview, some implementation details have changed - 
1. `DateValue.Value` is now deprecated in favor of `DateValue.GetConvertedValue(timeZone)`, and if `timeZone` is `null`, it will use the local timezone. This change has been made to factor this in without change in functionality.
2. The `locale` parameter has been temporarily removed from `PowerFxConfig` constructor to unblock us from fixing other compile time errors, and work on this fix and test it in isolation.
3. The implementation of `IUntypedObject` interface has been updated per the updated interface.

Most of the checklist items are not applicable as these are in-progress changes being done on an intermediate branch to facilitate parallel efforts on the many compile time errors that this is addressing.

NOTE: This change is being merged into the intermediate feature branch currently. Once all the compile time breaking changes have been addressed and tests are passing we will merge this feature branch into main, for full review of all the compile time fixes at once.

# Checklist

- [ ] The code change is covered by unit tests. I have added tests that prove my fix is effective or that my feature works
- [ ] I have performed end-to-end test locally.
- [ ] New and existing unit tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [N/A] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I used clear names for everything
- [x] I have performed a self-review of my own code
