### PR TITLE
Support localization with updated PowerFx version

### DIFF
--- a/src/Microsoft.PowerApps.TestEngine.Tests/PowerFx/PowerFxEngineTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/PowerFx/PowerFxEngineTests.cs
@@ -115,6 +115,31 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx
         }
 
         [Fact]
+        public void ExecuteMultipleFunctionsWithDifferentLocaleTest()
+        {
+            // en-US locale
+            var culture = new CultureInfo("en-US");
+            var enUSpowerFxExpression = "1+1;2+2;";
+            var powerFxEngine = new PowerFxEngine(MockTestInfraFunctions.Object, MockPowerAppFunctions.Object, MockSingleTestInstanceState.Object, MockTestState.Object, MockFileSystem.Object);
+            powerFxEngine.Setup();
+            var enUSResult = powerFxEngine.Execute(enUSpowerFxExpression, culture);            
+
+            // fr locale
+            culture = new CultureInfo("fr");
+            var frpowerFxExpression = "1+1;;2+2;;";
+            powerFxEngine = new PowerFxEngine(MockTestInfraFunctions.Object, MockPowerAppFunctions.Object, MockSingleTestInstanceState.Object, MockTestState.Object, MockFileSystem.Object);
+            powerFxEngine.Setup();
+            var frResult = powerFxEngine.Execute(frpowerFxExpression, culture);
+
+            // Assertions
+            Assert.Equal(4, ((DecimalValue)enUSResult).Value);
+            LoggingTestHelper.VerifyLogging(MockLogger, $"Attempting:\n\n{{\n{enUSpowerFxExpression}}}", LogLevel.Trace, Times.Once());
+            Assert.Equal(4, ((DecimalValue)frResult).Value);
+            LoggingTestHelper.VerifyLogging(MockLogger, $"Attempting:\n\n{{\n{frpowerFxExpression}}}", LogLevel.Trace, Times.Once());
+        }
+
+
+        [Fact]
         public async Task ExecuteWithVariablesTest()
         {
             var recordType = RecordType.Empty().Add("Text", FormulaType.String);

--- a/src/Microsoft.PowerApps.TestEngine.Tests/PowerFx/PowerFxEngineTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/PowerFx/PowerFxEngineTests.cs
@@ -47,14 +47,14 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx
         public void SetupDoesNotThrow()
         {
             var powerFxEngine = new PowerFxEngine(MockTestInfraFunctions.Object, MockPowerAppFunctions.Object, MockSingleTestInstanceState.Object, MockTestState.Object, MockFileSystem.Object);
-            powerFxEngine.Setup(It.IsAny<CultureInfo>());
+            powerFxEngine.Setup();
         }
 
         [Fact]
         public void ExecuteThrowsOnNoSetupTest()
         {
             var powerFxEngine = new PowerFxEngine(MockTestInfraFunctions.Object, MockPowerAppFunctions.Object, MockSingleTestInstanceState.Object, MockTestState.Object, MockFileSystem.Object);
-            Assert.Throws<InvalidOperationException>(() => powerFxEngine.Execute(""));
+            Assert.Throws<InvalidOperationException>(() => powerFxEngine.Execute("", It.IsAny<CultureInfo>()));
             LoggingTestHelper.VerifyLogging(MockLogger, "Engine is null, make sure to call Setup first", LogLevel.Error, Times.Once());
         }
 
@@ -80,7 +80,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx
             MockTestState.Setup(x => x.GetTestSettings()).Returns(testSettings);
 
             var powerFxEngine = new PowerFxEngine(MockTestInfraFunctions.Object, MockPowerAppFunctions.Object, MockSingleTestInstanceState.Object, MockTestState.Object, MockFileSystem.Object);
-            powerFxEngine.Setup(It.IsAny<CultureInfo>());
+            powerFxEngine.Setup();
             await Assert.ThrowsAsync<TimeoutException>(() => powerFxEngine.UpdatePowerFxModelAsync());
             LoggingTestHelper.VerifyLogging(MockLogger, "Something went wrong when Test Engine tried to get App status.", LogLevel.Error, Times.Once());
         }
@@ -89,13 +89,13 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx
         public void ExecuteOneFunctionTest()
         {
             var powerFxEngine = new PowerFxEngine(MockTestInfraFunctions.Object, MockPowerAppFunctions.Object, MockSingleTestInstanceState.Object, MockTestState.Object, MockFileSystem.Object);
-            powerFxEngine.Setup(It.IsAny<CultureInfo>());
-            var result = powerFxEngine.Execute("1+1");
-            Assert.Equal(2, ((NumberValue)result).Value);
+            powerFxEngine.Setup();
+            var result = powerFxEngine.Execute("1+1", new CultureInfo("en-US"));
+            Assert.Equal(2, ((DecimalValue)result).Value);
             LoggingTestHelper.VerifyLogging(MockLogger, "Attempting:\n\n{\n1+1}", LogLevel.Trace, Times.Once());
 
-            result = powerFxEngine.Execute("=1+1");
-            Assert.Equal(2, ((NumberValue)result).Value);
+            result = powerFxEngine.Execute("=1+1", new CultureInfo("en-US"));
+            Assert.Equal(2, ((DecimalValue)result).Value);
             LoggingTestHelper.VerifyLogging(MockLogger, "Attempting:\n\n{\n1+1}", LogLevel.Trace, Times.Exactly(2));
         }
 
@@ -104,12 +104,12 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx
         {
             var powerFxExpression = "1+1; //some comment \n 2+2;\n Concatenate(\"hello\", \"world\");";
             var powerFxEngine = new PowerFxEngine(MockTestInfraFunctions.Object, MockPowerAppFunctions.Object, MockSingleTestInstanceState.Object, MockTestState.Object, MockFileSystem.Object);
-            powerFxEngine.Setup(It.IsAny<CultureInfo>());
-            var result = powerFxEngine.Execute(powerFxExpression);
+            powerFxEngine.Setup();
+            var result = powerFxEngine.Execute(powerFxExpression, It.IsAny<CultureInfo>());
             Assert.Equal("helloworld", ((StringValue)result).Value);
             LoggingTestHelper.VerifyLogging(MockLogger, $"Attempting:\n\n{{\n{powerFxExpression}}}", LogLevel.Trace, Times.Once());
 
-            result = powerFxEngine.Execute($"={powerFxExpression}");
+            result = powerFxEngine.Execute($"={powerFxExpression}", It.IsAny<CultureInfo>());
             Assert.Equal("helloworld", ((StringValue)result).Value);
             LoggingTestHelper.VerifyLogging(MockLogger, $"Attempting:\n\n{{\n{powerFxExpression}}}", LogLevel.Trace, Times.Exactly(2));
         }
@@ -154,18 +154,18 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx
             MockTestState.Setup(x => x.GetTestSettings()).Returns(testSettings);
 
             var powerFxEngine = new PowerFxEngine(MockTestInfraFunctions.Object, MockPowerAppFunctions.Object, MockSingleTestInstanceState.Object, MockTestState.Object, MockFileSystem.Object);
-            powerFxEngine.Setup(It.IsAny<CultureInfo>());
+            powerFxEngine.Setup();
             await powerFxEngine.UpdatePowerFxModelAsync();
 
             MockPowerAppFunctions.Verify(x => x.LoadPowerAppsObjectModelAsync(), Times.Once());
 
-            var result = powerFxEngine.Execute(powerFxExpression);
+            var result = powerFxEngine.Execute(powerFxExpression, It.IsAny<CultureInfo>());
             Assert.Equal($"{label1Text}{label2Text}", ((StringValue)result).Value);
             LoggingTestHelper.VerifyLogging(MockLogger, $"Attempting:\n\n{{\n{powerFxExpression}}}", LogLevel.Trace, Times.Once());
             MockPowerAppFunctions.Verify(x => x.GetPropertyValueFromControl<string>(It.Is<ItemPath>((itemPath) => itemPath.ControlName == label1ItemPath.ControlName && itemPath.PropertyName == label1ItemPath.PropertyName)), Times.Once());
             MockPowerAppFunctions.Verify(x => x.GetPropertyValueFromControl<string>(It.Is<ItemPath>((itemPath) => itemPath.ControlName == label2ItemPath.ControlName && itemPath.PropertyName == label2ItemPath.PropertyName)), Times.Once());
 
-            result = powerFxEngine.Execute($"={powerFxExpression}");
+            result = powerFxEngine.Execute($"={powerFxExpression}", It.IsAny<CultureInfo>());
             Assert.Equal($"{label1Text}{label2Text}", ((StringValue)result).Value);
             LoggingTestHelper.VerifyLogging(MockLogger, $"Attempting:\n\n{{\n{powerFxExpression}}}", LogLevel.Trace, Times.Exactly(2));
             MockPowerAppFunctions.Verify(x => x.GetPropertyValueFromControl<string>(It.Is<ItemPath>((itemPath) => itemPath.ControlName == label1ItemPath.ControlName && itemPath.PropertyName == label1ItemPath.PropertyName)), Times.Exactly(2));
@@ -178,8 +178,8 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx
             var powerFxExpression = "someNonExistentPowerFxFunction(1, 2, 3)";
             MockPowerAppFunctions.Setup(x => x.LoadPowerAppsObjectModelAsync()).Returns(Task.FromResult(new Dictionary<string, ControlRecordValue>()));
             var powerFxEngine = new PowerFxEngine(MockTestInfraFunctions.Object, MockPowerAppFunctions.Object, MockSingleTestInstanceState.Object, MockTestState.Object, MockFileSystem.Object);
-            powerFxEngine.Setup(CultureInfo.CurrentCulture);
-            Assert.ThrowsAsync<Exception>(async () => await powerFxEngine.ExecuteWithRetryAsync(powerFxExpression));
+            powerFxEngine.Setup();
+            Assert.ThrowsAsync<Exception>(async () => await powerFxEngine.ExecuteWithRetryAsync(powerFxExpression, It.IsAny<CultureInfo>()));
         }
 
         [Fact]
@@ -187,8 +187,8 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx
         {
             var powerFxExpression = "Concatenate(Label1.Text, Label2.Text)";
             var powerFxEngine = new PowerFxEngine(MockTestInfraFunctions.Object, MockPowerAppFunctions.Object, MockSingleTestInstanceState.Object, MockTestState.Object, MockFileSystem.Object);
-            powerFxEngine.Setup(It.IsAny<CultureInfo>());
-            Assert.ThrowsAsync<Exception>(async () => await powerFxEngine.ExecuteWithRetryAsync(powerFxExpression));
+            powerFxEngine.Setup();
+            Assert.ThrowsAsync<Exception>(async () => await powerFxEngine.ExecuteWithRetryAsync(powerFxExpression, It.IsAny<CultureInfo>()));
         }
 
         [Fact]
@@ -196,12 +196,12 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx
         {
             var powerFxExpression = "Assert(1+1=2, \"Adding 1 + 1\")";
             var powerFxEngine = new PowerFxEngine(MockTestInfraFunctions.Object, MockPowerAppFunctions.Object, MockSingleTestInstanceState.Object, MockTestState.Object, MockFileSystem.Object);
-            powerFxEngine.Setup(It.IsAny<CultureInfo>());
-            var result = powerFxEngine.Execute(powerFxExpression);
+            powerFxEngine.Setup();
+            var result = powerFxEngine.Execute(powerFxExpression, It.IsAny<CultureInfo>());
             Assert.IsType<BlankValue>(result);
 
             var failingPowerFxExpression = "Assert(1+1=3, \"Supposed to fail\")";
-            Assert.ThrowsAny<Exception>(() => powerFxEngine.Execute(failingPowerFxExpression));
+            Assert.ThrowsAny<Exception>(() => powerFxEngine.Execute(failingPowerFxExpression, It.IsAny<CultureInfo>()));
         }
 
         [Fact]
@@ -212,12 +212,12 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx
             MockTestInfraFunctions.Setup(x => x.ScreenshotAsync(It.IsAny<string>())).Returns(Task.CompletedTask);
             var powerFxExpression = "Screenshot(\"1.jpg\")";
             var powerFxEngine = new PowerFxEngine(MockTestInfraFunctions.Object, MockPowerAppFunctions.Object, MockSingleTestInstanceState.Object, MockTestState.Object, MockFileSystem.Object);
-            powerFxEngine.Setup(It.IsAny<CultureInfo>());
-            var result = powerFxEngine.Execute(powerFxExpression);
+            powerFxEngine.Setup();
+            var result = powerFxEngine.Execute(powerFxExpression, It.IsAny<CultureInfo>());
             Assert.IsType<BlankValue>(result);
 
             var failingPowerFxExpression = "Screenshot(\"1.txt\")";
-            Assert.ThrowsAny<Exception>(() => powerFxEngine.Execute(failingPowerFxExpression));
+            Assert.ThrowsAny<Exception>(() => powerFxEngine.Execute(failingPowerFxExpression, It.IsAny<CultureInfo>()));
         }
 
         [Fact]
@@ -235,10 +235,10 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx
 
             var powerFxExpression = "Select(Button1)";
             var powerFxEngine = new PowerFxEngine(MockTestInfraFunctions.Object, MockPowerAppFunctions.Object, MockSingleTestInstanceState.Object, MockTestState.Object, MockFileSystem.Object);
-            powerFxEngine.Setup(It.IsAny<CultureInfo>());
+            powerFxEngine.Setup();
             await powerFxEngine.UpdatePowerFxModelAsync();
-            await powerFxEngine.ExecuteWithRetryAsync(powerFxExpression);
-            var result = powerFxEngine.Execute(powerFxExpression);
+            await powerFxEngine.ExecuteWithRetryAsync(powerFxExpression, It.IsAny<CultureInfo>());
+            var result = powerFxEngine.Execute(powerFxExpression, It.IsAny<CultureInfo>());
             Assert.IsType<BlankValue>(result);
             MockPowerAppFunctions.Verify(x => x.LoadPowerAppsObjectModelAsync(), Times.Exactly(3));
         }
@@ -259,9 +259,9 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx
 
             var powerFxExpression = "Select(Button1)";
             var powerFxEngine = new PowerFxEngine(MockTestInfraFunctions.Object, MockPowerAppFunctions.Object, MockSingleTestInstanceState.Object, MockTestState.Object, MockFileSystem.Object);
-            powerFxEngine.Setup(It.IsAny<CultureInfo>());
+            powerFxEngine.Setup();
             await powerFxEngine.UpdatePowerFxModelAsync();
-            Assert.ThrowsAny<Exception>(() => powerFxEngine.Execute(powerFxExpression));
+            Assert.ThrowsAny<Exception>(() => powerFxEngine.Execute(powerFxExpression, It.IsAny<CultureInfo>()));
             MockPowerAppFunctions.Verify(x => x.LoadPowerAppsObjectModelAsync(), Times.Once());
         }
 
@@ -280,9 +280,9 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx
 
             var powerFxExpression = "Select(Button1)";
             var powerFxEngine = new PowerFxEngine(MockTestInfraFunctions.Object, MockPowerAppFunctions.Object, MockSingleTestInstanceState.Object, MockTestState.Object, MockFileSystem.Object);
-            powerFxEngine.Setup(It.IsAny<CultureInfo>());
+            powerFxEngine.Setup();
             await powerFxEngine.UpdatePowerFxModelAsync();
-            Assert.ThrowsAny<Exception>(() => powerFxEngine.Execute(powerFxExpression));
+            Assert.ThrowsAny<Exception>(() => powerFxEngine.Execute(powerFxExpression, It.IsAny<CultureInfo>()));
             MockPowerAppFunctions.Verify(x => x.LoadPowerAppsObjectModelAsync(), Times.Once());
         }
 
@@ -303,10 +303,10 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx
             var powerFxExpression = "SetProperty(Button1.Text, \"10\")";
             var powerFxEngine = new PowerFxEngine(MockTestInfraFunctions.Object, MockPowerAppFunctions.Object, MockSingleTestInstanceState.Object, MockTestState.Object, MockFileSystem.Object);
 
-            powerFxEngine.Setup(It.IsAny<CultureInfo>());
+            powerFxEngine.Setup();
             await powerFxEngine.UpdatePowerFxModelAsync();
-            await powerFxEngine.ExecuteWithRetryAsync(powerFxExpression);
-            var result = powerFxEngine.Execute(powerFxExpression);
+            await powerFxEngine.ExecuteWithRetryAsync(powerFxExpression, It.IsAny<CultureInfo>());
+            var result = powerFxEngine.Execute(powerFxExpression, It.IsAny<CultureInfo>());
             Assert.IsType<BooleanValue>(result);
             MockPowerAppFunctions.Verify(x => x.LoadPowerAppsObjectModelAsync(), Times.Once());
         }
@@ -327,9 +327,9 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx
             var powerFxExpression = "SetProperty(Button1.Text, \"10\")";
             var powerFxEngine = new PowerFxEngine(MockTestInfraFunctions.Object, MockPowerAppFunctions.Object, MockSingleTestInstanceState.Object, MockTestState.Object, MockFileSystem.Object);
 
-            powerFxEngine.Setup(It.IsAny<CultureInfo>());
+            powerFxEngine.Setup();
             await powerFxEngine.UpdatePowerFxModelAsync();
-            Assert.ThrowsAny<Exception>(() => powerFxEngine.Execute(powerFxExpression));
+            Assert.ThrowsAny<Exception>(() => powerFxEngine.Execute(powerFxExpression, It.IsAny<CultureInfo>()));
             MockPowerAppFunctions.Verify(x => x.LoadPowerAppsObjectModelAsync(), Times.Once());
         }
 
@@ -360,10 +360,10 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx
 
             var powerFxExpression = "Wait(Label1, \"Text\", \"1\")";
             var powerFxEngine = new PowerFxEngine(MockTestInfraFunctions.Object, MockPowerAppFunctions.Object, MockSingleTestInstanceState.Object, MockTestState.Object, MockFileSystem.Object);
-            powerFxEngine.Setup(It.IsAny<CultureInfo>());
+            powerFxEngine.Setup();
             await powerFxEngine.UpdatePowerFxModelAsync();
-            await powerFxEngine.ExecuteWithRetryAsync(powerFxExpression);
-            var result = powerFxEngine.Execute(powerFxExpression);
+            await powerFxEngine.ExecuteWithRetryAsync(powerFxExpression, It.IsAny<CultureInfo>());
+            var result = powerFxEngine.Execute(powerFxExpression, It.IsAny<CultureInfo>());
             Assert.IsType<BlankValue>(result);
             MockPowerAppFunctions.Verify(x => x.LoadPowerAppsObjectModelAsync(), Times.Once());
         }
@@ -383,9 +383,9 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx
 
             var powerFxExpression = "Wait(Label1, \"Text\", \"1\")";
             var powerFxEngine = new PowerFxEngine(MockTestInfraFunctions.Object, MockPowerAppFunctions.Object, MockSingleTestInstanceState.Object, MockTestState.Object, MockFileSystem.Object);
-            powerFxEngine.Setup(It.IsAny<CultureInfo>());
+            powerFxEngine.Setup();
             await powerFxEngine.UpdatePowerFxModelAsync();
-            Assert.ThrowsAny<Exception>(() => powerFxEngine.Execute(powerFxExpression));
+            Assert.ThrowsAny<Exception>(() => powerFxEngine.Execute(powerFxExpression, It.IsAny<CultureInfo>()));
             MockPowerAppFunctions.Verify(x => x.LoadPowerAppsObjectModelAsync(), Times.Once());
         }
 
@@ -426,7 +426,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx
             var oldUICulture = CultureInfo.CurrentUICulture;
             var frenchCulture = new CultureInfo("fr");
             CultureInfo.CurrentUICulture = frenchCulture;
-            powerFxEngine.Setup(frenchCulture);
+            powerFxEngine.Setup();
             var testSettings = new TestSettings() { Timeout = 3000 };
             MockTestState.Setup(x => x.GetTestSettings()).Returns(testSettings);
             var expression = "Select(Label1/*Label;;22*/);;\"Just stirng \n;literal\";;Select(Label2)\n;;Select(Label3);;Assert(1=1; \"Supposed to pass;;\");;Max(1,2)";
@@ -435,9 +435,9 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx
 
             // Engine.Eval should throw an exception when none of the used first names exist in the underlying symbol table yet.
             // This confirms that we would be hitting goStepByStep branch
-            Assert.ThrowsAny<Exception>(() => powerFxEngine.Execute(expression));
+            Assert.ThrowsAny<Exception>(() => powerFxEngine.Execute(expression, frenchCulture));
             await powerFxEngine.UpdatePowerFxModelAsync();
-            var result = powerFxEngine.Execute(expression);
+            var result = powerFxEngine.Execute(expression, frenchCulture);
 
             try
             {
@@ -450,8 +450,8 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx
 
             // Assert
             Assert.Equal(2, updateCounter);
-            Assert.Equal(FormulaType.Number, result.Type);
-            Assert.Equal(1.2, (result as NumberValue).Value);
+            Assert.Equal(FormulaType.Decimal, result.Type);
+            Assert.Equal("1.2", (result as DecimalValue).Value.ToString());
             LoggingTestHelper.VerifyLogging(MockLogger, $"Syntax check failed. Now attempting to execute lines step by step", LogLevel.Debug, Times.Exactly(2));
         }
 

--- a/src/Microsoft.PowerApps.TestEngine.Tests/PowerFx/PowerFxEngineTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/PowerFx/PowerFxEngineTests.cs
@@ -138,7 +138,6 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx
             LoggingTestHelper.VerifyLogging(MockLogger, $"Attempting:\n\n{{\n{frpowerFxExpression}}}", LogLevel.Trace, Times.Once());
         }
 
-
         [Fact]
         public async Task ExecuteWithVariablesTest()
         {

--- a/src/Microsoft.PowerApps.TestEngine.Tests/PowerFx/PowerFxHelperTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/PowerFx/PowerFxHelperTests.cs
@@ -39,13 +39,11 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx
         [InlineData("en-US", "Max(;;;1,2)", "Max(;;;1,2)")]
         [InlineData("en-US", ";;;;", "", "", "", "")]
         [InlineData("en-US", "")]
-        [InlineData("en-US", "Max(;22)", "Max(", "22)")]
+        [InlineData("en-US", "Max(;22)", "Max(;22)")]
         [InlineData("en-US", "Select(Button1/*Selecting button 1;;;*/);Assert(Button1.Text = Text(\"Ab\";\"Abcd\"))", "Select(Button1/*Selecting button 1;;;*/)", "Assert(Button1.Text = Text(\"Ab\";\"Abcd\"))")]
         [InlineData("en-US", "Select(Button1)", "Select(Button1)")]
         [InlineData("fr", "Max(1;;2;;3;30;;Max(230;;23;;33);;3)", "Max(1;;2;;3;30;;Max(230;;23;;33);;3)")]
-        // Once new powerfx version is consumed, this would fail due to recent PowerFx Lexer changes
-        // Fix would be to this to InlineData("en-US", "'Test;2212", "'Test", "2212")
-        [InlineData("en-US", "'Test;2212", "'Test;2212")]
+        [InlineData("en-US", "'Test;2212", "'Test", "2212")]
         [InlineData("en-US", "'Test;;2333';Max(1;'Button1;Button2';23;/*\n\n;;Comment\n\n*/33,100;Max(100;200,20;30)))", "'Test;;2333'", "Max(1;'Button1;Button2';23;/*\n\n;;Comment\n\n*/33,100;Max(100;200,20;30)))")]
         [InlineData("en-US", "'Test;;2333';Max(1;'Button1;Button2';23;/*\n\n;;Comment\n\n33,100;Max(100;200,20;30)))", "'Test;;2333'", "Max(1;'Button1;Button2';23;/*\n\n;;Comment\n\n33,100;Max(100;200,20;30)))")]
         public void TestFormulasSeparatedByChainingOpAreExtractedCorrectly(string locale, string expression, params string[] expectedFormulas)
@@ -59,7 +57,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx
             var (result, engine) = GetCheckResultAndEngine(expression, locale);
 
             // Act
-            var actualFormulas = PowerFxHelper.ExtractFormulasSeparatedByChainingOperator(engine, result);
+            var actualFormulas = PowerFxHelper.ExtractFormulasSeparatedByChainingOperator(engine, result, culture);
 
             // Assert
             try

--- a/src/Microsoft.PowerApps.TestEngine.Tests/SingleTestRunnerTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/SingleTestRunnerTests.cs
@@ -88,9 +88,9 @@ namespace Microsoft.PowerApps.TestEngine.Tests
 
 
             var locale = string.IsNullOrEmpty(testSuitelocale) ? CultureInfo.CurrentCulture : new CultureInfo(testSuitelocale);
-            MockPowerFxEngine.Setup(x => x.Setup(locale));
+            MockPowerFxEngine.Setup(x => x.Setup());
             MockPowerFxEngine.Setup(x => x.UpdatePowerFxModelAsync()).Returns(Task.CompletedTask);
-            MockPowerFxEngine.Setup(x => x.Execute(It.IsAny<string>())).Returns(FormulaValue.NewBlank());
+            MockPowerFxEngine.Setup(x => x.Execute(It.IsAny<string>(), It.IsAny<CultureInfo>())).Returns(FormulaValue.NewBlank());
 
             MockTestEngineEventHandler.Setup(x => x.SetAndInitializeCounters(It.IsAny<int>()));
             MockTestEngineEventHandler.Setup(x => x.EncounteredException(It.IsAny<Exception>()));
@@ -101,11 +101,11 @@ namespace Microsoft.PowerApps.TestEngine.Tests
 
             if (powerFxTestSuccess)
             {
-                MockPowerFxEngine.Setup(x => x.ExecuteWithRetryAsync(It.IsAny<string>())).Returns(Task.CompletedTask);
+                MockPowerFxEngine.Setup(x => x.ExecuteWithRetryAsync(It.IsAny<string>(), It.IsAny<CultureInfo>())).Returns(Task.CompletedTask);
             }
             else
             {
-                MockPowerFxEngine.Setup(x => x.ExecuteWithRetryAsync(It.IsAny<string>())).Throws(new Exception("something bad happened"));
+                MockPowerFxEngine.Setup(x => x.ExecuteWithRetryAsync(It.IsAny<string>(), It.IsAny<CultureInfo>())).Throws(new Exception("something bad happened"));
             }
             MockPowerFxEngine.Setup(x => x.GetPowerAppFunctions()).Returns(MockPowerAppFunctions.Object);
 
@@ -138,7 +138,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
         private void VerifySuccessfulTestExecution(string testResultDirectory, TestSuiteDefinition testSuiteDefinition, BrowserConfiguration browserConfig,
             string testSuiteId, string testRunId, string testId, bool testSuccess, string[]? additionalFiles, string? errorMessage, string? stackTrace, string appUrl, CultureInfo locale)
         {
-            MockPowerFxEngine.Verify(x => x.Setup(locale), Times.Once());
+            MockPowerFxEngine.Verify(x => x.Setup(), Times.Once());
             MockPowerFxEngine.Verify(x => x.UpdatePowerFxModelAsync(), Times.Once());
             MockTestInfraFunctions.Verify(x => x.SetupAsync(), Times.Once());
             MockUserManager.Verify(x => x.LoginAsUserAsync(appUrl), Times.Once());
@@ -328,7 +328,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
         {
             await SingleTestRunnerHandlesExceptionsThrownCorrectlyHelper((Exception exceptionToThrow) =>
             {
-                MockPowerFxEngine.Setup(x => x.Setup(It.IsAny<CultureInfo>())).Throws(exceptionToThrow);
+                MockPowerFxEngine.Setup(x => x.Setup()).Throws(exceptionToThrow);
             });
         }
 
@@ -404,7 +404,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
 
             var exceptionToThrow = new InvalidOperationException("Test exception");
 
-            MockPowerFxEngine.Setup(x => x.Execute(It.IsAny<string>())).Throws(exceptionToThrow);
+            MockPowerFxEngine.Setup(x => x.Execute(It.IsAny<string>(), It.IsAny<CultureInfo>())).Throws(exceptionToThrow);
 
             var locale = string.IsNullOrEmpty(testData.testSuiteLocale) ? CultureInfo.CurrentCulture : new CultureInfo(testData.testSuiteLocale);
 

--- a/src/Microsoft.PowerApps.TestEngine/PowerFx/IPowerFxEngine.cs
+++ b/src/Microsoft.PowerApps.TestEngine/PowerFx/IPowerFxEngine.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 using System.Globalization;
+using System.Text.RegularExpressions;
 using Microsoft.PowerApps.TestEngine.PowerApps;
 using Microsoft.PowerFx.Types;
 
@@ -14,23 +15,24 @@ namespace Microsoft.PowerApps.TestEngine.PowerFx
     {
         /// <summary>
         /// Set up the Power FX engine
-        /// </summary>
-        /// <param name="locale">The locale to be used when setting up the Power FX engine. This is typically provided by the test plan file</param>
-        public void Setup(CultureInfo locale);
+        /// </summary>       
+        public void Setup();
 
         /// <summary>
         /// Executes testSteps with retry
         /// </summary>
         /// <param name="testSteps">Test steps</param>
+        /// <param name="culture">The locale to be used when excecuting tests. This is typically provided by the test plan file</param>
         /// <returns>A task</returns>
-        public Task ExecuteWithRetryAsync(string testSteps);
+        public Task ExecuteWithRetryAsync(string testSteps, CultureInfo culture);
 
         /// <summary>
         /// Executes a list of Power FX functions
         /// </summary>
         /// <param name="testSteps">Test steps</param>
+        /// <param name="culture">The locale to be when excecuting tests. This is typically provided by the test plan file</param>
         /// <returns>Result of the Power FX.</returns>
-        public FormulaValue Execute(string testSteps);
+        public FormulaValue Execute(string testSteps, CultureInfo culture);
 
         /// <summary>
         /// Update the Power FX object model

--- a/src/Microsoft.PowerApps.TestEngine/PowerFx/PowerFxHelper.cs
+++ b/src/Microsoft.PowerApps.TestEngine/PowerFx/PowerFxHelper.cs
@@ -20,7 +20,7 @@ namespace Microsoft.PowerApps.TestEngine.PowerFx
         /// <param name="result">Check result instance created after processing the expression</param>
         /// <param name="culture">The locale to be used when excecuting tests</param>
         /// <returns>An enumerable of formulas extracted from the expression that are separated by chaining operator</returns>
-        public static IEnumerable<string> ExtractFormulasSeparatedByChainingOperator(Engine engine, CheckResult result, CultureInfo culture = null)
+        public static IEnumerable<string> ExtractFormulasSeparatedByChainingOperator(Engine engine, CheckResult result, CultureInfo culture)
         {
             if (string.IsNullOrEmpty(result?.Parse?.Text))
             {
@@ -44,7 +44,7 @@ namespace Microsoft.PowerApps.TestEngine.PowerFx
         /// <param name="expression">Expression from which formulas separated by chaining operator would be extracted</param>
         /// <param name="culture">The locale to be used when excecuting tests</param>
         /// <returns>Spans that represent formulas separated by chaining operator at multiple levels and depths</returns>
-        private static IEnumerable<Span> ExtractSpansOfFormulasSeparatedByChainingOperator(Engine engine, string expression, CultureInfo culture = null)
+        private static IEnumerable<Span> ExtractSpansOfFormulasSeparatedByChainingOperator(Engine engine, string expression, CultureInfo culture)
         {
             var chainOperatorTokens = engine.Tokenize(expression, culture).Where(tok => tok.Kind == TokKind.Semicolon).OrderBy(tok => tok.Span.Min);
             var formulas = new List<Span>();

--- a/src/Microsoft.PowerApps.TestEngine/PowerFx/PowerFxHelper.cs
+++ b/src/Microsoft.PowerApps.TestEngine/PowerFx/PowerFxHelper.cs
@@ -46,8 +46,6 @@ namespace Microsoft.PowerApps.TestEngine.PowerFx
         /// <returns>Spans that represent formulas separated by chaining operator at multiple levels and depths</returns>
         private static IEnumerable<Span> ExtractSpansOfFormulasSeparatedByChainingOperator(Engine engine, string expression, CultureInfo culture = null)
         {
-
-            var resultp = engine.Tokenize(expression, culture);
             var chainOperatorTokens = engine.Tokenize(expression, culture).Where(tok => tok.Kind == TokKind.Semicolon).OrderBy(tok => tok.Span.Min);
             var formulas = new List<Span>();
             var lowerBound = 0;

--- a/src/Microsoft.PowerApps.TestEngine/PowerFx/PowerFxHelper.cs
+++ b/src/Microsoft.PowerApps.TestEngine/PowerFx/PowerFxHelper.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+using System.Globalization;
 using Microsoft.PowerFx;
 using Microsoft.PowerFx.Syntax;
 
@@ -17,15 +18,16 @@ namespace Microsoft.PowerApps.TestEngine.PowerFx
         /// </summary>
         /// <param name="engine">Instance of an engine configured with the desired locale</param>
         /// <param name="result">Check result instance created after processing the expression</param>
+        /// <param name="culture">The locale to be used when excecuting tests</param>
         /// <returns>An enumerable of formulas extracted from the expression that are separated by chaining operator</returns>
-        public static IEnumerable<string> ExtractFormulasSeparatedByChainingOperator(Engine engine, CheckResult result)
+        public static IEnumerable<string> ExtractFormulasSeparatedByChainingOperator(Engine engine, CheckResult result, CultureInfo culture = null)
         {
             if (string.IsNullOrEmpty(result?.Parse?.Text))
             {
                 return new string[0];
             }
 
-            var spansForFormulasSeparatedAcrossMultipleDepths = ExtractSpansOfFormulasSeparatedByChainingOperator(engine, result?.Parse.Text);
+            var spansForFormulasSeparatedAcrossMultipleDepths = ExtractSpansOfFormulasSeparatedByChainingOperator(engine, result?.Parse.Text, culture);
             if (result?.Parse?.Root == null)
             {
                 return spansForFormulasSeparatedAcrossMultipleDepths.Select(span => result.Parse.Text.Substring(span.Start, span.End - span.Start));
@@ -40,10 +42,13 @@ namespace Microsoft.PowerApps.TestEngine.PowerFx
         /// </summary>
         /// <param name="engine">Instance of an engine configured with the desired locale</param>
         /// <param name="expression">Expression from which formulas separated by chaining operator would be extracted</param>
+        /// <param name="culture">The locale to be used when excecuting tests</param>
         /// <returns>Spans that represent formulas separated by chaining operator at multiple levels and depths</returns>
-        private static IEnumerable<Span> ExtractSpansOfFormulasSeparatedByChainingOperator(Engine engine, string expression)
+        private static IEnumerable<Span> ExtractSpansOfFormulasSeparatedByChainingOperator(Engine engine, string expression, CultureInfo culture = null)
         {
-            var chainOperatorTokens = engine.Tokenize(expression).Where(tok => tok.Kind == TokKind.Semicolon).OrderBy(tok => tok.Span.Min);
+
+            var resultp = engine.Tokenize(expression, culture);
+            var chainOperatorTokens = engine.Tokenize(expression, culture).Where(tok => tok.Kind == TokKind.Semicolon).OrderBy(tok => tok.Span.Min);
             var formulas = new List<Span>();
             var lowerBound = 0;
 

--- a/src/Microsoft.PowerApps.TestEngine/SingleTestRunner.cs
+++ b/src/Microsoft.PowerApps.TestEngine/SingleTestRunner.cs
@@ -127,7 +127,7 @@ namespace Microsoft.PowerApps.TestEngine
                 await _testInfraFunctions.SetupNetworkRequestMockAsync();
 
                 // Set up Power Fx
-                _powerFxEngine.Setup(locale);
+                _powerFxEngine.Setup();
                 await _powerFxEngine.UpdatePowerFxModelAsync();
 
                 allTestsSkipped = false;
@@ -159,15 +159,15 @@ namespace Microsoft.PowerApps.TestEngine
                             if (!string.IsNullOrEmpty(testSuiteDefinition.OnTestCaseStart))
                             {
                                 Logger.LogInformation($"Running OnTestCaseStart for test case: {testCase.TestCaseName}");
-                                await _powerFxEngine.ExecuteWithRetryAsync(testSuiteDefinition.OnTestCaseStart);
+                                await _powerFxEngine.ExecuteWithRetryAsync(testSuiteDefinition.OnTestCaseStart, locale);
                             }
 
-                            await _powerFxEngine.ExecuteWithRetryAsync(testCase.TestSteps);
+                            await _powerFxEngine.ExecuteWithRetryAsync(testCase.TestSteps, locale);
 
                             if (!string.IsNullOrEmpty(testSuiteDefinition.OnTestCaseComplete))
                             {
                                 Logger.LogInformation($"Running OnTestCaseComplete for test case: {testCase.TestCaseName}");
-                                await _powerFxEngine.ExecuteWithRetryAsync(testSuiteDefinition.OnTestCaseComplete);
+                                await _powerFxEngine.ExecuteWithRetryAsync(testSuiteDefinition.OnTestCaseComplete, locale);
                             }
 
                             _eventHandler.TestCaseEnd(true);
@@ -219,7 +219,7 @@ namespace Microsoft.PowerApps.TestEngine
                 {
                     Logger.LogInformation($"Running OnTestSuiteComplete for test suite: {testSuiteName}");
                     _testState.SetTestResultsDirectory(testResultDirectory);
-                    _powerFxEngine.Execute(testSuiteDefinition.OnTestSuiteComplete);
+                    _powerFxEngine.Execute(testSuiteDefinition.OnTestSuiteComplete, locale);
                 }
             }
             catch (Exception ex)


### PR DESCRIPTION
**With Power Fx Interpreter version 0.2.6-preview**
PowerFxConfig constructor to no longer accept Locale as an input parameter.  This immediately breaks Test Engine's support for localization in Test Plans. The PowerFx PR with the changes >> https://github.com/microsoft/Power-Fx/pull/1292/files#diff-9022339f3f8c7c746994da6ac3f95ec05eadaaae5a3eb5ddd7691a226af4a279. 

**Problem to Solve**
 Support localization in Test Engine.
 
**Proposal**
Supporting 2 current scenarios

1.  Running teststeps with no syntax errors (Run engine.eval once for multiple test steps)
    - Pass **locale** as a ParseOption within Microsoft.PowerFx.RecalcEngine.Eval() when executing test steps
2. Running teststeps with syntax errors (Run engine.eval step by step)
    - Pass **locale** when spliting test steps >> PowerFxHelper.ExtractFormulasSeparatedByChainingOperator()
             - Here this **locale** is used even during tokenize (https://github.com/microsoft/Power-Fx/blob/main/src/libraries/Microsoft.PowerFx.Core/Public/Engine.cs :Tokenize() method supports CultureInfo with the updated PowerFx version)
    - Pass **locale**  as a ParseOption within Microsoft.PowerFx.RecalcEngine.Eval() when executing test steps 
## Checklist

- [x] The code change is covered by unit tests. I have added tests that prove my fix is effective or that my feature works
- [x] I have performed end-to-end test locally.
- [x] New and existing unit tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I used clear names for everything
- [x] I have performed a self-review of my own code
