### PR TITLE
Implementing ready function

### DIFF
--- a/src/Microsoft.PowerApps.TestEngine.Tests/PowerApps/PowerAppFunctionsTest.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/PowerApps/PowerAppFunctionsTest.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Dynamic;
-using System.Linq.Expressions;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.PowerApps.TestEngine.Config;
@@ -14,7 +13,6 @@ using Microsoft.PowerApps.TestEngine.TestInfra;
 using Microsoft.PowerApps.TestEngine.Tests.Helpers;
 using Microsoft.PowerFx.Types;
 using Moq;
-using Moq.Protected;
 using Newtonsoft.Json;
 using Xunit;
 

--- a/src/Microsoft.PowerApps.TestEngine.Tests/SingleTestRunnerTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/SingleTestRunnerTests.cs
@@ -89,6 +89,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
 
             var locale = string.IsNullOrEmpty(testSuitelocale) ? CultureInfo.CurrentCulture : new CultureInfo(testSuitelocale);
             MockPowerFxEngine.Setup(x => x.Setup(locale));
+            MockPowerFxEngine.Setup(x => x.RunRequirementsCheckAsync()).Returns(Task.CompletedTask);
             MockPowerFxEngine.Setup(x => x.UpdatePowerFxModelAsync()).Returns(Task.CompletedTask);
             MockPowerFxEngine.Setup(x => x.Execute(It.IsAny<string>())).Returns(FormulaValue.NewBlank());
 

--- a/src/Microsoft.PowerApps.TestEngine/PowerApps/IPowerAppFunctions.cs
+++ b/src/Microsoft.PowerApps.TestEngine/PowerApps/IPowerAppFunctions.cs
@@ -63,5 +63,11 @@ namespace Microsoft.PowerApps.TestEngine.PowerApps
         /// Get Debug Info
         /// </summary>
         public Task<object> GetDebugInfo();
+
+        /// <summary>
+        /// TestEngine ready function returns true if the functions are ready
+        /// else it throws exception
+        /// </summary>
+        public Task<bool> TestEngineReady();
     }
 }

--- a/src/Microsoft.PowerApps.TestEngine/PowerApps/PowerAppFunctions.cs
+++ b/src/Microsoft.PowerApps.TestEngine/PowerApps/PowerAppFunctions.cs
@@ -24,6 +24,7 @@ namespace Microsoft.PowerApps.TestEngine.PowerApps
         public static string EmbeddedJSFolderPath = "JS";
         public static string PublishedAppIframeName = "fullscreen-app-host";
         public static string CheckPowerAppsTestEngineObject = "typeof PowerAppsTestEngine";
+        public static string CheckPowerAppsTestEngineReadyFunction = "typeof PowerAppsTestEngine.testEngineReady";
 
         private string GetItemCountErrorMessage = "Something went wrong when Test Engine tried to get item count.";
         private string GetPropertyValueErrorMessage = "Something went wrong when Test Engine tried to get property value.";
@@ -406,6 +407,37 @@ namespace Microsoft.PowerApps.TestEngine.PowerApps
             }
             catch (Exception)
             {
+                throw;
+            }
+        }
+
+        public async Task<bool> TestEngineReady()
+        {
+            try
+            {
+                // check if ready function exists in the webplayer JSSDK, older versions won't have this new function
+                var checkIfReadyExists = await _testInfraFunctions.RunJavascriptAsync<string>(CheckPowerAppsTestEngineReadyFunction);
+                if(checkIfReadyExists != "undefined")
+                {
+                    var expression = $"PowerAppsTestEngine.testEngineReady()";
+                    return await _testInfraFunctions.RunJavascriptAsync<bool>(expression);
+                }
+
+                // To support webplayer version without ready function 
+                // return true for this without interrupting the test run
+                return true;
+            }
+            catch (Exception ex)
+            {
+                // To support old apps without ready function, if the error returned is function not exists in published app
+                // then return true for this without interrupting the test run
+                if (ex.Message?.ToString() == ExceptionHandlingHelper.PublishedAppWithoutJSSDKErrorCode)
+                {                   
+                    return true;
+                }
+
+                // If the error returned is anything other than PublishedAppWithoutJSSDKErrorCode capture that and throw
+                _singleTestInstanceState.GetLogger().LogDebug(ex.ToString());
                 throw;
             }
         }

--- a/src/Microsoft.PowerApps.TestEngine/PowerApps/PowerAppFunctions.cs
+++ b/src/Microsoft.PowerApps.TestEngine/PowerApps/PowerAppFunctions.cs
@@ -417,7 +417,7 @@ namespace Microsoft.PowerApps.TestEngine.PowerApps
             {
                 // check if ready function exists in the webplayer JSSDK, older versions won't have this new function
                 var checkIfReadyExists = await _testInfraFunctions.RunJavascriptAsync<string>(CheckPowerAppsTestEngineReadyFunction);
-                if(checkIfReadyExists != "undefined")
+                if (checkIfReadyExists != "undefined")
                 {
                     var expression = $"PowerAppsTestEngine.testEngineReady()";
                     return await _testInfraFunctions.RunJavascriptAsync<bool>(expression);
@@ -432,7 +432,7 @@ namespace Microsoft.PowerApps.TestEngine.PowerApps
                 // To support old apps without ready function, if the error returned is function not exists in published app
                 // then return true for this without interrupting the test run
                 if (ex.Message?.ToString() == ExceptionHandlingHelper.PublishedAppWithoutJSSDKErrorCode)
-                {                   
+                {
                     return true;
                 }
 

--- a/src/Microsoft.PowerApps.TestEngine/PowerFx/IPowerFxEngine.cs
+++ b/src/Microsoft.PowerApps.TestEngine/PowerFx/IPowerFxEngine.cs
@@ -39,6 +39,12 @@ namespace Microsoft.PowerApps.TestEngine.PowerFx
         public Task UpdatePowerFxModelAsync();
 
         /// <summary>
+        /// Run requirements checks for the engine
+        /// </summary>
+        /// <returns>A task</returns>
+        public Task RunRequirementsCheckAsync();
+
+        /// <summary>
         /// get PowerAppFunctions
         /// </summary>
         public IPowerAppFunctions GetPowerAppFunctions();

--- a/src/Microsoft.PowerApps.TestEngine/PowerFx/PowerFxEngine.cs
+++ b/src/Microsoft.PowerApps.TestEngine/PowerFx/PowerFxEngine.cs
@@ -139,7 +139,7 @@ namespace Microsoft.PowerApps.TestEngine.PowerFx
                 Logger.LogError("Engine is null, make sure to call Setup first");
                 throw new InvalidOperationException();
             }
-            
+
             await PollingHelper.PollAsync<bool>(false, (x) => !x, () => _powerAppFunctions.CheckIfAppIsIdleAsync(), _testState.GetTestSettings().Timeout, _singleTestInstanceState.GetLogger(), "Something went wrong when Test Engine tried to get App status.");
 
             var controlRecordValues = await _powerAppFunctions.LoadPowerAppsObjectModelAsync();

--- a/src/Microsoft.PowerApps.TestEngine/PowerFx/PowerFxEngine.cs
+++ b/src/Microsoft.PowerApps.TestEngine/PowerFx/PowerFxEngine.cs
@@ -139,8 +139,7 @@ namespace Microsoft.PowerApps.TestEngine.PowerFx
                 Logger.LogError("Engine is null, make sure to call Setup first");
                 throw new InvalidOperationException();
             }
-
-            await _powerAppFunctions.CheckAndHandleIfLegacyPlayerAsync();
+            
             await PollingHelper.PollAsync<bool>(false, (x) => !x, () => _powerAppFunctions.CheckIfAppIsIdleAsync(), _testState.GetTestSettings().Timeout, _singleTestInstanceState.GetLogger(), "Something went wrong when Test Engine tried to get App status.");
 
             var controlRecordValues = await _powerAppFunctions.LoadPowerAppsObjectModelAsync();
@@ -153,6 +152,12 @@ namespace Microsoft.PowerApps.TestEngine.PowerFx
         public IPowerAppFunctions GetPowerAppFunctions()
         {
             return _powerAppFunctions;
+        }
+
+        public async Task RunRequirementsCheckAsync()
+        {
+            await _powerAppFunctions.CheckAndHandleIfLegacyPlayerAsync();
+            await _powerAppFunctions.TestEngineReady();
         }
     }
 }

--- a/src/Microsoft.PowerApps.TestEngine/SingleTestRunner.cs
+++ b/src/Microsoft.PowerApps.TestEngine/SingleTestRunner.cs
@@ -128,6 +128,7 @@ namespace Microsoft.PowerApps.TestEngine
 
                 // Set up Power Fx
                 _powerFxEngine.Setup(locale);
+                await _powerFxEngine.RunRequirementsCheckAsync();
                 await _powerFxEngine.UpdatePowerFxModelAsync();
 
                 allTestsSkipped = false;


### PR DESCRIPTION
1. When the canvas published app is initialized >> there could be a delay in registration of published app JSSDK.
2. If the TestEngine functions including getAppStatus is executed it returns COMMAND NOT FOUND error >> which in turn is interpreted as published app Test Engine JSSDK not found >> though it is still in process.

**PROPOSAL**
- Call TestEngine ready function from TE before any other functions are executed. This way the rest of the functions >> registered (in the app side) before executing them.
- With this implementation, lifecycle of TE function execution would look like 
_Run TE >> execute **ready function** successfully >> execute other function like getAppStatus.._

We just need to make sure TE continue supporting old apps (back compatibility >> older apps won't have this new **ready function**).

**SUPPORTING DIFFERENT SCENARIOS** 

1. Webplayer app and published app versions with **no testEngineReady()** >> Continue test execution.
2. Webplayer app version with **testEngineReady()** and published app with **no testEngineReady()** >> Continue test execution.
3. Webplayer app version with **no testEngineReady()** >> Continue test execution.
5. Webplayer and published app with **testEngineReady()** >> Continue **if** true returned, **else** appropriate error codes are thrown in this case and handled appropriately.

## Checklist

- [x] The code change is covered by unit tests. I have added tests that prove my fix is effective or that my feature works
- [x] I have performed end-to-end test locally.
- [x] New and existing unit tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I used clear names for everything
- [x] I have performed a self-review of my own code
