### PR TITLE
Handling setProperty invalid argument type error when value is number

### DIFF
--- a/src/Microsoft.PowerApps.TestEngine.Tests/PowerFx/PowerFxEngineTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/PowerFx/PowerFxEngineTests.cs
@@ -91,11 +91,11 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx
             var powerFxEngine = new PowerFxEngine(MockTestInfraFunctions.Object, MockPowerAppFunctions.Object, MockSingleTestInstanceState.Object, MockTestState.Object, MockFileSystem.Object);
             powerFxEngine.Setup();
             var result = powerFxEngine.Execute("1+1", new CultureInfo("en-US"));
-            Assert.Equal(2, ((DecimalValue)result).Value);
+            Assert.Equal(2, ((NumberValue)result).Value);
             LoggingTestHelper.VerifyLogging(MockLogger, "Attempting:\n\n{\n1+1}", LogLevel.Trace, Times.Once());
 
             result = powerFxEngine.Execute("=1+1", new CultureInfo("en-US"));
-            Assert.Equal(2, ((DecimalValue)result).Value);
+            Assert.Equal(2, ((NumberValue)result).Value);
             LoggingTestHelper.VerifyLogging(MockLogger, "Attempting:\n\n{\n1+1}", LogLevel.Trace, Times.Exactly(2));
         }
 
@@ -132,9 +132,9 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx
             var frResult = powerFxEngine.Execute(frpowerFxExpression, culture);
 
             // Assertions
-            Assert.Equal(4, ((DecimalValue)enUSResult).Value);
+            Assert.Equal(4, ((NumberValue)enUSResult).Value);
             LoggingTestHelper.VerifyLogging(MockLogger, $"Attempting:\n\n{{\n{enUSpowerFxExpression}}}", LogLevel.Trace, Times.Once());
-            Assert.Equal(4, ((DecimalValue)frResult).Value);
+            Assert.Equal(4, ((NumberValue)frResult).Value);
             LoggingTestHelper.VerifyLogging(MockLogger, $"Attempting:\n\n{{\n{frpowerFxExpression}}}", LogLevel.Trace, Times.Once());
         }
 
@@ -474,8 +474,8 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx
 
             // Assert
             Assert.Equal(2, updateCounter);
-            Assert.Equal(FormulaType.Decimal, result.Type);
-            Assert.Equal("1.2", (result as DecimalValue).Value.ToString());
+            Assert.Equal(FormulaType.Number, result.Type);
+            Assert.Equal("1.2", (result as NumberValue).Value.ToString());
             LoggingTestHelper.VerifyLogging(MockLogger, $"Syntax check failed. Now attempting to execute lines step by step", LogLevel.Debug, Times.Exactly(2));
         }
 

--- a/src/Microsoft.PowerApps.TestEngine/PowerFx/PowerFxEngine.cs
+++ b/src/Microsoft.PowerApps.TestEngine/PowerFx/PowerFxEngine.cs
@@ -30,6 +30,8 @@ namespace Microsoft.PowerApps.TestEngine.PowerFx
         private ILogger Logger { get { return _singleTestInstanceState.GetLogger(); } }
         private static ParserOptions TestEngineParserConfig(CultureInfo culture)
         {
+            // Currently PowerApps does not support decimal but floating-point numbers
+            // Power Fx by default treats number as decimal. Hence setting NumberIsFloat config to true in our case
             return new ParserOptions() { AllowsSideEffects = true, Culture = culture, NumberIsFloat = true };
         }
 

--- a/src/Microsoft.PowerApps.TestEngine/PowerFx/PowerFxEngine.cs
+++ b/src/Microsoft.PowerApps.TestEngine/PowerFx/PowerFxEngine.cs
@@ -30,7 +30,7 @@ namespace Microsoft.PowerApps.TestEngine.PowerFx
         private ILogger Logger { get { return _singleTestInstanceState.GetLogger(); } }
         private static ParserOptions TestEngineParserConfig(CultureInfo culture)
         {
-            // Currently PowerApps does not support decimal but floating-point numbers
+            // Currently support for decimal is still in progress for PowerApps
             // Power Fx by default treats number as decimal. Hence setting NumberIsFloat config to true in our case
             return new ParserOptions() { AllowsSideEffects = true, Culture = culture, NumberIsFloat = true };
         }

--- a/src/Microsoft.PowerApps.TestEngine/PowerFx/PowerFxEngine.cs
+++ b/src/Microsoft.PowerApps.TestEngine/PowerFx/PowerFxEngine.cs
@@ -30,7 +30,7 @@ namespace Microsoft.PowerApps.TestEngine.PowerFx
         private ILogger Logger { get { return _singleTestInstanceState.GetLogger(); } }
         private static ParserOptions TestEngineParserConfig(CultureInfo culture)
         {
-            // Currently support for decimal is still in progress for PowerApps
+            // Currently support for decimal is in progress for PowerApps
             // Power Fx by default treats number as decimal. Hence setting NumberIsFloat config to true in our case
             return new ParserOptions() { AllowsSideEffects = true, Culture = culture, NumberIsFloat = true };
         }

--- a/src/Microsoft.PowerApps.TestEngine/PowerFx/PowerFxEngine.cs
+++ b/src/Microsoft.PowerApps.TestEngine/PowerFx/PowerFxEngine.cs
@@ -28,6 +28,10 @@ namespace Microsoft.PowerApps.TestEngine.PowerFx
 
         private RecalcEngine Engine { get; set; }
         private ILogger Logger { get { return _singleTestInstanceState.GetLogger(); } }
+        private static ParserOptions TestEngineParserConfig(CultureInfo culture)
+        {
+            return new ParserOptions() { AllowsSideEffects = true, Culture = culture, NumberIsFloat = true };
+        }
 
         public PowerFxEngine(ITestInfraFunctions testInfraFunctions,
                              IPowerAppFunctions powerAppFunctions,
@@ -103,7 +107,7 @@ namespace Microsoft.PowerApps.TestEngine.PowerFx
 
             var goStepByStep = false;
             // Check if the syntax is correct
-            var checkResult = Engine.Check(testSteps, null, new ParserOptions() { AllowsSideEffects = true, Culture = culture });
+            var checkResult = Engine.Check(testSteps, null, TestEngineParserConfig(culture));
             if (!checkResult.IsSuccess)
             {
                 // If it isn't, we have to go step by step as the object model isn't fully loaded
@@ -119,14 +123,14 @@ namespace Microsoft.PowerApps.TestEngine.PowerFx
                 foreach (var step in splitSteps)
                 {
                     Logger.LogTrace($"Attempting:{step.Replace("\n", "").Replace("\r", "")}");
-                    result = Engine.Eval(step, null, new ParserOptions() { AllowsSideEffects = true, Culture = culture });
+                    result = Engine.Eval(step, null, new ParserOptions() { AllowsSideEffects = true, Culture = culture, NumberIsFloat = true });
                 }
                 return result;
             }
             else
             {
                 Logger.LogTrace($"Attempting:\n\n{{\n{testSteps}}}");
-                return Engine.Eval(testSteps, null, new ParserOptions() { AllowsSideEffects = true, Culture = culture });
+                return Engine.Eval(testSteps, null, new ParserOptions() { AllowsSideEffects = true, Culture = culture, NumberIsFloat = true });
             }
         }
 

--- a/src/Microsoft.PowerApps.TestEngine/PowerFx/PowerFxEngine.cs
+++ b/src/Microsoft.PowerApps.TestEngine/PowerFx/PowerFxEngine.cs
@@ -28,12 +28,6 @@ namespace Microsoft.PowerApps.TestEngine.PowerFx
 
         private RecalcEngine Engine { get; set; }
         private ILogger Logger { get { return _singleTestInstanceState.GetLogger(); } }
-        private static ParserOptions TestEngineParserConfig(CultureInfo culture)
-        {
-            // Currently support for decimal is in progress for PowerApps
-            // Power Fx by default treats number as decimal. Hence setting NumberIsFloat config to true in our case
-            return new ParserOptions() { AllowsSideEffects = true, Culture = culture, NumberIsFloat = true };
-        }
 
         public PowerFxEngine(ITestInfraFunctions testInfraFunctions,
                              IPowerAppFunctions powerAppFunctions,
@@ -109,7 +103,7 @@ namespace Microsoft.PowerApps.TestEngine.PowerFx
 
             var goStepByStep = false;
             // Check if the syntax is correct
-            var checkResult = Engine.Check(testSteps, null, TestEngineParserConfig(culture));
+            var checkResult = Engine.Check(testSteps, null, GetPowerFxParserOptions(culture));
             if (!checkResult.IsSuccess)
             {
                 // If it isn't, we have to go step by step as the object model isn't fully loaded
@@ -152,6 +146,13 @@ namespace Microsoft.PowerApps.TestEngine.PowerFx
             {
                 Engine.UpdateVariable(control.Key, control.Value);
             }
+        }
+
+        private static ParserOptions GetPowerFxParserOptions(CultureInfo culture)
+        {
+            // Currently support for decimal is in progress for PowerApps
+            // Power Fx by default treats number as decimal. Hence setting NumberIsFloat config to true in our case
+            return new ParserOptions() { AllowsSideEffects = true, Culture = culture, NumberIsFloat = true };
         }
 
         public IPowerAppFunctions GetPowerAppFunctions()


### PR DESCRIPTION
### Problem
With the PowerFx version upgrade to 0.2.6-preview >> Run differentVariableTypes sample Or have a Rating control in powerapps and run test like `Setproperty(Rating.Value, 5)`. Below error thrown
<img width="515" alt="image" src="https://github.com/microsoft/PowerApps-TestEngine/assets/98551644/ba9a331c-b81b-4c00-8044-ddcc89407ebd">

By default in the ParserOptions of PowerFxEngine, NumberIsFloat is set to false. i.e, it is considered as decimal.
<img width="600" alt="image" src="https://github.com/microsoft/PowerApps-TestEngine/assets/98551644/fcd024bd-ee79-4f7b-a40e-6e0cdadaf0ad">

Currently PowerApps does not support decimal fully but floating-point numbers. Hence, we need to set this NumberIsFloat config to true in TestEngine.

### **Proposal**
Set parserconfig **Numberisfloat** config to true
## Checklist
- [x] The code change is covered by unit tests. I have added tests that prove my fix is effective or that my feature works
- [x] I have performed end-to-end test locally.
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I used clear names for everything
- [x] I have performed a self-review of my own code
