### PR TITLE
Setting test reporter testrun storage

### DIFF
--- a/src/Microsoft.PowerApps.TestEngine.Tests/Reporting/TestReporterTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/Reporting/TestReporterTests.cs
@@ -37,7 +37,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Reporting
             Assert.Throws<ArgumentException>(() => testReporter.GetTestRun(testRunId));
             Assert.Throws<ArgumentException>(() => testReporter.StartTestRun(testRunId));
             Assert.Throws<ArgumentException>(() => testReporter.EndTestRun(testRunId));
-            Assert.Throws<ArgumentException>(() => testReporter.CreateTest(testRunId, Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), "c:\\testplan.fx.yaml"));
+            Assert.Throws<ArgumentException>(() => testReporter.CreateTest(testRunId, Guid.NewGuid().ToString(), Guid.NewGuid().ToString()));
             Assert.Throws<ArgumentException>(() => testReporter.StartTest(testRunId, Guid.NewGuid().ToString()));
             Assert.Throws<ArgumentException>(() => testReporter.EndTest(testRunId, Guid.NewGuid().ToString(), true, "", new List<string>(), null));
             Assert.Throws<ArgumentException>(() => testReporter.GenerateTestReport(testRunId, "c:\\results"));
@@ -168,15 +168,15 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Reporting
             var testRunId = testReporter.CreateTestRun(testRunName, testUser);
             var testLocation = $"{TestReporter.ResultsPrefix}{testRunId}";
 
-            Assert.Throws<InvalidOperationException>(() => testReporter.CreateTest(testRunId, Guid.NewGuid().ToString(), testName, testLocation));
+            Assert.Throws<InvalidOperationException>(() => testReporter.CreateTest(testRunId, Guid.NewGuid().ToString(), testName));
 
             testReporter.StartTestRun(testRunId);
 
-            Assert.Throws<InvalidOperationException>(() => testReporter.CreateTest(testRunId, Guid.NewGuid().ToString(), testName, testLocation));
+            Assert.Throws<InvalidOperationException>(() => testReporter.CreateTest(testRunId, Guid.NewGuid().ToString(), testName));
 
             var testSuiteId = testReporter.CreateTestSuite(testRunId, testSuiteName);
 
-            var testId = testReporter.CreateTest(testRunId, testSuiteId, testName, testLocation);
+            var testId = testReporter.CreateTest(testRunId, testSuiteId, testName);
 
             var testRun = testReporter.GetTestRun(testRunId);
 
@@ -207,7 +207,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Reporting
 
             var testName2 = "testName2";
             var testLocation2 = $"{TestReporter.ResultsPrefix}{testRunId}";
-            var testId2 = testReporter.CreateTest(testRunId, testSuiteId, testName2, testLocation);
+            var testId2 = testReporter.CreateTest(testRunId, testSuiteId, testName2);
 
             testRun = testReporter.GetTestRun(testRunId);
 
@@ -237,7 +237,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Reporting
             Assert.Equal(2, testRun.ResultSummary.Counters.Total);
 
             testReporter.EndTestRun(testRunId);
-            Assert.Throws<InvalidOperationException>(() => testReporter.CreateTest(testRunId, Guid.NewGuid().ToString(), testName, testLocation));
+            Assert.Throws<InvalidOperationException>(() => testReporter.CreateTest(testRunId, Guid.NewGuid().ToString(), testName));
         }
 
         [Fact]
@@ -251,7 +251,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Reporting
             var testRunId = testReporter.CreateTestRun(testRunName, testUser);
             testReporter.StartTestRun(testRunId);
             var testSuiteId = testReporter.CreateTestSuite(testRunId, testSuiteName);
-            var testId = testReporter.CreateTest(testRunId, testSuiteId, testName, "");
+            var testId = testReporter.CreateTest(testRunId, testSuiteId, testName);
             var testRun = testReporter.GetTestRun(testRunId);
 
             Assert.Equal($"{TestReporter.ResultsPrefix}{testRunId}", testRun.Definitions.UnitTests[0].Storage);
@@ -264,14 +264,13 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Reporting
             var testRunName = "testRunName";
             var testUser = "testUser";
             var testName = "testName";
-            var testLocation = "C:\\testplan.fx.yaml";
             var testReporter = new TestReporter(MockFileSystem.Object);
             var testRunId = testReporter.CreateTestRun(testRunName, testUser);
 
             testReporter.StartTestRun(testRunId);
 
             var testSuiteId = testReporter.CreateTestSuite(testRunId, "testSuite");
-            var testId = testReporter.CreateTest(testRunId, testSuiteId, testName, testLocation);
+            var testId = testReporter.CreateTest(testRunId, testSuiteId, testName);
 
             var before = DateTime.Now;
             testReporter.StartTest(testRunId, testId);
@@ -296,14 +295,13 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Reporting
             var testRunName = "testRunName";
             var testUser = "testUser";
             var testName = "testName";
-            var testLocation = "C:\\testplan.fx.yaml";
             var testReporter = new TestReporter(MockFileSystem.Object);
             var testRunId = testReporter.CreateTestRun(testRunName, testUser);
 
             testReporter.StartTestRun(testRunId);
 
             var testSuiteId = testReporter.CreateTestSuite(testRunId, "testSuite");
-            var testId = testReporter.CreateTest(testRunId, testSuiteId, testName, testLocation);
+            var testId = testReporter.CreateTest(testRunId, testSuiteId, testName);
 
             Assert.Throws<InvalidOperationException>(() => testReporter.EndTest(testRunId, testId, success, stdout, additionalFiles.ToList(), errorMessage));
 
@@ -353,14 +351,13 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Reporting
             var testRunName = "testRunName";
             var testUser = "testUser";
             var testName = "testName";
-            var testLocation = "C:\\testplan.fx.yaml";
             var testReporter = new TestReporter(MockFileSystem.Object);
             var testRunId = testReporter.CreateTestRun(testRunName, testUser);
 
             testReporter.StartTestRun(testRunId);
 
             var testSuiteId = testReporter.CreateTestSuite(testRunId, "testSuite");
-            var testId = testReporter.CreateTest(testRunId, testSuiteId, testName, testLocation);
+            var testId = testReporter.CreateTest(testRunId, testSuiteId, testName);
 
             testReporter.FailTest(testRunId, testId);
 
@@ -380,7 +377,6 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Reporting
             var testRunName = "testRunName";
             var testUser = "testUser";
             var testName = "testName";
-            var testLocation = "C:\\testplan.fx.yaml";
             var resultDirectory = "C:\\results";
             var testReporter = new TestReporter(MockFileSystem.Object);
             var testRunId = testReporter.CreateTestRun(testRunName, testUser);
@@ -390,7 +386,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Reporting
             testReporter.StartTestRun(testRunId);
 
             var testSuiteId = testReporter.CreateTestSuite(testRunId, "testSuite");
-            var testId = testReporter.CreateTest(testRunId, testSuiteId, testName, testLocation);
+            var testId = testReporter.CreateTest(testRunId, testSuiteId, testName);
 
             testReporter.StartTest(testRunId, testId);
 

--- a/src/Microsoft.PowerApps.TestEngine.Tests/Reporting/TestReporterTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/Reporting/TestReporterTests.cs
@@ -163,10 +163,10 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Reporting
             var testRunName = "testRunName";
             var testUser = "testUser";
             var testName = "testName";
-            var testSuiteName = "testSuite";
-            var testLocation = "C:\\testplan.fx.yaml";
+            var testSuiteName = "testSuite";            
             var testReporter = new TestReporter(MockFileSystem.Object);
             var testRunId = testReporter.CreateTestRun(testRunName, testUser);
+            var testLocation = $"{TestReporter.ResultsPrefix}{testRunId}";
 
             Assert.Throws<InvalidOperationException>(() => testReporter.CreateTest(testRunId, Guid.NewGuid().ToString(), testName, testLocation));
 
@@ -206,8 +206,8 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Reporting
             Assert.Equal(1, testRun.ResultSummary.Counters.Total);
 
             var testName2 = "testName2";
-            var testLocation2 = "C:\\testplan2.fx.yaml";
-            var testId2 = testReporter.CreateTest(testRunId, testSuiteId, testName2, testLocation2);
+            var testLocation2 = $"{TestReporter.ResultsPrefix}{testRunId}";
+            var testId2 = testReporter.CreateTest(testRunId, testSuiteId, testName2, testLocation);
 
             testRun = testReporter.GetTestRun(testRunId);
 
@@ -238,6 +238,24 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Reporting
 
             testReporter.EndTestRun(testRunId);
             Assert.Throws<InvalidOperationException>(() => testReporter.CreateTest(testRunId, Guid.NewGuid().ToString(), testName, testLocation));
+        }
+
+        [Fact]
+        public void CreateTestStorageNameTest()
+        {
+            var testRunName = "testRunName";
+            var testUser = "testUser";
+            var testName = "testName";
+            var testSuiteName = "testSuite";
+            var testReporter = new TestReporter(MockFileSystem.Object);
+            var testRunId = testReporter.CreateTestRun(testRunName, testUser);
+            testReporter.StartTestRun(testRunId);
+            var testSuiteId = testReporter.CreateTestSuite(testRunId, testSuiteName);
+            var testId = testReporter.CreateTest(testRunId, testSuiteId, testName, "");
+            var testRun = testReporter.GetTestRun(testRunId);
+
+            Assert.Equal($"{TestReporter.ResultsPrefix}{testRunId}", testRun.Definitions.UnitTests[0].Storage);
+            Assert.Equal(testId, testRun.Definitions.UnitTests[0].Id);
         }
 
         [Fact]

--- a/src/Microsoft.PowerApps.TestEngine.Tests/SingleTestRunnerTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/SingleTestRunnerTests.cs
@@ -60,7 +60,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
             LoggingTestHelper.SetupMock(MockLogger);
             MockLogger.Setup(x => x.BeginScope(It.IsAny<string>())).Returns(new TestLoggerScope("", () => { }));
 
-            MockTestReporter.Setup(x => x.CreateTest(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>())).Returns(testId);
+            MockTestReporter.Setup(x => x.CreateTest(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>())).Returns(testId);
             MockTestReporter.Setup(x => x.CreateTestSuite(It.IsAny<string>(), It.IsAny<string>())).Returns(testSuiteId);
             MockTestReporter.Setup(x => x.StartTest(It.IsAny<string>(), It.IsAny<string>()));
             MockTestReporter.Setup(x => x.EndTest(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<string>(), It.IsAny<List<string>>(), It.IsAny<string>()));
@@ -147,7 +147,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
             MockUrlMapper.Verify(x => x.GenerateTestUrl("", ""), Times.Once());
             MockTestInfraFunctions.Verify(x => x.GoToUrlAsync(appUrl), Times.Once());
             MockTestState.Verify(x => x.GetTestSuiteDefinition(), Times.Exactly(2));
-            MockTestReporter.Verify(x => x.CreateTest(testRunId, testSuiteId, testSuiteDefinition.TestCases[0].TestCaseName, "TODO"), Times.Once());
+            MockTestReporter.Verify(x => x.CreateTest(testRunId, testSuiteId, testSuiteDefinition.TestCases[0].TestCaseName), Times.Once());
             MockTestReporter.Verify(x => x.StartTest(testRunId, testId), Times.Once());
             MockTestState.Verify(x => x.SetTestId(testId), Times.Once());
             MockLoggerFactory.Verify(x => x.CreateLogger(testSuiteId), Times.Once());

--- a/src/Microsoft.PowerApps.TestEngine/Reporting/ITestReporter.cs
+++ b/src/Microsoft.PowerApps.TestEngine/Reporting/ITestReporter.cs
@@ -44,9 +44,8 @@ namespace Microsoft.PowerApps.TestEngine.Reporting
         /// <param name="testRunId">Test run id</param>
         /// <param name="testSuiteId">Test suite id</param>
         /// <param name="testName">Name of test</param>
-        /// <param name="testLocation">Location of test file</param>
         /// <returns>Test id</returns>
-        public string CreateTest(string testRunId, string testSuiteId, string testName, string testLocation);
+        public string CreateTest(string testRunId, string testSuiteId, string testName);
 
         /// <summary>
         /// Starts test. This records the start time of the test.

--- a/src/Microsoft.PowerApps.TestEngine/Reporting/TestReporter.cs
+++ b/src/Microsoft.PowerApps.TestEngine/Reporting/TestReporter.cs
@@ -146,7 +146,7 @@ namespace Microsoft.PowerApps.TestEngine.Reporting
             return testRun.TestLists.TestList.Where(x => x.Id == testSuiteId).Count() == 1;
         }
 
-        public string CreateTest(string testRunId, string testSuiteId, string testName, string testLocation)
+        public string CreateTest(string testRunId, string testSuiteId, string testName)
         {
             var testRun = GetTestRun(testRunId);
 

--- a/src/Microsoft.PowerApps.TestEngine/Reporting/TestReporter.cs
+++ b/src/Microsoft.PowerApps.TestEngine/Reporting/TestReporter.cs
@@ -168,7 +168,7 @@ namespace Microsoft.PowerApps.TestEngine.Reporting
             var unitTestDefinition = new UnitTestDefinition
             {
                 Name = testName,
-                Storage = $"{ ResultsPrefix }{ testRunId }",
+                Storage = $"{ResultsPrefix}{testRunId}",
                 Id = Guid.NewGuid().ToString(),
                 Execution = new TestExecution()
                 {

--- a/src/Microsoft.PowerApps.TestEngine/Reporting/TestReporter.cs
+++ b/src/Microsoft.PowerApps.TestEngine/Reporting/TestReporter.cs
@@ -15,6 +15,7 @@ namespace Microsoft.PowerApps.TestEngine.Reporting
 
         public static string FailedResultOutcome = "Failed";
         public static string PassedResultOutcome = "Passed";
+        public static string ResultsPrefix = "Results_";
 
         private string testRunAppURL;
         private string testResultsDirectory;
@@ -167,7 +168,7 @@ namespace Microsoft.PowerApps.TestEngine.Reporting
             var unitTestDefinition = new UnitTestDefinition
             {
                 Name = testName,
-                Storage = testLocation,
+                Storage = $"{ ResultsPrefix }{ testRunId }",
                 Id = Guid.NewGuid().ToString(),
                 Execution = new TestExecution()
                 {
@@ -288,7 +289,7 @@ namespace Microsoft.PowerApps.TestEngine.Reporting
             XmlSerializerNamespaces xsNS = new XmlSerializerNamespaces();
             xsNS.Add("", "http://microsoft.com/schemas/VisualStudio/TeamTest/2010");
             var serializer = new XmlSerializer(typeof(TestRun));
-            var testResultPath = Path.Combine(resultsDirectory, $"Results_{testRunId}.trx");
+            var testResultPath = Path.Combine(resultsDirectory, $"{ResultsPrefix}{testRunId}.trx");
             using (var writer = new StringWriter())
             {
                 serializer.Serialize(writer, testRun, xsNS);

--- a/src/Microsoft.PowerApps.TestEngine/SingleTestRunner.cs
+++ b/src/Microsoft.PowerApps.TestEngine/SingleTestRunner.cs
@@ -139,7 +139,7 @@ namespace Microsoft.PowerApps.TestEngine
                     _eventHandler.TestCaseBegin(testCase.TestCaseName);
 
                     TestSuccess = true;
-                    var testId = _testReporter.CreateTest(testRunId, testSuiteId, $"{testCase.TestCaseName}", "TODO");
+                    var testId = _testReporter.CreateTest(testRunId, testSuiteId, $"{testCase.TestCaseName}");
                     _testReporter.StartTest(testRunId, testId);
                     _testState.SetTestId(testId);
 
@@ -242,7 +242,7 @@ namespace Microsoft.PowerApps.TestEngine
                     // Run test case one by one, mark it as failed
                     foreach (var testCase in _testState.GetTestSuiteDefinition().TestCases)
                     {
-                        var testId = _testReporter.CreateTest(testRunId, testSuiteId, $"{testCase.TestCaseName}", "TODO");
+                        var testId = _testReporter.CreateTest(testRunId, testSuiteId, $"{testCase.TestCaseName}");
                         _testReporter.FailTest(testRunId, testId);
                     }
                 }


### PR DESCRIPTION
Test reporter Test run storage name is useful to differentiate each trx report if parsed or consumed by trx parsers.
Currently it is set to hardcoded default value of **Todo** for every trx report generated. 
We need to change this from "Todo" to something meaningful and that can differentiate **each test run**.

### Proposal

- Use the same **trx** file names used >> **Results_{TestRunId}** instead of Todo.
- This way it is easily identifiable and meaningful

## Checklist

- [x] The code change is covered by unit tests. I have added tests that prove my fix is effective or that my feature works
- [x] I have performed end-to-end test locally.
- [x] New and existing unit tests pass locally with my changes
- [x] My changes generate no new warnings
- [x] I used clear names for everything
- [x] I have performed a self-review of my own code
