### PR TITLE
Upgrade PowerFx.Interpreter library to 0.2.6-preview

### DIFF
--- a/samples/calculator/testPlanWithCommaForDecimal.fx.yaml
+++ b/samples/calculator/testPlanWithCommaForDecimal.fx.yaml
@@ -3,7 +3,7 @@ testSuite:
   testSuiteDescription: Verifies that the calculator app works. The calculator is a component.
   persona: User1
   # appId: fd32a609-eaca-4d91-b5b4-31651d265133
-  appLogicalName: new_calculator_a3613
+  appLogicalName: new_calculator2_11d82
 
   # This sample has been written to demonstrate tests written in regions that use commas ',' instead of 
   # periods '.' for a decimal separator. E.g., "10,22" instead of "10.22". However since all of our tests 

--- a/samples/calculator/testPlanWithCommaForDecimal.fx.yaml
+++ b/samples/calculator/testPlanWithCommaForDecimal.fx.yaml
@@ -13,29 +13,29 @@ testSuite:
     - testCaseName: Default Check
       testSteps: |
         = Screenshot("calculator_loaded.png");;
-          Assert(Calculator_1.Number1Label.Text = "10.12"; "Validate default value for number 1 label");;
-          Assert(Calculator_1.Number2Label.Text = "2.2"; "Validate default value for number 2 label");;
+          Assert(Calculator_1.Number1Label.Text = "4.42"; "Validate default value for number 1 label");;
+          Assert(Calculator_1.Number2Label.Text = "2.5"; "Validate default value for number 2 label");;
     - testCaseName: Check Addition
       testSteps: |
         = Select(Calculator_1.Add);;
-          Assert(Calculator_1.ResultLabel.Text = "12.32"; "Validate result label has the results of addition");;
-          Assert(Calculator_1.CalculatorResult = 12,32; "Validate component output calculator result has the results of addition");;
+          Assert(Calculator_1.ResultLabel.Text = "6.92"; "Validate result label has the results of addition");;
+          Assert(Calculator_1.CalculatorResult = 6,92; "Validate component output calculator result has the results of addition");;
     - testCaseName: Check subtraction
       testSteps: |
         = Select(Calculator_1.Subtract);;
-          Assert(Calculator_1.ResultLabel.Text = "7.92"; "Validate result label has the results of subtraction");;
-          Assert(Calculator_1.CalculatorResult = 7,92; "Validate component output calculator result has the results of subtraction");;
+          Assert(Calculator_1.ResultLabel.Text = "1.92"; "Validate result label has the results of subtraction");;
+          Assert(Calculator_1.CalculatorResult = 1,92; "Validate component output calculator result has the results of subtraction");;
           
     - testCaseName: Check multiplication
       testSteps: |
         = Select(Calculator_1.Multiply);;
-          Assert(Calculator_1.ResultLabel.Text = "22.264"; "Validate result label has the results of multiplication");;
-          Assert(Calculator_1.CalculatorResult = 22,264; "Validate component output calculator result has the results of multiplication");;
+          Assert(Calculator_1.ResultLabel.Text = "11.05"; "Validate result label has the results of multiplication");;
+          Assert(Calculator_1.CalculatorResult = 11,05; "Validate component output calculator result has the results of multiplication");;
     - testCaseName: Check division
       testSteps: |      
         = Select(Calculator_1.Divide);;
-          Assert(Calculator_1.ResultLabel.Text = "4.6"; "Validate result label has the results of division");;
-          Assert(Calculator_1.CalculatorResult = 4,6; "Validate component output calculator result has the results of division");;
+          Assert(Calculator_1.ResultLabel.Text = "1.768"; "Validate result label has the results of division");;
+          Assert(Calculator_1.CalculatorResult = 1,768; "Validate component output calculator result has the results of division");;
           Screenshot("calculator_end.png");;
 
 testSettings:

--- a/src/Microsoft.PowerApps.TestEngine.Tests/PowerApps/PowerAppFunctionsTest.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/PowerApps/PowerAppFunctionsTest.cs
@@ -158,7 +158,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerApps
             var result = await powerAppFunctions.SetPropertyAsync(itemPath, DateValue.NewDateOnly(dt.Date));
 
             Assert.True(result);
-            MockTestInfraFunctions.Verify(x => x.RunJavascriptAsync<bool>($"PowerAppsTestEngine.setPropertyValue({itemPathString},{{\"SelectedDate\":Date.parse(\"{((DateValue)DateValue.NewDateOnly(dt.Date)).Value}\")}})"), Times.Once());
+            MockTestInfraFunctions.Verify(x => x.RunJavascriptAsync<bool>($"PowerAppsTestEngine.setPropertyValue({itemPathString},{{\"SelectedDate\":Date.parse(\"{((DateValue)DateValue.NewDateOnly(dt.Date)).GetConvertedValue(null)}\")}})"), Times.Once());
         }
 
         [Fact]
@@ -542,8 +542,8 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerApps
         {
             MockSingleTestInstanceState.Setup(x => x.GetLogger()).Returns(MockLogger.Object);
             MockTestInfraFunctions.Setup(x => x.AddScriptTagAsync(It.IsAny<string>(), It.IsAny<string>())).Returns(Task.CompletedTask);
-                        MockTestInfraFunctions.SetupSequence(x => x.RunJavascriptAsync<string>("typeof PowerAppsTestEngine"))
-                .Returns(Task.FromResult("object"));
+            MockTestInfraFunctions.SetupSequence(x => x.RunJavascriptAsync<string>("typeof PowerAppsTestEngine"))
+    .Returns(Task.FromResult("object"));
 
             MockTestInfraFunctions.Setup(x => x.RunJavascriptAsync<string>("PowerAppsTestEngine.buildObjectModel().then((objectModel) => JSON.stringify(objectModel))")).Returns(Task.FromResult("{}"));
             var testSettings = new TestSettings() { Timeout = 12000 };
@@ -570,7 +570,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerApps
 
             var powerAppFunctions = new PowerAppFunctions(MockTestInfraFunctions.Object, MockSingleTestInstanceState.Object, MockTestState.Object);
             await Assert.ThrowsAsync<TimeoutException>(async () => { await powerAppFunctions.LoadPowerAppsObjectModelAsync(); });
-            
+
             MockTestInfraFunctions.Verify(x => x.RunJavascriptAsync<string>("PowerAppsTestEngine.buildObjectModel().then((objectModel) => JSON.stringify(objectModel))"), Times.AtLeastOnce());
             LoggingTestHelper.VerifyLogging(MockLogger, "Start to load power apps object model", LogLevel.Debug, Times.Once());
         }
@@ -820,7 +820,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerApps
             var powerAppFunctions = new PowerAppFunctions(MockTestInfraFunctions.Object, MockSingleTestInstanceState.Object, MockTestState.Object);
             await Assert.ThrowsAsync<Exception>(async () => { await powerAppFunctions.SetPropertyDateAsync(itemPath, DateValue.NewDateOnly(dt.Date)); });
 
-            MockTestInfraFunctions.Verify(x => x.RunJavascriptAsync<bool>($"PowerAppsTestEngine.setPropertyValue({itemPathString},{{\"SelectedDate\":Date.parse(\"{((DateValue)DateValue.NewDateOnly(dt.Date)).Value}\")}})"), Times.Once());
+            MockTestInfraFunctions.Verify(x => x.RunJavascriptAsync<bool>($"PowerAppsTestEngine.setPropertyValue({itemPathString},{{\"SelectedDate\":Date.parse(\"{((DateValue)DateValue.NewDateOnly(dt.Date)).GetConvertedValue(null)}\")}})"), Times.Once());
             LoggingTestHelper.VerifyLogging(MockLogger, ExceptionHandlingHelper.PublishedAppWithoutJSSDKMessage, LogLevel.Error, Times.Once());
         }
 

--- a/src/Microsoft.PowerApps.TestEngine.Tests/PowerApps/PowerFXModel/ControlRecordValueTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/PowerApps/PowerFXModel/ControlRecordValueTests.cs
@@ -9,7 +9,6 @@ using Microsoft.PowerFx.Types;
 using Moq;
 using Newtonsoft.Json;
 using Xunit;
-using YamlDotNet.Core.Tokens;
 
 namespace Microsoft.PowerApps.TestEngine.Tests.PowerApps.PowerFXModel
 {
@@ -47,8 +46,8 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerApps.PowerFXModel
 
             Assert.Equal(propertyValue, (controlRecordValue.GetField("Text") as StringValue).Value);
             Assert.Equal(numberPropertyValue, (controlRecordValue.GetField("X") as NumberValue).Value);
-            Assert.Equal(datePropertyValue.ToString(), (controlRecordValue.GetField("SelectedDate") as DateValue).Value.ToString());
-            Assert.Equal(dateTimePropertyValue.ToString(), (controlRecordValue.GetField("DefaultDate") as DateTimeValue).Value.ToString());
+            Assert.Equal(datePropertyValue.ToString(), (controlRecordValue.GetField("SelectedDate") as DateValue).GetConvertedValue(null).ToString());
+            Assert.Equal(dateTimePropertyValue.ToString(), (controlRecordValue.GetField("DefaultDate") as DateTimeValue).GetConvertedValue(null).ToString());
 
             mockPowerAppFunctions.Verify(x => x.GetPropertyValueFromControl<string>(It.Is<ItemPath>((x) => x.PropertyName == "Text" && x.ControlName == controlName)), Times.Once());
             mockPowerAppFunctions.Verify(x => x.GetPropertyValueFromControl<string>(It.Is<ItemPath>((x) => x.PropertyName == "X" && x.ControlName == controlName)), Times.Once());

--- a/src/Microsoft.PowerApps.TestEngine.Tests/PowerFx/Functions/SetPropertyFunctionTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/PowerFx/Functions/SetPropertyFunctionTests.cs
@@ -8,7 +8,6 @@ using Microsoft.Extensions.Logging;
 using Microsoft.PowerApps.TestEngine.Config;
 using Microsoft.PowerApps.TestEngine.PowerApps;
 using Microsoft.PowerApps.TestEngine.PowerApps.PowerFxModel;
-using Microsoft.PowerApps.TestEngine.PowerFx;
 using Microsoft.PowerApps.TestEngine.PowerFx.Functions;
 using Microsoft.PowerApps.TestEngine.Tests.Helpers;
 using Microsoft.PowerFx.Types;
@@ -146,7 +145,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx.Functions
 
             // check to see if the value of DatePicker1's 'Value' property is the correct datetime (01/01/2030)
             Assert.IsType<BooleanValue>(result);
-            MockPowerAppFunctions.Verify(x => x.SetPropertyAsync(It.Is<ItemPath>((item) => item.ControlName == recordValue.Name), It.Is<DateValue>(dateVal => dateVal.Value == dt)), Times.Once());
+            MockPowerAppFunctions.Verify(x => x.SetPropertyAsync(It.Is<ItemPath>((item) => item.ControlName == recordValue.Name), It.Is<DateValue>(dateVal => dateVal.GetConvertedValue(null) == dt)), Times.Once());
         }
 
         [Fact]
@@ -157,7 +156,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx.Functions
 
             // Make setPropertyFunction contain a component called Dropdown1
             var recordType = RecordType.Empty().Add("Selected", RecordType.Empty());
-            var recordValue = new ControlRecordValue(recordType, MockPowerAppFunctions.Object,"Dropdown1");
+            var recordValue = new ControlRecordValue(recordType, MockPowerAppFunctions.Object, "Dropdown1");
             var setPropertyFunction = new SetPropertyFunction(MockPowerAppFunctions.Object, MockLogger.Object);
 
             // Set the value of Dropdown1's 'Selected' property to {"Value":"2"}

--- a/src/Microsoft.PowerApps.TestEngine.Tests/PowerFx/Functions/SomeOtherUntypedObject.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/PowerFx/Functions/SomeOtherUntypedObject.cs
@@ -26,12 +26,22 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx.Functions
             throw new global::System.NotImplementedException();
         }
 
+        public decimal GetDecimal()
+        {
+            throw new global::System.NotImplementedException();
+        }
+
         public double GetDouble()
         {
             throw new global::System.NotImplementedException();
         }
 
         public string GetString()
+        {
+            throw new global::System.NotImplementedException();
+        }
+
+        public string GetUntypedNumber()
         {
             throw new global::System.NotImplementedException();
         }

--- a/src/Microsoft.PowerApps.TestEngine.Tests/PowerFx/PowerFxEngineTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/PowerFx/PowerFxEngineTests.cs
@@ -135,11 +135,11 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx
             var powerFxEngine = new PowerFxEngine(MockTestInfraFunctions.Object, MockPowerAppFunctions.Object, MockSingleTestInstanceState.Object, MockTestState.Object, MockFileSystem.Object);
             powerFxEngine.Setup();
             var result = powerFxEngine.Execute("1+1", new CultureInfo("en-US"));
-            Assert.Equal(2, ((DecimalValue)result).Value);
+            Assert.Equal(2, ((NumberValue)result).Value);
             LoggingTestHelper.VerifyLogging(MockLogger, "Attempting:\n\n{\n1+1}", LogLevel.Trace, Times.Once());
 
             result = powerFxEngine.Execute("=1+1", new CultureInfo("en-US"));
-            Assert.Equal(2, ((DecimalValue)result).Value);
+            Assert.Equal(2, ((NumberValue)result).Value);
             LoggingTestHelper.VerifyLogging(MockLogger, "Attempting:\n\n{\n1+1}", LogLevel.Trace, Times.Exactly(2));
         }
 
@@ -176,9 +176,9 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx
             var frResult = powerFxEngine.Execute(frpowerFxExpression, culture);
 
             // Assertions
-            Assert.Equal(4, ((DecimalValue)enUSResult).Value);
+            Assert.Equal(4, ((NumberValue)enUSResult).Value);
             LoggingTestHelper.VerifyLogging(MockLogger, $"Attempting:\n\n{{\n{enUSpowerFxExpression}}}", LogLevel.Trace, Times.Once());
-            Assert.Equal(4, ((DecimalValue)frResult).Value);
+            Assert.Equal(4, ((NumberValue)frResult).Value);
             LoggingTestHelper.VerifyLogging(MockLogger, $"Attempting:\n\n{{\n{frpowerFxExpression}}}", LogLevel.Trace, Times.Once());
         }
 
@@ -518,8 +518,8 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx
 
             // Assert
             Assert.Equal(2, updateCounter);
-            Assert.Equal(FormulaType.Decimal, result.Type);
-            Assert.Equal("1.2", (result as DecimalValue).Value.ToString());
+            Assert.Equal(FormulaType.Number, result.Type);
+            Assert.Equal("1.2", (result as NumberValue).Value.ToString());
             LoggingTestHelper.VerifyLogging(MockLogger, $"Syntax check failed. Now attempting to execute lines step by step", LogLevel.Debug, Times.Exactly(2));
         }
 

--- a/src/Microsoft.PowerApps.TestEngine.Tests/PowerFx/PowerFxEngineTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/PowerFx/PowerFxEngineTests.cs
@@ -13,7 +13,6 @@ using Microsoft.PowerApps.TestEngine.PowerFx;
 using Microsoft.PowerApps.TestEngine.System;
 using Microsoft.PowerApps.TestEngine.TestInfra;
 using Microsoft.PowerApps.TestEngine.Tests.Helpers;
-using Microsoft.PowerFx;
 using Microsoft.PowerFx.Types;
 using Moq;
 using Newtonsoft.Json;
@@ -91,7 +90,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx
             MockPowerAppFunctions.Setup(x => x.TestEngineReady()).Returns(Task.FromResult(true));
 
             var powerFxEngine = new PowerFxEngine(MockTestInfraFunctions.Object, MockPowerAppFunctions.Object, MockSingleTestInstanceState.Object, MockTestState.Object, MockFileSystem.Object);
-            powerFxEngine.Setup(It.IsAny<CultureInfo>());
+            powerFxEngine.Setup();
 
             await powerFxEngine.RunRequirementsCheckAsync();
 
@@ -106,9 +105,9 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx
             MockPowerAppFunctions.Setup(x => x.TestEngineReady()).Returns(Task.FromResult(true));
 
             var powerFxEngine = new PowerFxEngine(MockTestInfraFunctions.Object, MockPowerAppFunctions.Object, MockSingleTestInstanceState.Object, MockTestState.Object, MockFileSystem.Object);
-            powerFxEngine.Setup(It.IsAny<CultureInfo>());
+            powerFxEngine.Setup();
 
-            await Assert.ThrowsAsync <Exception>(() => powerFxEngine.RunRequirementsCheckAsync());
+            await Assert.ThrowsAsync<Exception>(() => powerFxEngine.RunRequirementsCheckAsync());
 
             MockPowerAppFunctions.Verify(x => x.CheckAndHandleIfLegacyPlayerAsync(), Times.Once());
             MockPowerAppFunctions.Verify(x => x.TestEngineReady(), Times.Never());
@@ -121,7 +120,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx
             MockPowerAppFunctions.Setup(x => x.TestEngineReady()).Throws(new Exception());
 
             var powerFxEngine = new PowerFxEngine(MockTestInfraFunctions.Object, MockPowerAppFunctions.Object, MockSingleTestInstanceState.Object, MockTestState.Object, MockFileSystem.Object);
-            powerFxEngine.Setup(It.IsAny<CultureInfo>());
+            powerFxEngine.Setup();
 
             await Assert.ThrowsAsync<Exception>(() => powerFxEngine.RunRequirementsCheckAsync());
 
@@ -166,7 +165,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx
             var enUSpowerFxExpression = "1+1;2+2;";
             var powerFxEngine = new PowerFxEngine(MockTestInfraFunctions.Object, MockPowerAppFunctions.Object, MockSingleTestInstanceState.Object, MockTestState.Object, MockFileSystem.Object);
             powerFxEngine.Setup();
-            var enUSResult = powerFxEngine.Execute(enUSpowerFxExpression, culture);            
+            var enUSResult = powerFxEngine.Execute(enUSpowerFxExpression, culture);
 
             // fr locale
             culture = new CultureInfo("fr");

--- a/src/Microsoft.PowerApps.TestEngine.Tests/PowerFx/PowerFxEngineTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/PowerFx/PowerFxEngineTests.cs
@@ -47,14 +47,14 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx
         public void SetupDoesNotThrow()
         {
             var powerFxEngine = new PowerFxEngine(MockTestInfraFunctions.Object, MockPowerAppFunctions.Object, MockSingleTestInstanceState.Object, MockTestState.Object, MockFileSystem.Object);
-            powerFxEngine.Setup(It.IsAny<CultureInfo>());
+            powerFxEngine.Setup();
         }
 
         [Fact]
         public void ExecuteThrowsOnNoSetupTest()
         {
             var powerFxEngine = new PowerFxEngine(MockTestInfraFunctions.Object, MockPowerAppFunctions.Object, MockSingleTestInstanceState.Object, MockTestState.Object, MockFileSystem.Object);
-            Assert.Throws<InvalidOperationException>(() => powerFxEngine.Execute(""));
+            Assert.Throws<InvalidOperationException>(() => powerFxEngine.Execute("", It.IsAny<CultureInfo>()));
             LoggingTestHelper.VerifyLogging(MockLogger, "Engine is null, make sure to call Setup first", LogLevel.Error, Times.Once());
         }
 
@@ -79,7 +79,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx
             MockTestState.Setup(x => x.GetTestSettings()).Returns(testSettings);
 
             var powerFxEngine = new PowerFxEngine(MockTestInfraFunctions.Object, MockPowerAppFunctions.Object, MockSingleTestInstanceState.Object, MockTestState.Object, MockFileSystem.Object);
-            powerFxEngine.Setup(It.IsAny<CultureInfo>());
+            powerFxEngine.Setup();
             await Assert.ThrowsAsync<TimeoutException>(() => powerFxEngine.UpdatePowerFxModelAsync());
             LoggingTestHelper.VerifyLogging(MockLogger, "Something went wrong when Test Engine tried to get App status.", LogLevel.Error, Times.Once());
         }
@@ -133,13 +133,13 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx
         public void ExecuteOneFunctionTest()
         {
             var powerFxEngine = new PowerFxEngine(MockTestInfraFunctions.Object, MockPowerAppFunctions.Object, MockSingleTestInstanceState.Object, MockTestState.Object, MockFileSystem.Object);
-            powerFxEngine.Setup(It.IsAny<CultureInfo>());
-            var result = powerFxEngine.Execute("1+1");
-            Assert.Equal(2, ((NumberValue)result).Value);
+            powerFxEngine.Setup();
+            var result = powerFxEngine.Execute("1+1", new CultureInfo("en-US"));
+            Assert.Equal(2, ((DecimalValue)result).Value);
             LoggingTestHelper.VerifyLogging(MockLogger, "Attempting:\n\n{\n1+1}", LogLevel.Trace, Times.Once());
 
-            result = powerFxEngine.Execute("=1+1");
-            Assert.Equal(2, ((NumberValue)result).Value);
+            result = powerFxEngine.Execute("=1+1", new CultureInfo("en-US"));
+            Assert.Equal(2, ((DecimalValue)result).Value);
             LoggingTestHelper.VerifyLogging(MockLogger, "Attempting:\n\n{\n1+1}", LogLevel.Trace, Times.Exactly(2));
         }
 
@@ -148,14 +148,38 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx
         {
             var powerFxExpression = "1+1; //some comment \n 2+2;\n Concatenate(\"hello\", \"world\");";
             var powerFxEngine = new PowerFxEngine(MockTestInfraFunctions.Object, MockPowerAppFunctions.Object, MockSingleTestInstanceState.Object, MockTestState.Object, MockFileSystem.Object);
-            powerFxEngine.Setup(It.IsAny<CultureInfo>());
-            var result = powerFxEngine.Execute(powerFxExpression);
+            powerFxEngine.Setup();
+            var result = powerFxEngine.Execute(powerFxExpression, It.IsAny<CultureInfo>());
             Assert.Equal("helloworld", ((StringValue)result).Value);
             LoggingTestHelper.VerifyLogging(MockLogger, $"Attempting:\n\n{{\n{powerFxExpression}}}", LogLevel.Trace, Times.Once());
 
-            result = powerFxEngine.Execute($"={powerFxExpression}");
+            result = powerFxEngine.Execute($"={powerFxExpression}", It.IsAny<CultureInfo>());
             Assert.Equal("helloworld", ((StringValue)result).Value);
             LoggingTestHelper.VerifyLogging(MockLogger, $"Attempting:\n\n{{\n{powerFxExpression}}}", LogLevel.Trace, Times.Exactly(2));
+        }
+
+        [Fact]
+        public void ExecuteMultipleFunctionsWithDifferentLocaleTest()
+        {
+            // en-US locale
+            var culture = new CultureInfo("en-US");
+            var enUSpowerFxExpression = "1+1;2+2;";
+            var powerFxEngine = new PowerFxEngine(MockTestInfraFunctions.Object, MockPowerAppFunctions.Object, MockSingleTestInstanceState.Object, MockTestState.Object, MockFileSystem.Object);
+            powerFxEngine.Setup();
+            var enUSResult = powerFxEngine.Execute(enUSpowerFxExpression, culture);            
+
+            // fr locale
+            culture = new CultureInfo("fr");
+            var frpowerFxExpression = "1+1;;2+2;;";
+            powerFxEngine = new PowerFxEngine(MockTestInfraFunctions.Object, MockPowerAppFunctions.Object, MockSingleTestInstanceState.Object, MockTestState.Object, MockFileSystem.Object);
+            powerFxEngine.Setup();
+            var frResult = powerFxEngine.Execute(frpowerFxExpression, culture);
+
+            // Assertions
+            Assert.Equal(4, ((DecimalValue)enUSResult).Value);
+            LoggingTestHelper.VerifyLogging(MockLogger, $"Attempting:\n\n{{\n{enUSpowerFxExpression}}}", LogLevel.Trace, Times.Once());
+            Assert.Equal(4, ((DecimalValue)frResult).Value);
+            LoggingTestHelper.VerifyLogging(MockLogger, $"Attempting:\n\n{{\n{frpowerFxExpression}}}", LogLevel.Trace, Times.Once());
         }
 
         [Fact]
@@ -198,18 +222,18 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx
             MockTestState.Setup(x => x.GetTestSettings()).Returns(testSettings);
 
             var powerFxEngine = new PowerFxEngine(MockTestInfraFunctions.Object, MockPowerAppFunctions.Object, MockSingleTestInstanceState.Object, MockTestState.Object, MockFileSystem.Object);
-            powerFxEngine.Setup(It.IsAny<CultureInfo>());
+            powerFxEngine.Setup();
             await powerFxEngine.UpdatePowerFxModelAsync();
 
             MockPowerAppFunctions.Verify(x => x.LoadPowerAppsObjectModelAsync(), Times.Once());
 
-            var result = powerFxEngine.Execute(powerFxExpression);
+            var result = powerFxEngine.Execute(powerFxExpression, It.IsAny<CultureInfo>());
             Assert.Equal($"{label1Text}{label2Text}", ((StringValue)result).Value);
             LoggingTestHelper.VerifyLogging(MockLogger, $"Attempting:\n\n{{\n{powerFxExpression}}}", LogLevel.Trace, Times.Once());
             MockPowerAppFunctions.Verify(x => x.GetPropertyValueFromControl<string>(It.Is<ItemPath>((itemPath) => itemPath.ControlName == label1ItemPath.ControlName && itemPath.PropertyName == label1ItemPath.PropertyName)), Times.Once());
             MockPowerAppFunctions.Verify(x => x.GetPropertyValueFromControl<string>(It.Is<ItemPath>((itemPath) => itemPath.ControlName == label2ItemPath.ControlName && itemPath.PropertyName == label2ItemPath.PropertyName)), Times.Once());
 
-            result = powerFxEngine.Execute($"={powerFxExpression}");
+            result = powerFxEngine.Execute($"={powerFxExpression}", It.IsAny<CultureInfo>());
             Assert.Equal($"{label1Text}{label2Text}", ((StringValue)result).Value);
             LoggingTestHelper.VerifyLogging(MockLogger, $"Attempting:\n\n{{\n{powerFxExpression}}}", LogLevel.Trace, Times.Exactly(2));
             MockPowerAppFunctions.Verify(x => x.GetPropertyValueFromControl<string>(It.Is<ItemPath>((itemPath) => itemPath.ControlName == label1ItemPath.ControlName && itemPath.PropertyName == label1ItemPath.PropertyName)), Times.Exactly(2));
@@ -222,8 +246,8 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx
             var powerFxExpression = "someNonExistentPowerFxFunction(1, 2, 3)";
             MockPowerAppFunctions.Setup(x => x.LoadPowerAppsObjectModelAsync()).Returns(Task.FromResult(new Dictionary<string, ControlRecordValue>()));
             var powerFxEngine = new PowerFxEngine(MockTestInfraFunctions.Object, MockPowerAppFunctions.Object, MockSingleTestInstanceState.Object, MockTestState.Object, MockFileSystem.Object);
-            powerFxEngine.Setup(CultureInfo.CurrentCulture);
-            Assert.ThrowsAsync<Exception>(async () => await powerFxEngine.ExecuteWithRetryAsync(powerFxExpression));
+            powerFxEngine.Setup();
+            Assert.ThrowsAsync<Exception>(async () => await powerFxEngine.ExecuteWithRetryAsync(powerFxExpression, It.IsAny<CultureInfo>()));
         }
 
         [Fact]
@@ -231,8 +255,8 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx
         {
             var powerFxExpression = "Concatenate(Label1.Text, Label2.Text)";
             var powerFxEngine = new PowerFxEngine(MockTestInfraFunctions.Object, MockPowerAppFunctions.Object, MockSingleTestInstanceState.Object, MockTestState.Object, MockFileSystem.Object);
-            powerFxEngine.Setup(It.IsAny<CultureInfo>());
-            Assert.ThrowsAsync<Exception>(async () => await powerFxEngine.ExecuteWithRetryAsync(powerFxExpression));
+            powerFxEngine.Setup();
+            Assert.ThrowsAsync<Exception>(async () => await powerFxEngine.ExecuteWithRetryAsync(powerFxExpression, It.IsAny<CultureInfo>()));
         }
 
         [Fact]
@@ -240,12 +264,12 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx
         {
             var powerFxExpression = "Assert(1+1=2, \"Adding 1 + 1\")";
             var powerFxEngine = new PowerFxEngine(MockTestInfraFunctions.Object, MockPowerAppFunctions.Object, MockSingleTestInstanceState.Object, MockTestState.Object, MockFileSystem.Object);
-            powerFxEngine.Setup(It.IsAny<CultureInfo>());
-            var result = powerFxEngine.Execute(powerFxExpression);
+            powerFxEngine.Setup();
+            var result = powerFxEngine.Execute(powerFxExpression, It.IsAny<CultureInfo>());
             Assert.IsType<BlankValue>(result);
 
             var failingPowerFxExpression = "Assert(1+1=3, \"Supposed to fail\")";
-            Assert.ThrowsAny<Exception>(() => powerFxEngine.Execute(failingPowerFxExpression));
+            Assert.ThrowsAny<Exception>(() => powerFxEngine.Execute(failingPowerFxExpression, It.IsAny<CultureInfo>()));
         }
 
         [Fact]
@@ -256,12 +280,12 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx
             MockTestInfraFunctions.Setup(x => x.ScreenshotAsync(It.IsAny<string>())).Returns(Task.CompletedTask);
             var powerFxExpression = "Screenshot(\"1.jpg\")";
             var powerFxEngine = new PowerFxEngine(MockTestInfraFunctions.Object, MockPowerAppFunctions.Object, MockSingleTestInstanceState.Object, MockTestState.Object, MockFileSystem.Object);
-            powerFxEngine.Setup(It.IsAny<CultureInfo>());
-            var result = powerFxEngine.Execute(powerFxExpression);
+            powerFxEngine.Setup();
+            var result = powerFxEngine.Execute(powerFxExpression, It.IsAny<CultureInfo>());
             Assert.IsType<BlankValue>(result);
 
             var failingPowerFxExpression = "Screenshot(\"1.txt\")";
-            Assert.ThrowsAny<Exception>(() => powerFxEngine.Execute(failingPowerFxExpression));
+            Assert.ThrowsAny<Exception>(() => powerFxEngine.Execute(failingPowerFxExpression, It.IsAny<CultureInfo>()));
         }
 
         [Fact]
@@ -279,10 +303,10 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx
 
             var powerFxExpression = "Select(Button1)";
             var powerFxEngine = new PowerFxEngine(MockTestInfraFunctions.Object, MockPowerAppFunctions.Object, MockSingleTestInstanceState.Object, MockTestState.Object, MockFileSystem.Object);
-            powerFxEngine.Setup(It.IsAny<CultureInfo>());
+            powerFxEngine.Setup();
             await powerFxEngine.UpdatePowerFxModelAsync();
-            await powerFxEngine.ExecuteWithRetryAsync(powerFxExpression);
-            var result = powerFxEngine.Execute(powerFxExpression);
+            await powerFxEngine.ExecuteWithRetryAsync(powerFxExpression, It.IsAny<CultureInfo>());
+            var result = powerFxEngine.Execute(powerFxExpression, It.IsAny<CultureInfo>());
             Assert.IsType<BlankValue>(result);
             MockPowerAppFunctions.Verify(x => x.LoadPowerAppsObjectModelAsync(), Times.Exactly(3));
         }
@@ -303,9 +327,9 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx
 
             var powerFxExpression = "Select(Button1)";
             var powerFxEngine = new PowerFxEngine(MockTestInfraFunctions.Object, MockPowerAppFunctions.Object, MockSingleTestInstanceState.Object, MockTestState.Object, MockFileSystem.Object);
-            powerFxEngine.Setup(It.IsAny<CultureInfo>());
+            powerFxEngine.Setup();
             await powerFxEngine.UpdatePowerFxModelAsync();
-            Assert.ThrowsAny<Exception>(() => powerFxEngine.Execute(powerFxExpression));
+            Assert.ThrowsAny<Exception>(() => powerFxEngine.Execute(powerFxExpression, It.IsAny<CultureInfo>()));
             MockPowerAppFunctions.Verify(x => x.LoadPowerAppsObjectModelAsync(), Times.Once());
         }
 
@@ -324,9 +348,9 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx
 
             var powerFxExpression = "Select(Button1)";
             var powerFxEngine = new PowerFxEngine(MockTestInfraFunctions.Object, MockPowerAppFunctions.Object, MockSingleTestInstanceState.Object, MockTestState.Object, MockFileSystem.Object);
-            powerFxEngine.Setup(It.IsAny<CultureInfo>());
+            powerFxEngine.Setup();
             await powerFxEngine.UpdatePowerFxModelAsync();
-            Assert.ThrowsAny<Exception>(() => powerFxEngine.Execute(powerFxExpression));
+            Assert.ThrowsAny<Exception>(() => powerFxEngine.Execute(powerFxExpression, It.IsAny<CultureInfo>()));
             MockPowerAppFunctions.Verify(x => x.LoadPowerAppsObjectModelAsync(), Times.Once());
         }
 
@@ -347,10 +371,10 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx
             var powerFxExpression = "SetProperty(Button1.Text, \"10\")";
             var powerFxEngine = new PowerFxEngine(MockTestInfraFunctions.Object, MockPowerAppFunctions.Object, MockSingleTestInstanceState.Object, MockTestState.Object, MockFileSystem.Object);
 
-            powerFxEngine.Setup(It.IsAny<CultureInfo>());
+            powerFxEngine.Setup();
             await powerFxEngine.UpdatePowerFxModelAsync();
-            await powerFxEngine.ExecuteWithRetryAsync(powerFxExpression);
-            var result = powerFxEngine.Execute(powerFxExpression);
+            await powerFxEngine.ExecuteWithRetryAsync(powerFxExpression, It.IsAny<CultureInfo>());
+            var result = powerFxEngine.Execute(powerFxExpression, It.IsAny<CultureInfo>());
             Assert.IsType<BooleanValue>(result);
             MockPowerAppFunctions.Verify(x => x.LoadPowerAppsObjectModelAsync(), Times.Once());
         }
@@ -371,9 +395,9 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx
             var powerFxExpression = "SetProperty(Button1.Text, \"10\")";
             var powerFxEngine = new PowerFxEngine(MockTestInfraFunctions.Object, MockPowerAppFunctions.Object, MockSingleTestInstanceState.Object, MockTestState.Object, MockFileSystem.Object);
 
-            powerFxEngine.Setup(It.IsAny<CultureInfo>());
+            powerFxEngine.Setup();
             await powerFxEngine.UpdatePowerFxModelAsync();
-            Assert.ThrowsAny<Exception>(() => powerFxEngine.Execute(powerFxExpression));
+            Assert.ThrowsAny<Exception>(() => powerFxEngine.Execute(powerFxExpression, It.IsAny<CultureInfo>()));
             MockPowerAppFunctions.Verify(x => x.LoadPowerAppsObjectModelAsync(), Times.Once());
         }
 
@@ -404,10 +428,10 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx
 
             var powerFxExpression = "Wait(Label1, \"Text\", \"1\")";
             var powerFxEngine = new PowerFxEngine(MockTestInfraFunctions.Object, MockPowerAppFunctions.Object, MockSingleTestInstanceState.Object, MockTestState.Object, MockFileSystem.Object);
-            powerFxEngine.Setup(It.IsAny<CultureInfo>());
+            powerFxEngine.Setup();
             await powerFxEngine.UpdatePowerFxModelAsync();
-            await powerFxEngine.ExecuteWithRetryAsync(powerFxExpression);
-            var result = powerFxEngine.Execute(powerFxExpression);
+            await powerFxEngine.ExecuteWithRetryAsync(powerFxExpression, It.IsAny<CultureInfo>());
+            var result = powerFxEngine.Execute(powerFxExpression, It.IsAny<CultureInfo>());
             Assert.IsType<BlankValue>(result);
             MockPowerAppFunctions.Verify(x => x.LoadPowerAppsObjectModelAsync(), Times.Once());
         }
@@ -427,9 +451,9 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx
 
             var powerFxExpression = "Wait(Label1, \"Text\", \"1\")";
             var powerFxEngine = new PowerFxEngine(MockTestInfraFunctions.Object, MockPowerAppFunctions.Object, MockSingleTestInstanceState.Object, MockTestState.Object, MockFileSystem.Object);
-            powerFxEngine.Setup(It.IsAny<CultureInfo>());
+            powerFxEngine.Setup();
             await powerFxEngine.UpdatePowerFxModelAsync();
-            Assert.ThrowsAny<Exception>(() => powerFxEngine.Execute(powerFxExpression));
+            Assert.ThrowsAny<Exception>(() => powerFxEngine.Execute(powerFxExpression, It.IsAny<CultureInfo>()));
             MockPowerAppFunctions.Verify(x => x.LoadPowerAppsObjectModelAsync(), Times.Once());
         }
 
@@ -470,7 +494,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx
             var oldUICulture = CultureInfo.CurrentUICulture;
             var frenchCulture = new CultureInfo("fr");
             CultureInfo.CurrentUICulture = frenchCulture;
-            powerFxEngine.Setup(frenchCulture);
+            powerFxEngine.Setup();
             var testSettings = new TestSettings() { Timeout = 3000 };
             MockTestState.Setup(x => x.GetTestSettings()).Returns(testSettings);
             var expression = "Select(Label1/*Label;;22*/);;\"Just stirng \n;literal\";;Select(Label2)\n;;Select(Label3);;Assert(1=1; \"Supposed to pass;;\");;Max(1,2)";
@@ -479,9 +503,9 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx
 
             // Engine.Eval should throw an exception when none of the used first names exist in the underlying symbol table yet.
             // This confirms that we would be hitting goStepByStep branch
-            Assert.ThrowsAny<Exception>(() => powerFxEngine.Execute(expression));
+            Assert.ThrowsAny<Exception>(() => powerFxEngine.Execute(expression, frenchCulture));
             await powerFxEngine.UpdatePowerFxModelAsync();
-            var result = powerFxEngine.Execute(expression);
+            var result = powerFxEngine.Execute(expression, frenchCulture);
 
             try
             {
@@ -494,8 +518,8 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx
 
             // Assert
             Assert.Equal(2, updateCounter);
-            Assert.Equal(FormulaType.Number, result.Type);
-            Assert.Equal(1.2, (result as NumberValue).Value);
+            Assert.Equal(FormulaType.Decimal, result.Type);
+            Assert.Equal("1.2", (result as DecimalValue).Value.ToString());
             LoggingTestHelper.VerifyLogging(MockLogger, $"Syntax check failed. Now attempting to execute lines step by step", LogLevel.Debug, Times.Exactly(2));
         }
 

--- a/src/Microsoft.PowerApps.TestEngine.Tests/PowerFx/PowerFxHelperTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/PowerFx/PowerFxHelperTests.cs
@@ -4,7 +4,6 @@
 using System.Globalization;
 using Microsoft.PowerApps.TestEngine.PowerFx;
 using Microsoft.PowerFx;
-using Microsoft.PowerFx.Preview;
 using Xunit;
 
 namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx
@@ -52,7 +51,8 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx
         public void TestFormulasSeparatedByChainingOpAreExtractedCorrectly(string locale, string expression, params string[] expectedFormulas)
         {
             // Arrange
-            FeatureFlags.StringInterpolation = true;
+            // Setting this feature flag is no longer needed
+            //FeatureFlags.StringInterpolation = true;
             var oldUICulture = CultureInfo.CurrentUICulture;
             var culture = new CultureInfo(locale);
             CultureInfo.CurrentUICulture = culture;
@@ -75,7 +75,9 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx
 
         private static Engine GetEngine(string locale)
         {
-            var recalcEngine = new RecalcEngine(new PowerFxConfig(new CultureInfo(locale)));
+            //TODO: Temporarily removed the locale input parameter from PowerFxConfig(...), make sure to add it back
+            //var recalcEngine = new RecalcEngine(new PowerFxConfig(new CultureInfo(locale)));
+            var recalcEngine = new RecalcEngine(new PowerFxConfig());
             return recalcEngine;
         }
 

--- a/src/Microsoft.PowerApps.TestEngine.Tests/PowerFx/PowerFxHelperTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/PowerFx/PowerFxHelperTests.cs
@@ -39,13 +39,11 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx
         [InlineData("en-US", "Max(;;;1,2)", "Max(;;;1,2)")]
         [InlineData("en-US", ";;;;", "", "", "", "")]
         [InlineData("en-US", "")]
-        [InlineData("en-US", "Max(;22)", "Max(", "22)")]
+        [InlineData("en-US", "Max(;22)", "Max(;22)")]
         [InlineData("en-US", "Select(Button1/*Selecting button 1;;;*/);Assert(Button1.Text = Text(\"Ab\";\"Abcd\"))", "Select(Button1/*Selecting button 1;;;*/)", "Assert(Button1.Text = Text(\"Ab\";\"Abcd\"))")]
         [InlineData("en-US", "Select(Button1)", "Select(Button1)")]
         [InlineData("fr", "Max(1;;2;;3;30;;Max(230;;23;;33);;3)", "Max(1;;2;;3;30;;Max(230;;23;;33);;3)")]
-        // Once new powerfx version is consumed, this would fail due to recent PowerFx Lexer changes
-        // Fix would be to this to InlineData("en-US", "'Test;2212", "'Test", "2212")
-        [InlineData("en-US", "'Test;2212", "'Test;2212")]
+        [InlineData("en-US", "'Test;2212", "'Test", "2212")]
         [InlineData("en-US", "'Test;;2333';Max(1;'Button1;Button2';23;/*\n\n;;Comment\n\n*/33,100;Max(100;200,20;30)))", "'Test;;2333'", "Max(1;'Button1;Button2';23;/*\n\n;;Comment\n\n*/33,100;Max(100;200,20;30)))")]
         [InlineData("en-US", "'Test;;2333';Max(1;'Button1;Button2';23;/*\n\n;;Comment\n\n33,100;Max(100;200,20;30)))", "'Test;;2333'", "Max(1;'Button1;Button2';23;/*\n\n;;Comment\n\n33,100;Max(100;200,20;30)))")]
         public void TestFormulasSeparatedByChainingOpAreExtractedCorrectly(string locale, string expression, params string[] expectedFormulas)
@@ -59,7 +57,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx
             var (result, engine) = GetCheckResultAndEngine(expression, locale);
 
             // Act
-            var actualFormulas = PowerFxHelper.ExtractFormulasSeparatedByChainingOperator(engine, result);
+            var actualFormulas = PowerFxHelper.ExtractFormulasSeparatedByChainingOperator(engine, result, culture);
 
             // Assert
             try

--- a/src/Microsoft.PowerApps.TestEngine.Tests/SingleTestRunnerTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/SingleTestRunnerTests.cs
@@ -88,10 +88,10 @@ namespace Microsoft.PowerApps.TestEngine.Tests
 
 
             var locale = string.IsNullOrEmpty(testSuitelocale) ? CultureInfo.CurrentCulture : new CultureInfo(testSuitelocale);
-            MockPowerFxEngine.Setup(x => x.Setup(locale));
+            MockPowerFxEngine.Setup(x => x.Setup());
             MockPowerFxEngine.Setup(x => x.RunRequirementsCheckAsync()).Returns(Task.CompletedTask);
             MockPowerFxEngine.Setup(x => x.UpdatePowerFxModelAsync()).Returns(Task.CompletedTask);
-            MockPowerFxEngine.Setup(x => x.Execute(It.IsAny<string>())).Returns(FormulaValue.NewBlank());
+            MockPowerFxEngine.Setup(x => x.Execute(It.IsAny<string>(), It.IsAny<CultureInfo>())).Returns(FormulaValue.NewBlank());
 
             MockTestEngineEventHandler.Setup(x => x.SetAndInitializeCounters(It.IsAny<int>()));
             MockTestEngineEventHandler.Setup(x => x.EncounteredException(It.IsAny<Exception>()));
@@ -102,11 +102,11 @@ namespace Microsoft.PowerApps.TestEngine.Tests
 
             if (powerFxTestSuccess)
             {
-                MockPowerFxEngine.Setup(x => x.ExecuteWithRetryAsync(It.IsAny<string>())).Returns(Task.CompletedTask);
+                MockPowerFxEngine.Setup(x => x.ExecuteWithRetryAsync(It.IsAny<string>(), It.IsAny<CultureInfo>())).Returns(Task.CompletedTask);
             }
             else
             {
-                MockPowerFxEngine.Setup(x => x.ExecuteWithRetryAsync(It.IsAny<string>())).Throws(new Exception("something bad happened"));
+                MockPowerFxEngine.Setup(x => x.ExecuteWithRetryAsync(It.IsAny<string>(), It.IsAny<CultureInfo>())).Throws(new Exception("something bad happened"));
             }
             MockPowerFxEngine.Setup(x => x.GetPowerAppFunctions()).Returns(MockPowerAppFunctions.Object);
 
@@ -139,7 +139,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
         private void VerifySuccessfulTestExecution(string testResultDirectory, TestSuiteDefinition testSuiteDefinition, BrowserConfiguration browserConfig,
             string testSuiteId, string testRunId, string testId, bool testSuccess, string[]? additionalFiles, string? errorMessage, string? stackTrace, string appUrl, CultureInfo locale)
         {
-            MockPowerFxEngine.Verify(x => x.Setup(locale), Times.Once());
+            MockPowerFxEngine.Verify(x => x.Setup(), Times.Once());
             MockPowerFxEngine.Verify(x => x.UpdatePowerFxModelAsync(), Times.Once());
             MockTestInfraFunctions.Verify(x => x.SetupAsync(), Times.Once());
             MockUserManager.Verify(x => x.LoginAsUserAsync(appUrl), Times.Once());
@@ -329,7 +329,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
         {
             await SingleTestRunnerHandlesExceptionsThrownCorrectlyHelper((Exception exceptionToThrow) =>
             {
-                MockPowerFxEngine.Setup(x => x.Setup(It.IsAny<CultureInfo>())).Throws(exceptionToThrow);
+                MockPowerFxEngine.Setup(x => x.Setup()).Throws(exceptionToThrow);
             });
         }
 
@@ -405,7 +405,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
 
             var exceptionToThrow = new InvalidOperationException("Test exception");
 
-            MockPowerFxEngine.Setup(x => x.Execute(It.IsAny<string>())).Throws(exceptionToThrow);
+            MockPowerFxEngine.Setup(x => x.Execute(It.IsAny<string>(), It.IsAny<CultureInfo>())).Throws(exceptionToThrow);
 
             var locale = string.IsNullOrEmpty(testData.testSuiteLocale) ? CultureInfo.CurrentCulture : new CultureInfo(testData.testSuiteLocale);
 

--- a/src/Microsoft.PowerApps.TestEngine/Microsoft.PowerApps.TestEngine.csproj
+++ b/src/Microsoft.PowerApps.TestEngine/Microsoft.PowerApps.TestEngine.csproj
@@ -30,7 +30,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Playwright" Version="1.35.0" />
-    <PackageReference Include="Microsoft.PowerFx.Interpreter" Version="0.2.3-preview" />
+    <PackageReference Include="Microsoft.PowerFx.Interpreter" Version="0.2.6-preview" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageReference Include="YamlDotNet" Version="11.2.1" />
   </ItemGroup>

--- a/src/Microsoft.PowerApps.TestEngine/PowerApps/PowerAppFunctions.cs
+++ b/src/Microsoft.PowerApps.TestEngine/PowerApps/PowerAppFunctions.cs
@@ -273,7 +273,7 @@ namespace Microsoft.PowerApps.TestEngine.PowerApps
 
                 var itemPathString = JsonConvert.SerializeObject(itemPath);
                 var propertyNameString = JsonConvert.SerializeObject(itemPath.PropertyName);
-                var recordValue = value.Value;
+                var recordValue = value.GetConvertedValue(null);
 
                 // Date.parse() parses the date to unix timestamp
                 var expression = $"PowerAppsTestEngine.setPropertyValue({itemPathString},{{{propertyNameString}:Date.parse(\"{recordValue}\")}})";

--- a/src/Microsoft.PowerApps.TestEngine/PowerFx/Functions/WaitFunction.cs
+++ b/src/Microsoft.PowerApps.TestEngine/PowerFx/Functions/WaitFunction.cs
@@ -3,7 +3,6 @@
 
 using Microsoft.Extensions.Logging;
 using Microsoft.PowerApps.TestEngine.Helpers;
-using Microsoft.PowerApps.TestEngine.PowerApps;
 using Microsoft.PowerApps.TestEngine.PowerApps.PowerFxModel;
 using Microsoft.PowerFx;
 using Microsoft.PowerFx.Types;
@@ -206,17 +205,17 @@ namespace Microsoft.PowerApps.TestEngine.PowerFx.Functions
             // Handling in the case that the property is a DateTime
             if (propType.GetType() == typeof(DateTimeValue))
             {
-                PollingCondition<DateTime>((x) => x != value.Value, () =>
+                PollingCondition<DateTime>((x) => x != value.GetConvertedValue(null), () =>
                 {
-                    return ((DateTimeValue)controlModel.GetField(propName.Value)).Value;
+                    return ((DateTimeValue)controlModel.GetField(propName.Value)).GetConvertedValue(null);
                 }, _timeout);
             }
             // Otherwise, the property should be be a Date
             else
             {
-                PollingCondition<DateTime>((x) => x != value.Value, () =>
+                PollingCondition<DateTime>((x) => x != value.GetConvertedValue(null), () =>
                 {
-                    return ((DateValue)controlModel.GetField(propName.Value)).Value;
+                    return ((DateValue)controlModel.GetField(propName.Value)).GetConvertedValue(null);
                 }, _timeout);
             }
 
@@ -249,9 +248,9 @@ namespace Microsoft.PowerApps.TestEngine.PowerFx.Functions
             // Handling in the case that the property is a DateTime
             if (propType.GetType() == typeof(DateTimeValue))
             {
-                PollingCondition<DateTime>((x) => x != value.Value, () =>
+                PollingCondition<DateTime>((x) => x != value.GetConvertedValue(null), () =>
                 {
-                    return ((DateTimeValue)controlModel.GetField(propName.Value)).Value;
+                    return ((DateTimeValue)controlModel.GetField(propName.Value)).GetConvertedValue(null);
                 }, _timeout);
 
                 _logger.LogInformation("Successfully finished executing Wait function, condition was met.");
@@ -260,9 +259,9 @@ namespace Microsoft.PowerApps.TestEngine.PowerFx.Functions
             // Handling in the case that the property is a Date
             else if (propType.GetType() == typeof(DateValue))
             {
-                PollingCondition<DateTime>((x) => x != value.Value, () =>
+                PollingCondition<DateTime>((x) => x != value.GetConvertedValue(null), () =>
                 {
-                    return ((DateValue)controlModel.GetField(propName.Value)).Value;
+                    return ((DateValue)controlModel.GetField(propName.Value)).GetConvertedValue(null);
                 }, _timeout);
 
                 _logger.LogInformation("Successfully finished executing Wait function, condition was met.");

--- a/src/Microsoft.PowerApps.TestEngine/PowerFx/IPowerFxEngine.cs
+++ b/src/Microsoft.PowerApps.TestEngine/PowerFx/IPowerFxEngine.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 using System.Globalization;
+using System.Text.RegularExpressions;
 using Microsoft.PowerApps.TestEngine.PowerApps;
 using Microsoft.PowerFx.Types;
 
@@ -14,23 +15,24 @@ namespace Microsoft.PowerApps.TestEngine.PowerFx
     {
         /// <summary>
         /// Set up the Power FX engine
-        /// </summary>
-        /// <param name="locale">The locale to be used when setting up the Power FX engine. This is typically provided by the test plan file</param>
-        public void Setup(CultureInfo locale);
+        /// </summary>       
+        public void Setup();
 
         /// <summary>
         /// Executes testSteps with retry
         /// </summary>
         /// <param name="testSteps">Test steps</param>
+        /// <param name="culture">The locale to be used when excecuting tests. This is typically provided by the test plan file</param>
         /// <returns>A task</returns>
-        public Task ExecuteWithRetryAsync(string testSteps);
+        public Task ExecuteWithRetryAsync(string testSteps, CultureInfo culture);
 
         /// <summary>
         /// Executes a list of Power FX functions
         /// </summary>
         /// <param name="testSteps">Test steps</param>
+        /// <param name="culture">The locale to be when excecuting tests. This is typically provided by the test plan file</param>
         /// <returns>Result of the Power FX.</returns>
-        public FormulaValue Execute(string testSteps);
+        public FormulaValue Execute(string testSteps, CultureInfo culture);
 
         /// <summary>
         /// Update the Power FX object model

--- a/src/Microsoft.PowerApps.TestEngine/PowerFx/PowerFxEngine.cs
+++ b/src/Microsoft.PowerApps.TestEngine/PowerFx/PowerFxEngine.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-using System.Dynamic;
 using System.Globalization;
 using Microsoft.Extensions.Logging;
 using Microsoft.PowerApps.TestEngine.Config;
@@ -11,7 +10,6 @@ using Microsoft.PowerApps.TestEngine.PowerFx.Functions;
 using Microsoft.PowerApps.TestEngine.System;
 using Microsoft.PowerApps.TestEngine.TestInfra;
 using Microsoft.PowerFx;
-using Microsoft.PowerFx.Syntax;
 using Microsoft.PowerFx.Types;
 
 namespace Microsoft.PowerApps.TestEngine.PowerFx
@@ -46,7 +44,9 @@ namespace Microsoft.PowerApps.TestEngine.PowerFx
 
         public void Setup(CultureInfo locale)
         {
-            var powerFxConfig = new PowerFxConfig(locale);
+            //TODO: Temporarily removed the locale input parameter from PowerFxConfig(...), make sure to add it back
+            //var powerFxConfig = new PowerFxConfig(locale);
+            var powerFxConfig = new PowerFxConfig();
 
             powerFxConfig.AddFunction(new SelectOneParamFunction(_powerAppFunctions, async () => await UpdatePowerFxModelAsync(), Logger));
             powerFxConfig.AddFunction(new SelectTwoParamsFunction(_powerAppFunctions, async () => await UpdatePowerFxModelAsync(), Logger));

--- a/src/Microsoft.PowerApps.TestEngine/PowerFx/PowerFxEngine.cs
+++ b/src/Microsoft.PowerApps.TestEngine/PowerFx/PowerFxEngine.cs
@@ -103,7 +103,7 @@ namespace Microsoft.PowerApps.TestEngine.PowerFx
 
             var goStepByStep = false;
             // Check if the syntax is correct
-            var checkResult = Engine.Check(testSteps, null, new ParserOptions() { AllowsSideEffects = true, Culture = culture });
+            var checkResult = Engine.Check(testSteps, null, GetPowerFxParserOptions(culture));
             if (!checkResult.IsSuccess)
             {
                 // If it isn't, we have to go step by step as the object model isn't fully loaded
@@ -119,14 +119,14 @@ namespace Microsoft.PowerApps.TestEngine.PowerFx
                 foreach (var step in splitSteps)
                 {
                     Logger.LogTrace($"Attempting:{step.Replace("\n", "").Replace("\r", "")}");
-                    result = Engine.Eval(step, null, new ParserOptions() { AllowsSideEffects = true, Culture = culture });
+                    result = Engine.Eval(step, null, new ParserOptions() { AllowsSideEffects = true, Culture = culture, NumberIsFloat = true });
                 }
                 return result;
             }
             else
             {
                 Logger.LogTrace($"Attempting:\n\n{{\n{testSteps}}}");
-                return Engine.Eval(testSteps, null, new ParserOptions() { AllowsSideEffects = true, Culture = culture });
+                return Engine.Eval(testSteps, null, new ParserOptions() { AllowsSideEffects = true, Culture = culture, NumberIsFloat = true });
             }
         }
 
@@ -145,6 +145,13 @@ namespace Microsoft.PowerApps.TestEngine.PowerFx
             {
                 Engine.UpdateVariable(control.Key, control.Value);
             }
+        }
+
+        private static ParserOptions GetPowerFxParserOptions(CultureInfo culture)
+        {
+            // Currently support for decimal is in progress for PowerApps
+            // Power Fx by default treats number as decimal. Hence setting NumberIsFloat config to true in our case
+            return new ParserOptions() { AllowsSideEffects = true, Culture = culture, NumberIsFloat = true };
         }
 
         public IPowerAppFunctions GetPowerAppFunctions()

--- a/src/Microsoft.PowerApps.TestEngine/PowerFx/PowerFxHelper.cs
+++ b/src/Microsoft.PowerApps.TestEngine/PowerFx/PowerFxHelper.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+using System.Globalization;
 using Microsoft.PowerFx;
 using Microsoft.PowerFx.Syntax;
 
@@ -17,15 +18,16 @@ namespace Microsoft.PowerApps.TestEngine.PowerFx
         /// </summary>
         /// <param name="engine">Instance of an engine configured with the desired locale</param>
         /// <param name="result">Check result instance created after processing the expression</param>
+        /// <param name="culture">The locale to be used when excecuting tests</param>
         /// <returns>An enumerable of formulas extracted from the expression that are separated by chaining operator</returns>
-        public static IEnumerable<string> ExtractFormulasSeparatedByChainingOperator(Engine engine, CheckResult result)
+        public static IEnumerable<string> ExtractFormulasSeparatedByChainingOperator(Engine engine, CheckResult result, CultureInfo culture)
         {
             if (string.IsNullOrEmpty(result?.Parse?.Text))
             {
                 return new string[0];
             }
 
-            var spansForFormulasSeparatedAcrossMultipleDepths = ExtractSpansOfFormulasSeparatedByChainingOperator(engine, result?.Parse.Text);
+            var spansForFormulasSeparatedAcrossMultipleDepths = ExtractSpansOfFormulasSeparatedByChainingOperator(engine, result?.Parse.Text, culture);
             if (result?.Parse?.Root == null)
             {
                 return spansForFormulasSeparatedAcrossMultipleDepths.Select(span => result.Parse.Text.Substring(span.Start, span.End - span.Start));
@@ -40,10 +42,11 @@ namespace Microsoft.PowerApps.TestEngine.PowerFx
         /// </summary>
         /// <param name="engine">Instance of an engine configured with the desired locale</param>
         /// <param name="expression">Expression from which formulas separated by chaining operator would be extracted</param>
+        /// <param name="culture">The locale to be used when excecuting tests</param>
         /// <returns>Spans that represent formulas separated by chaining operator at multiple levels and depths</returns>
-        private static IEnumerable<Span> ExtractSpansOfFormulasSeparatedByChainingOperator(Engine engine, string expression)
+        private static IEnumerable<Span> ExtractSpansOfFormulasSeparatedByChainingOperator(Engine engine, string expression, CultureInfo culture)
         {
-            var chainOperatorTokens = engine.Tokenize(expression).Where(tok => tok.Kind == TokKind.Semicolon).OrderBy(tok => tok.Span.Min);
+            var chainOperatorTokens = engine.Tokenize(expression, culture).Where(tok => tok.Kind == TokKind.Semicolon).OrderBy(tok => tok.Span.Min);
             var formulas = new List<Span>();
             var lowerBound = 0;
 

--- a/src/Microsoft.PowerApps.TestEngine/SingleTestRunner.cs
+++ b/src/Microsoft.PowerApps.TestEngine/SingleTestRunner.cs
@@ -127,7 +127,7 @@ namespace Microsoft.PowerApps.TestEngine
                 await _testInfraFunctions.SetupNetworkRequestMockAsync();
 
                 // Set up Power Fx
-                _powerFxEngine.Setup(locale);
+                _powerFxEngine.Setup();
                 await _powerFxEngine.RunRequirementsCheckAsync();
                 await _powerFxEngine.UpdatePowerFxModelAsync();
 
@@ -160,15 +160,15 @@ namespace Microsoft.PowerApps.TestEngine
                             if (!string.IsNullOrEmpty(testSuiteDefinition.OnTestCaseStart))
                             {
                                 Logger.LogInformation($"Running OnTestCaseStart for test case: {testCase.TestCaseName}");
-                                await _powerFxEngine.ExecuteWithRetryAsync(testSuiteDefinition.OnTestCaseStart);
+                                await _powerFxEngine.ExecuteWithRetryAsync(testSuiteDefinition.OnTestCaseStart, locale);
                             }
 
-                            await _powerFxEngine.ExecuteWithRetryAsync(testCase.TestSteps);
+                            await _powerFxEngine.ExecuteWithRetryAsync(testCase.TestSteps, locale);
 
                             if (!string.IsNullOrEmpty(testSuiteDefinition.OnTestCaseComplete))
                             {
                                 Logger.LogInformation($"Running OnTestCaseComplete for test case: {testCase.TestCaseName}");
-                                await _powerFxEngine.ExecuteWithRetryAsync(testSuiteDefinition.OnTestCaseComplete);
+                                await _powerFxEngine.ExecuteWithRetryAsync(testSuiteDefinition.OnTestCaseComplete, locale);
                             }
 
                             _eventHandler.TestCaseEnd(true);
@@ -220,7 +220,7 @@ namespace Microsoft.PowerApps.TestEngine
                 {
                     Logger.LogInformation($"Running OnTestSuiteComplete for test suite: {testSuiteName}");
                     _testState.SetTestResultsDirectory(testResultDirectory);
-                    _powerFxEngine.Execute(testSuiteDefinition.OnTestSuiteComplete);
+                    _powerFxEngine.Execute(testSuiteDefinition.OnTestSuiteComplete, locale);
                 }
             }
             catch (Exception ex)


### PR DESCRIPTION
## Description

This PR upgrades the version of Microsoft.PowerFx.Interpreter to 0.2.6-preview, and addresses any compile time and breaking changes and also updates tests associated with this upgrade.

## Checklist

- [x] The code change is covered by unit tests. I have added tests that prove my fix is effective or that my feature works
- [x] I have performed end-to-end test locally.
- [x] New and existing unit tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I used clear names for everything
- [x] I have performed a self-review of my own code
