### PR TITLE
Fixing console url

### DIFF
--- a/src/Microsoft.PowerApps.TestEngine.Tests/ConsoleOutputTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/ConsoleOutputTests.cs
@@ -65,7 +65,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
             Assert.Contains("Running test suite: TestSuiteName", printer.ToString());
             Assert.Contains("\n   Test results will be stored in: ./testDirectory", printer.ToString());
             Assert.Contains("\n   Browser: Chromium", printer.ToString());
-            Assert.Contains("\n   App URL: make.powerapps.com/testapp", printer.ToString());
+            Assert.Contains("\n   App URL: make.powerapps.com/testapp&source=testengine", printer.ToString());
         }
 
         [Fact]

--- a/src/Microsoft.PowerApps.TestEngine/TestEngineEventHandler.cs
+++ b/src/Microsoft.PowerApps.TestEngine/TestEngineEventHandler.cs
@@ -46,7 +46,7 @@ namespace Microsoft.PowerApps.TestEngine
             Console.WriteLine($"Running test suite: {suiteName}");
             Console.WriteLine($"   Test results will be stored in: {directory}");
             Console.WriteLine($"   Browser: {browserName}");
-            Console.WriteLine($"   App URL: {url.Replace("&source=testengine", string.Empty)}");
+            Console.WriteLine($"   App URL: {url}");
         }
 
         public void SuiteEnd()


### PR DESCRIPTION
Currently source=testengine is not shown part of the app url in console output.
But this **console output is incorrect**, we need this to **dynamically load published&webplayer app JSSDK**.

**Solution**
Not replacing source=testengine from appurl  in console output
<img width="845" alt="image" src="https://github.com/microsoft/PowerApps-TestEngine/assets/98551644/641026f1-a2fd-4363-bfdc-4968d495b172">

## Checklist

- [x] The code change is covered by unit tests. I have added tests that prove my fix is effective or that my feature works
- [x] I have performed end-to-end test locally.
- [x] Existing unit tests pass locally with my changes
- [x] My changes generate no new warnings
- [x] I used clear names for everything
- [x] I have performed a self-review of my own code
