### PR TITLE
Updated docs\PowerFx and added link to SetProperty page

### DIFF
--- a/docs/PowerFX/README.md
+++ b/docs/PowerFX/README.md
@@ -1,10 +1,9 @@
 # Power Fx
 
-Any documented [Power Fx](https://docs.microsoft.com/en-us/power-platform/power-fx/overview) functions can be used
-
 There are several specifically defined functions for the test framework.
 
 - [Assert](./Assert.md)
 - [Screenshot](./Screenshot.md)
 - [Select](./Select.md)
+- [SetProperty](./SetProperty.md)
 - [Wait](./Wait.md)


### PR DESCRIPTION
# Description

Updated the Power Fx section of our doc to remove statement indicating "any Power Fx function supported". Also added a link to SetProperty page.

# Checklist

- [N/A] The code change is covered by unit tests. I have added tests that prove my fix is effective or that my feature works
- [N/A] I have performed end-to-end test locally.
- [N/A] New and existing unit tests pass locally with my changes
- [N/A] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I used clear names for everything
- [x] I have performed a self-review of my own code
