### PR TITLE
Users/nthekkumpat/update debug info

### DIFF
--- a/src/Microsoft.PowerApps.TestEngine.Tests/Helpers/LoggingHelpersTest.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/Helpers/LoggingHelpersTest.cs
@@ -43,7 +43,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Helpers
         public async Task DebugInfoWithSessionTest()
         {
             var obj = new ExpandoObject();
-            obj.TryAdd("sessionID", "somesessionId");
+            obj.TryAdd("sessionId", "somesessionId");
 
             MockPowerAppFunctions.Setup(x => x.GetDebugInfo()).Returns(Task.FromResult((object)obj));
             var loggingHelper = new LoggingHelper(MockPowerAppFunctions.Object, MockSingleTestInstanceState.Object);
@@ -51,7 +51,28 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Helpers
 
             MockPowerAppFunctions.Verify(x => x.GetDebugInfo(), Times.Once());
             LoggingTestHelper.VerifyLogging(MockLogger, "------------------------------\n Debug Info \n------------------------------", LogLevel.Information, Times.Once());
-            LoggingTestHelper.VerifyLogging(MockLogger, "sessionID:\tsomesessionId", LogLevel.Information, Times.Once());
+            LoggingTestHelper.VerifyLogging(MockLogger, "sessionId:\tsomesessionId", LogLevel.Information, Times.Once());
+        }
+
+        [Fact]
+        public async Task DebugInfoReturnsDetailsTest()
+        {
+            var obj = new ExpandoObject();
+            obj.TryAdd("appId", "someAppId");
+            obj.TryAdd("appVersion", "someAppVersionId");
+            obj.TryAdd("environmentId", "someEnvironmentId");
+            obj.TryAdd("sessionId", "someSessionId");
+
+            MockPowerAppFunctions.Setup(x => x.GetDebugInfo()).Returns(Task.FromResult((object)obj));
+            var loggingHelper = new LoggingHelper(MockPowerAppFunctions.Object, MockSingleTestInstanceState.Object);
+            loggingHelper.DebugInfo();
+
+            MockPowerAppFunctions.Verify(x => x.GetDebugInfo(), Times.Once());
+            LoggingTestHelper.VerifyLogging(MockLogger, "------------------------------\n Debug Info \n------------------------------", LogLevel.Information, Times.Once());
+            LoggingTestHelper.VerifyLogging(MockLogger, "appId:\tsomeAppId", LogLevel.Information, Times.Once());
+            LoggingTestHelper.VerifyLogging(MockLogger, "appVersion:\tsomeAppVersionId", LogLevel.Information, Times.Once());
+            LoggingTestHelper.VerifyLogging(MockLogger, "environmentId:\tsomeEnvironmentId", LogLevel.Information, Times.Once());
+            LoggingTestHelper.VerifyLogging(MockLogger, "sessionId:\tsomeSessionId", LogLevel.Information, Times.Once());
         }
     }
 }

--- a/src/Microsoft.PowerApps.TestEngine.Tests/Helpers/LoggingHelpersTest.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/Helpers/LoggingHelpersTest.cs
@@ -43,7 +43,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Helpers
         public async Task DebugInfoWithSessionTest()
         {
             var obj = new ExpandoObject();
-            obj.TryAdd("sessionId", "somesessionId");
+            obj.TryAdd("sessionID", "somesessionId");
 
             MockPowerAppFunctions.Setup(x => x.GetDebugInfo()).Returns(Task.FromResult((object)obj));
             var loggingHelper = new LoggingHelper(MockPowerAppFunctions.Object, MockSingleTestInstanceState.Object);
@@ -51,28 +51,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Helpers
 
             MockPowerAppFunctions.Verify(x => x.GetDebugInfo(), Times.Once());
             LoggingTestHelper.VerifyLogging(MockLogger, "------------------------------\n Debug Info \n------------------------------", LogLevel.Information, Times.Once());
-            LoggingTestHelper.VerifyLogging(MockLogger, "sessionId:\tsomesessionId", LogLevel.Information, Times.Once());
-        }
-
-        [Fact]
-        public async Task DebugInfoReturnsDetailsTest()
-        {
-            var obj = new ExpandoObject();
-            obj.TryAdd("appId", "someAppId");
-            obj.TryAdd("appVersion", "someAppVersionId");
-            obj.TryAdd("environmentId", "someEnvironmentId");
-            obj.TryAdd("sessionId", "someSessionId");
-
-            MockPowerAppFunctions.Setup(x => x.GetDebugInfo()).Returns(Task.FromResult((object)obj));
-            var loggingHelper = new LoggingHelper(MockPowerAppFunctions.Object, MockSingleTestInstanceState.Object);
-            loggingHelper.DebugInfo();
-
-            MockPowerAppFunctions.Verify(x => x.GetDebugInfo(), Times.Once());
-            LoggingTestHelper.VerifyLogging(MockLogger, "------------------------------\n Debug Info \n------------------------------", LogLevel.Information, Times.Once());
-            LoggingTestHelper.VerifyLogging(MockLogger, "appId:\tsomeAppId", LogLevel.Information, Times.Once());
-            LoggingTestHelper.VerifyLogging(MockLogger, "appVersion:\tsomeAppVersionId", LogLevel.Information, Times.Once());
-            LoggingTestHelper.VerifyLogging(MockLogger, "environmentId:\tsomeEnvironmentId", LogLevel.Information, Times.Once());
-            LoggingTestHelper.VerifyLogging(MockLogger, "sessionId:\tsomeSessionId", LogLevel.Information, Times.Once());
+            LoggingTestHelper.VerifyLogging(MockLogger, "sessionID:\tsomesessionId", LogLevel.Information, Times.Once());
         }
     }
 }

--- a/src/Microsoft.PowerApps.TestEngine.Tests/PowerApps/PowerAppFunctionsTest.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/PowerApps/PowerAppFunctionsTest.cs
@@ -600,7 +600,10 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerApps
             MockSingleTestInstanceState.Setup(x => x.GetLogger()).Returns(MockLogger.Object);
 
             var newSession = new ExpandoObject();
-            newSession.TryAdd("sessionID", "somesessionId");
+            newSession.TryAdd("appId", "someAppId");
+            newSession.TryAdd("appVersion", "someAppVersionId");
+            newSession.TryAdd("environmentId", "someEnvironmentId");
+            newSession.TryAdd("sessionId", "someSessionId");
 
             MockTestInfraFunctions.Setup(x => x.AddScriptTagAsync(It.IsAny<string>(), It.IsAny<string>())).Returns(Task.CompletedTask);
             MockTestInfraFunctions.SetupSequence(x => x.RunJavascriptAsync<object>("PowerAppsTestEngine.debugInfo"))

--- a/src/Microsoft.PowerApps.TestEngine.Tests/PowerApps/PowerAppFunctionsTest.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/PowerApps/PowerAppFunctionsTest.cs
@@ -600,10 +600,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerApps
             MockSingleTestInstanceState.Setup(x => x.GetLogger()).Returns(MockLogger.Object);
 
             var newSession = new ExpandoObject();
-            newSession.TryAdd("appId", "someAppId");
-            newSession.TryAdd("appVersion", "someAppVersionId");
-            newSession.TryAdd("environmentId", "someEnvironmentId");
-            newSession.TryAdd("sessionId", "someSessionId");
+            newSession.TryAdd("sessionID", "somesessionId");
 
             MockTestInfraFunctions.Setup(x => x.AddScriptTagAsync(It.IsAny<string>(), It.IsAny<string>())).Returns(Task.CompletedTask);
             MockTestInfraFunctions.SetupSequence(x => x.RunJavascriptAsync<object>("PowerAppsTestEngine.debugInfo"))

--- a/src/Microsoft.PowerApps.TestEngine.Tests/SingleTestRunnerTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/SingleTestRunnerTests.cs
@@ -298,13 +298,10 @@ namespace Microsoft.PowerApps.TestEngine.Tests
 
             SetupMocks(testData.testRunId, testData.testSuiteId, testData.testId, testData.appUrl, testData.testSuiteDefinition, true, testData.additionalFiles, testData.testSuiteLocale);
 
-            var debugObj = new ExpandoObject();
-            debugObj.TryAdd("appId", "someAppId");
-            debugObj.TryAdd("appVersion", "someAppVersionId");
-            debugObj.TryAdd("environmentId", "someEnvironmentId");
-            debugObj.TryAdd("sessionId", "someSessionId");
+            var obj = new ExpandoObject();
+            obj.TryAdd("sessionID", "somesessionId");
 
-            MockPowerAppFunctions.Setup(x => x.GetDebugInfo()).Returns(Task.FromResult((object)debugObj));
+            MockPowerAppFunctions.Setup(x => x.GetDebugInfo()).Returns(Task.FromResult((object)obj));
 
             var exceptionToThrow = new InvalidOperationException("Test exception");
             additionalMockSetup(exceptionToThrow);

--- a/src/Microsoft.PowerApps.TestEngine.Tests/SingleTestRunnerTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/SingleTestRunnerTests.cs
@@ -298,10 +298,13 @@ namespace Microsoft.PowerApps.TestEngine.Tests
 
             SetupMocks(testData.testRunId, testData.testSuiteId, testData.testId, testData.appUrl, testData.testSuiteDefinition, true, testData.additionalFiles, testData.testSuiteLocale);
 
-            var obj = new ExpandoObject();
-            obj.TryAdd("sessionID", "somesessionId");
+            var debugObj = new ExpandoObject();
+            debugObj.TryAdd("appId", "someAppId");
+            debugObj.TryAdd("appVersion", "someAppVersionId");
+            debugObj.TryAdd("environmentId", "someEnvironmentId");
+            debugObj.TryAdd("sessionId", "someSessionId");
 
-            MockPowerAppFunctions.Setup(x => x.GetDebugInfo()).Returns(Task.FromResult((object)obj));
+            MockPowerAppFunctions.Setup(x => x.GetDebugInfo()).Returns(Task.FromResult((object)debugObj));
 
             var exceptionToThrow = new InvalidOperationException("Test exception");
             additionalMockSetup(exceptionToThrow);

--- a/src/Microsoft.PowerApps.TestEngine/JS/CanvasAppSdk.js
+++ b/src/Microsoft.PowerApps.TestEngine/JS/CanvasAppSdk.js
@@ -151,6 +151,9 @@ var PowerAppsTestEngine = {
     },
 
     debugInfo: {
-        sessionID: Core.Telemetry?.Log?._sessionId
+        appId: Core.Telemetry?.Log?.getAppId(),
+        appVersion: Core.Telemetry?.Log?.getAppVersion(),
+        environmentId: Core.Telemetry?.Log?.getEnvironmentId(),
+        sessionId: Core.Telemetry?.Log?._sessionId,
     }
 }

--- a/src/Microsoft.PowerApps.TestEngine/JS/CanvasAppSdk.js
+++ b/src/Microsoft.PowerApps.TestEngine/JS/CanvasAppSdk.js
@@ -151,9 +151,6 @@ var PowerAppsTestEngine = {
     },
 
     debugInfo: {
-        appId: Core.Telemetry?.Log?.getAppId(),
-        appVersion: Core.Telemetry?.Log?.getAppVersion(),
-        environmentId: Core.Telemetry?.Log?.getEnvironmentId(),
-        sessionId: Core.Telemetry?.Log?._sessionId,
+        sessionID: Core.Telemetry?.Log?._sessionId
     }
 }


### PR DESCRIPTION
Currently session id is the only information in debugInfo.
**Capturing more details in the legacy webplayer JSSDK.** 

## Checklist
- [ ] The code change is covered by unit tests. I have added tests that prove my fix is effective or that my feature works
- [ ] I have performed end-to-end test locally.
- [ ] New and existing unit tests pass locally with my changes
- [ ] My changes generate no new warnings
- [ ] I used clear names for everything
- [ ] I have performed a self-review of my own code
