### PR TITLE
Fix Issue Where Moq Prints instead of actual Error

### DIFF
--- a/src/Microsoft.PowerApps.TestEngine.Tests/Helpers/PollingHelpersTest.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/Helpers/PollingHelpersTest.cs
@@ -39,6 +39,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Helpers
         [Fact]
         public void PollingSucceedsTest()
         {
+            LoggingTestHelper.SetupMock(MockLogger);
             Assert.True(PollingHelper.Poll(false, conditionToCheck, functionToCall, _enoughRuntime, MockLogger.Object));
         }
 
@@ -52,12 +53,14 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Helpers
         [Fact]
         public async Task PollingAsyncSucceedsTest()
         {
+            LoggingTestHelper.SetupMock(MockLogger);
             await PollingHelper.PollAsync(false, conditionToCheck, () => functionToCallAsync(), _enoughRuntime, MockLogger.Object);
         }
 
         [Fact]
         public void PollingAsyncTimeoutTest()
         {
+            LoggingTestHelper.SetupMock(MockLogger);
             Assert.ThrowsAsync<TimeoutException>(() => PollingHelper.PollAsync(false, conditionToCheck, () => functionToCallAsync(), _notEnoughRuntime, MockLogger.Object));
         }
 
@@ -71,6 +74,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Helpers
         [Fact]
         public void PollingAsyncThrowsOnInvalidArgumentsTest()
         {
+            LoggingTestHelper.SetupMock(MockLogger);
             Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => PollingHelper.PollAsync(false, conditionToCheck, () => functionToCallAsync(), _invalidRuntime, MockLogger.Object));
         }
 

--- a/src/Microsoft.PowerApps.TestEngine/Helpers/PollingHelper.cs
+++ b/src/Microsoft.PowerApps.TestEngine/Helpers/PollingHelper.cs
@@ -99,7 +99,7 @@ namespace Microsoft.PowerApps.TestEngine.Helpers
             }
         }
 
-        // Will not print out error message
+        // Will not give an exception message
         private static void CheckIfTimedOut(DateTime startTime, int timeout, ILogger logger)
         {
             if ((DateTime.Now - startTime) > TimeSpan.FromMilliseconds(timeout))


### PR DESCRIPTION
## Description

A Moq 'strict' failure was printing when an issue was logged, instead of what was actually supposed to be logged. This is because the logger must be setup in every test in this file, which it was not. Verified locally, this is what it looks like now:

<img width="359" alt="image" src="https://github.com/microsoft/PowerApps-TestEngine/assets/100798954/98dbe6a7-95b1-4c50-b115-16cf82949c7d">


## Checklist

- [x] The code change is covered by unit tests. I have added tests that prove my fix is effective or that my feature works
- [x] I have performed end-to-end test locally.
- [x] New and existing unit tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I used clear names for everything
- [x] I have performed a self-review of my own code
