### PR TITLE
CLI Input Sanitization

### DIFF
--- a/src/Microsoft.PowerApps.TestEngine.Tests/TestEngineTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/TestEngineTests.cs
@@ -308,7 +308,6 @@ namespace Microsoft.PowerApps.TestEngine.Tests
         [Theory]
         [InlineData(null, "Default-EnvironmentId", "a01af035-a529-4aaf-aded-011ad676f976", "apps.powerapps.com")]
         [InlineData("C:\\testPlan.fx.yaml", "", "a01af035-a529-4aaf-aded-011ad676f976", "apps.powerapps.com")]
-        [InlineData("C:\\testPlan.fx.yaml", "Default-EnvironmentId", "00000000-0000-0000-0000-000000000000", "apps.powerapps.com")]
         [InlineData("C:\\testPlan.fx.yaml", "Default-EnvironmentId", "a01af035-a529-4aaf-aded-011ad676f976", "")]
         public async Task TestEngineThrowsOnNullArguments(string testConfigFilePath, string environmentId, Guid tenantId, string domain)
         {

--- a/src/Microsoft.PowerApps.TestEngine/TestEngine.cs
+++ b/src/Microsoft.PowerApps.TestEngine/TestEngine.cs
@@ -72,7 +72,7 @@ namespace Microsoft.PowerApps.TestEngine
                     throw new ArgumentNullException(nameof(environmentId));
                 }
 
-                if (tenantId == null || tenantId == Guid.Empty)
+                if (tenantId == null)
                 {
                     throw new ArgumentNullException(nameof(tenantId));
                 }


### PR DESCRIPTION
# Description

Removed `Guid.Empty` from input sanitization with the idea as we don't want to error out the application for a valid Guid that has a value of "empty".

# Checklist

- [x] The code change is covered by unit tests. I have added tests that prove my fix is effective or that my feature works
- [x] I have performed end-to-end test locally.
- [x] New and existing unit tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I used clear names for everything
- [x] I have performed a self-review of my own code
