### PR TITLE
Adding UserInput or UserApp Exceptions

### DIFF
--- a/src/Microsoft.PowerApps.TestEngine.Tests/Config/TestStateTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/Config/TestStateTests.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.PowerApps.TestEngine.Config;
 using Moq;
 using Xunit;
+using ILogger = Microsoft.Extensions.Logging.ILogger;
 
 namespace Microsoft.PowerApps.TestEngine.Tests.Config
 {
@@ -110,9 +111,10 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Config
             var testConfigFile = "testPlan.fx.yaml";
 
             var testPlanDefinition = GenerateTestPlanDefinition();
+            var logger = new Mock<ILogger>(MockBehavior.Strict);
 
-            MockTestConfigParser.Setup(x => x.ParseTestConfig<TestPlanDefinition>(It.IsAny<string>())).Returns(testPlanDefinition);
-            state.ParseAndSetTestState(testConfigFile);
+            MockTestConfigParser.Setup(x => x.ParseTestConfig<TestPlanDefinition>(It.IsAny<string>(), logger.Object)).Returns(testPlanDefinition);
+            state.ParseAndSetTestState(testConfigFile, logger.Object);
 
             var testSuiteDefinitions = state.GetTestSuiteDefinition();
             Assert.NotNull(testSuiteDefinitions);
@@ -162,10 +164,12 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Config
             testPlanDefinition.TestSettings.FilePath = testSettingsFile;
             testPlanDefinition.EnvironmentVariables.FilePath = environmentVariablesFile;
 
-            MockTestConfigParser.Setup(x => x.ParseTestConfig<TestPlanDefinition>(It.IsAny<string>())).Returns(testPlanDefinition);
-            MockTestConfigParser.Setup(x => x.ParseTestConfig<TestSettings>(It.IsAny<string>())).Returns(testSettings);
-            MockTestConfigParser.Setup(x => x.ParseTestConfig<EnvironmentVariables>(It.IsAny<string>())).Returns(environmentVariables);
-            state.ParseAndSetTestState(testConfigFile);
+            var logger = new Mock<ILogger>(MockBehavior.Strict);
+
+            MockTestConfigParser.Setup(x => x.ParseTestConfig<TestPlanDefinition>(It.IsAny<string>(), logger.Object)).Returns(testPlanDefinition);
+            MockTestConfigParser.Setup(x => x.ParseTestConfig<TestSettings>(It.IsAny<string>(), logger.Object)).Returns(testSettings);
+            MockTestConfigParser.Setup(x => x.ParseTestConfig<EnvironmentVariables>(It.IsAny<string>(), logger.Object)).Returns(environmentVariables);
+            state.ParseAndSetTestState(testConfigFile, logger.Object);
 
             var actualTestSettings = state.GetTestSettings();
             Assert.NotNull(actualTestSettings);
@@ -183,7 +187,9 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Config
         public void ParseAndSetTestStateThrowsOnInvalidTestConfigFile(string testConfigPath)
         {
             var state = new TestState(MockTestConfigParser.Object);
-            Assert.Throws<ArgumentNullException>(() => state.ParseAndSetTestState(testConfigPath));
+            var logger = new Mock<ILogger>(MockBehavior.Strict);
+
+            Assert.Throws<ArgumentNullException>(() => state.ParseAndSetTestState(testConfigPath, logger.Object));
         }
 
         [Fact]
@@ -193,9 +199,10 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Config
             var testConfigFile = "testPlan.fx.yaml";
             var testPlanDefinition = GenerateTestPlanDefinition();
             testPlanDefinition.TestSuite = null;
+            var logger = new Mock<ILogger>(MockBehavior.Strict);
 
-            MockTestConfigParser.Setup(x => x.ParseTestConfig<TestPlanDefinition>(It.IsAny<string>())).Returns(testPlanDefinition);
-            Assert.Throws<InvalidOperationException>(() => state.ParseAndSetTestState(testConfigFile));
+            MockTestConfigParser.Setup(x => x.ParseTestConfig<TestPlanDefinition>(It.IsAny<string>(), logger.Object)).Returns(testPlanDefinition);
+            Assert.Throws<InvalidOperationException>(() => state.ParseAndSetTestState(testConfigFile, logger.Object));
         }
 
         [Theory]
@@ -207,9 +214,10 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Config
             var testConfigFile = "testPlan.fx.yaml";
             var testPlanDefinition = GenerateTestPlanDefinition();
             testPlanDefinition.TestSuite.TestSuiteName = testName;
+            var logger = new Mock<ILogger>(MockBehavior.Strict);
 
-            MockTestConfigParser.Setup(x => x.ParseTestConfig<TestPlanDefinition>(It.IsAny<string>())).Returns(testPlanDefinition);
-            Assert.Throws<InvalidOperationException>(() => state.ParseAndSetTestState(testConfigFile));
+            MockTestConfigParser.Setup(x => x.ParseTestConfig<TestPlanDefinition>(It.IsAny<string>(), logger.Object)).Returns(testPlanDefinition);
+            Assert.Throws<InvalidOperationException>(() => state.ParseAndSetTestState(testConfigFile, logger.Object));
         }
 
         [Theory]
@@ -221,9 +229,10 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Config
             var testConfigFile = "testPlan.fx.yaml";
             var testPlanDefinition = GenerateTestPlanDefinition();
             testPlanDefinition.TestSuite.Persona = persona;
+            var logger = new Mock<ILogger>(MockBehavior.Strict);
 
-            MockTestConfigParser.Setup(x => x.ParseTestConfig<TestPlanDefinition>(It.IsAny<string>())).Returns(testPlanDefinition);
-            Assert.Throws<InvalidOperationException>(() => state.ParseAndSetTestState(testConfigFile));
+            MockTestConfigParser.Setup(x => x.ParseTestConfig<TestPlanDefinition>(It.IsAny<string>(), logger.Object)).Returns(testPlanDefinition);
+            Assert.Throws<InvalidOperationException>(() => state.ParseAndSetTestState(testConfigFile, logger.Object));
         }
 
         [Theory]
@@ -238,9 +247,10 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Config
             var testPlanDefinition = GenerateTestPlanDefinition();
             testPlanDefinition.TestSuite.AppLogicalName = appLogicalName;
             testPlanDefinition.TestSuite.AppId = appId;
+            var logger = new Mock<ILogger>(MockBehavior.Strict);
 
-            MockTestConfigParser.Setup(x => x.ParseTestConfig<TestPlanDefinition>(It.IsAny<string>())).Returns(testPlanDefinition);
-            Assert.Throws<InvalidOperationException>(() => state.ParseAndSetTestState(testConfigFile));
+            MockTestConfigParser.Setup(x => x.ParseTestConfig<TestPlanDefinition>(It.IsAny<string>(), logger.Object)).Returns(testPlanDefinition);
+            Assert.Throws<InvalidOperationException>(() => state.ParseAndSetTestState(testConfigFile, logger.Object));
         }
 
         [Theory]
@@ -253,9 +263,10 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Config
             var testPlanDefinition = GenerateTestPlanDefinition();
             testPlanDefinition.TestSuite.AppLogicalName = appLogicalName;
             testPlanDefinition.TestSuite.AppId = appId;
+            var logger = new Mock<ILogger>(MockBehavior.Strict);
 
-            MockTestConfigParser.Setup(x => x.ParseTestConfig<TestPlanDefinition>(It.IsAny<string>())).Returns(testPlanDefinition);
-            state.ParseAndSetTestState(testConfigFile);
+            MockTestConfigParser.Setup(x => x.ParseTestConfig<TestPlanDefinition>(It.IsAny<string>(), logger.Object)).Returns(testPlanDefinition);
+            state.ParseAndSetTestState(testConfigFile, logger.Object);
             Assert.Equal(state.GetTestSuiteDefinition().AppLogicalName, appLogicalName);
             Assert.Equal(state.GetTestSuiteDefinition().AppId, appId);
         }
@@ -267,9 +278,10 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Config
             var testConfigFile = "testPlan.fx.yaml";
             var testPlanDefinition = GenerateTestPlanDefinition();
             testPlanDefinition.TestSuite.TestCases = new List<TestCase>();
+            var logger = new Mock<ILogger>(MockBehavior.Strict);
 
-            MockTestConfigParser.Setup(x => x.ParseTestConfig<TestPlanDefinition>(It.IsAny<string>())).Returns(testPlanDefinition);
-            Assert.Throws<InvalidOperationException>(() => state.ParseAndSetTestState(testConfigFile));
+            MockTestConfigParser.Setup(x => x.ParseTestConfig<TestPlanDefinition>(It.IsAny<string>(), logger.Object)).Returns(testPlanDefinition);
+            Assert.Throws<InvalidOperationException>(() => state.ParseAndSetTestState(testConfigFile, logger.Object));
         }
 
         [Theory]
@@ -281,9 +293,10 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Config
             var testConfigFile = "testPlan.fx.yaml";
             var testPlanDefinition = GenerateTestPlanDefinition();
             testPlanDefinition.TestSuite.TestCases[0].TestCaseName = testCaseName;
+            var logger = new Mock<ILogger>(MockBehavior.Strict);
 
-            MockTestConfigParser.Setup(x => x.ParseTestConfig<TestPlanDefinition>(It.IsAny<string>())).Returns(testPlanDefinition);
-            Assert.Throws<InvalidOperationException>(() => state.ParseAndSetTestState(testConfigFile));
+            MockTestConfigParser.Setup(x => x.ParseTestConfig<TestPlanDefinition>(It.IsAny<string>(), logger.Object)).Returns(testPlanDefinition);
+            Assert.Throws<InvalidOperationException>(() => state.ParseAndSetTestState(testConfigFile, logger.Object));
         }
 
         [Theory]
@@ -295,9 +308,10 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Config
             var testConfigFile = "testPlan.fx.yaml";
             var testPlanDefinition = GenerateTestPlanDefinition();
             testPlanDefinition.TestSuite.TestCases[0].TestSteps = testSteps;
+            var logger = new Mock<ILogger>(MockBehavior.Strict);
 
-            MockTestConfigParser.Setup(x => x.ParseTestConfig<TestPlanDefinition>(It.IsAny<string>())).Returns(testPlanDefinition);
-            Assert.Throws<InvalidOperationException>(() => state.ParseAndSetTestState(testConfigFile));
+            MockTestConfigParser.Setup(x => x.ParseTestConfig<TestPlanDefinition>(It.IsAny<string>(), logger.Object)).Returns(testPlanDefinition);
+            Assert.Throws<InvalidOperationException>(() => state.ParseAndSetTestState(testConfigFile, logger.Object));
         }
 
         [Fact]
@@ -307,9 +321,10 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Config
             var testConfigFile = "testPlan.fx.yaml";
             var testPlanDefinition = GenerateTestPlanDefinition();
             testPlanDefinition.TestSettings = null;
+            var logger = new Mock<ILogger>(MockBehavior.Strict);
 
-            MockTestConfigParser.Setup(x => x.ParseTestConfig<TestPlanDefinition>(It.IsAny<string>())).Returns(testPlanDefinition);
-            Assert.Throws<InvalidOperationException>(() => state.ParseAndSetTestState(testConfigFile));
+            MockTestConfigParser.Setup(x => x.ParseTestConfig<TestPlanDefinition>(It.IsAny<string>(), logger.Object)).Returns(testPlanDefinition);
+            Assert.Throws<InvalidOperationException>(() => state.ParseAndSetTestState(testConfigFile, logger.Object));
         }
 
         [Fact]
@@ -319,9 +334,10 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Config
             var testConfigFile = "testPlan.fx.yaml";
             var testPlanDefinition = GenerateTestPlanDefinition();
             testPlanDefinition.TestSettings.BrowserConfigurations = null;
+            var logger = new Mock<ILogger>(MockBehavior.Strict);
 
-            MockTestConfigParser.Setup(x => x.ParseTestConfig<TestPlanDefinition>(It.IsAny<string>())).Returns(testPlanDefinition);
-            Assert.Throws<InvalidOperationException>(() => state.ParseAndSetTestState(testConfigFile));
+            MockTestConfigParser.Setup(x => x.ParseTestConfig<TestPlanDefinition>(It.IsAny<string>(), logger.Object)).Returns(testPlanDefinition);
+            Assert.Throws<InvalidOperationException>(() => state.ParseAndSetTestState(testConfigFile, logger.Object));
         }
 
         [Fact]
@@ -331,9 +347,10 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Config
             var testConfigFile = "testPlan.fx.yaml";
             var testPlanDefinition = GenerateTestPlanDefinition();
             testPlanDefinition.TestSettings.BrowserConfigurations = new List<BrowserConfiguration>();
+            var logger = new Mock<ILogger>(MockBehavior.Strict);
 
-            MockTestConfigParser.Setup(x => x.ParseTestConfig<TestPlanDefinition>(It.IsAny<string>())).Returns(testPlanDefinition);
-            Assert.Throws<InvalidOperationException>(() => state.ParseAndSetTestState(testConfigFile));
+            MockTestConfigParser.Setup(x => x.ParseTestConfig<TestPlanDefinition>(It.IsAny<string>(), logger.Object)).Returns(testPlanDefinition);
+            Assert.Throws<InvalidOperationException>(() => state.ParseAndSetTestState(testConfigFile, logger.Object));
         }
 
         [Theory]
@@ -345,9 +362,10 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Config
             var testConfigFile = "testPlan.fx.yaml";
             var testPlanDefinition = GenerateTestPlanDefinition();
             testPlanDefinition.TestSettings.BrowserConfigurations.Add(new BrowserConfiguration() { Browser = browser });
+            var logger = new Mock<ILogger>(MockBehavior.Strict);
 
-            MockTestConfigParser.Setup(x => x.ParseTestConfig<TestPlanDefinition>(It.IsAny<string>())).Returns(testPlanDefinition);
-            Assert.Throws<InvalidOperationException>(() => state.ParseAndSetTestState(testConfigFile));
+            MockTestConfigParser.Setup(x => x.ParseTestConfig<TestPlanDefinition>(It.IsAny<string>(), logger.Object)).Returns(testPlanDefinition);
+            Assert.Throws<InvalidOperationException>(() => state.ParseAndSetTestState(testConfigFile, logger.Object));
         }
 
         [Theory]
@@ -364,9 +382,10 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Config
                 ScreenWidth = screenWidth,
                 ScreenHeight = screenHeight
             });
+            var logger = new Mock<ILogger>(MockBehavior.Strict);
 
-            MockTestConfigParser.Setup(x => x.ParseTestConfig<TestPlanDefinition>(It.IsAny<string>())).Returns(testPlanDefinition);
-            Assert.Throws<InvalidOperationException>(() => state.ParseAndSetTestState(testConfigFile));
+            MockTestConfigParser.Setup(x => x.ParseTestConfig<TestPlanDefinition>(It.IsAny<string>(), logger.Object)).Returns(testPlanDefinition);
+            Assert.Throws<InvalidOperationException>(() => state.ParseAndSetTestState(testConfigFile, logger.Object));
         }
 
         [Fact]
@@ -376,9 +395,10 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Config
             var testConfigFile = "testPlan.fx.yaml";
             var testPlanDefinition = GenerateTestPlanDefinition();
             testPlanDefinition.EnvironmentVariables = null;
+            var logger = new Mock<ILogger>(MockBehavior.Strict);
 
-            MockTestConfigParser.Setup(x => x.ParseTestConfig<TestPlanDefinition>(It.IsAny<string>())).Returns(testPlanDefinition);
-            Assert.Throws<InvalidOperationException>(() => state.ParseAndSetTestState(testConfigFile));
+            MockTestConfigParser.Setup(x => x.ParseTestConfig<TestPlanDefinition>(It.IsAny<string>(), logger.Object)).Returns(testPlanDefinition);
+            Assert.Throws<InvalidOperationException>(() => state.ParseAndSetTestState(testConfigFile, logger.Object));
         }
 
         [Fact]
@@ -388,9 +408,10 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Config
             var testConfigFile = "testPlan.fx.yaml";
             var testPlanDefinition = GenerateTestPlanDefinition();
             testPlanDefinition.EnvironmentVariables.Users = null;
+            var logger = new Mock<ILogger>(MockBehavior.Strict);
 
-            MockTestConfigParser.Setup(x => x.ParseTestConfig<TestPlanDefinition>(It.IsAny<string>())).Returns(testPlanDefinition);
-            Assert.Throws<InvalidOperationException>(() => state.ParseAndSetTestState(testConfigFile));
+            MockTestConfigParser.Setup(x => x.ParseTestConfig<TestPlanDefinition>(It.IsAny<string>(), logger.Object)).Returns(testPlanDefinition);
+            Assert.Throws<InvalidOperationException>(() => state.ParseAndSetTestState(testConfigFile, logger.Object));
         }
 
         [Fact]
@@ -400,9 +421,10 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Config
             var testConfigFile = "testPlan.fx.yaml";
             var testPlanDefinition = GenerateTestPlanDefinition();
             testPlanDefinition.EnvironmentVariables.Users = new List<UserConfiguration>();
+            var logger = new Mock<ILogger>(MockBehavior.Strict);
 
-            MockTestConfigParser.Setup(x => x.ParseTestConfig<TestPlanDefinition>(It.IsAny<string>())).Returns(testPlanDefinition);
-            Assert.Throws<InvalidOperationException>(() => state.ParseAndSetTestState(testConfigFile));
+            MockTestConfigParser.Setup(x => x.ParseTestConfig<TestPlanDefinition>(It.IsAny<string>(), logger.Object)).Returns(testPlanDefinition);
+            Assert.Throws<InvalidOperationException>(() => state.ParseAndSetTestState(testConfigFile, logger.Object));
         }
 
         [Theory]
@@ -414,9 +436,10 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Config
             var testConfigFile = "testPlan.fx.yaml";
             var testPlanDefinition = GenerateTestPlanDefinition();
             testPlanDefinition.EnvironmentVariables.Users[0].PersonaName = personaName;
+            var logger = new Mock<ILogger>(MockBehavior.Strict);
 
-            MockTestConfigParser.Setup(x => x.ParseTestConfig<TestPlanDefinition>(It.IsAny<string>())).Returns(testPlanDefinition);
-            Assert.Throws<InvalidOperationException>(() => state.ParseAndSetTestState(testConfigFile));
+            MockTestConfigParser.Setup(x => x.ParseTestConfig<TestPlanDefinition>(It.IsAny<string>(), logger.Object)).Returns(testPlanDefinition);
+            Assert.Throws<InvalidOperationException>(() => state.ParseAndSetTestState(testConfigFile, logger.Object));
         }
 
         [Theory]
@@ -428,9 +451,10 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Config
             var testConfigFile = "testPlan.fx.yaml";
             var testPlanDefinition = GenerateTestPlanDefinition();
             testPlanDefinition.EnvironmentVariables.Users[0].EmailKey = emailKey;
+            var logger = new Mock<ILogger>(MockBehavior.Strict);
 
-            MockTestConfigParser.Setup(x => x.ParseTestConfig<TestPlanDefinition>(It.IsAny<string>())).Returns(testPlanDefinition);
-            Assert.Throws<InvalidOperationException>(() => state.ParseAndSetTestState(testConfigFile));
+            MockTestConfigParser.Setup(x => x.ParseTestConfig<TestPlanDefinition>(It.IsAny<string>(), logger.Object)).Returns(testPlanDefinition);
+            Assert.Throws<InvalidOperationException>(() => state.ParseAndSetTestState(testConfigFile, logger.Object));
         }
 
         [Theory]
@@ -442,9 +466,10 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Config
             var testConfigFile = "testPlan.fx.yaml";
             var testPlanDefinition = GenerateTestPlanDefinition();
             testPlanDefinition.EnvironmentVariables.Users[0].PasswordKey = passwordKey;
+            var logger = new Mock<ILogger>(MockBehavior.Strict);
 
-            MockTestConfigParser.Setup(x => x.ParseTestConfig<TestPlanDefinition>(It.IsAny<string>())).Returns(testPlanDefinition);
-            Assert.Throws<InvalidOperationException>(() => state.ParseAndSetTestState(testConfigFile));
+            MockTestConfigParser.Setup(x => x.ParseTestConfig<TestPlanDefinition>(It.IsAny<string>(), logger.Object)).Returns(testPlanDefinition);
+            Assert.Throws<InvalidOperationException>(() => state.ParseAndSetTestState(testConfigFile, logger.Object));
         }
 
         [Fact]
@@ -454,9 +479,10 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Config
             var testConfigFile = "testPlan.fx.yaml";
             var testPlanDefinition = GenerateTestPlanDefinition();
             testPlanDefinition.TestSuite.Persona = Guid.NewGuid().ToString();
+            var logger = new Mock<ILogger>(MockBehavior.Strict);
 
-            MockTestConfigParser.Setup(x => x.ParseTestConfig<TestPlanDefinition>(It.IsAny<string>())).Returns(testPlanDefinition);
-            Assert.Throws<InvalidOperationException>(() => state.ParseAndSetTestState(testConfigFile));
+            MockTestConfigParser.Setup(x => x.ParseTestConfig<TestPlanDefinition>(It.IsAny<string>(), logger.Object)).Returns(testPlanDefinition);
+            Assert.Throws<InvalidOperationException>(() => state.ParseAndSetTestState(testConfigFile, logger.Object));
         }
 
         [Theory]

--- a/src/Microsoft.PowerApps.TestEngine.Tests/Config/TestStateTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/Config/TestStateTests.cs
@@ -3,9 +3,12 @@
 
 using System;
 using System.Collections.Generic;
+using System.Reflection.Emit;
 using Castle.Core.Logging;
 using Microsoft.Extensions.Logging;
 using Microsoft.PowerApps.TestEngine.Config;
+using Microsoft.PowerApps.TestEngine.System;
+using Microsoft.PowerApps.TestEngine.Tests.Helpers;
 using Moq;
 using Xunit;
 using ILogger = Microsoft.Extensions.Logging.ILogger;
@@ -200,9 +203,10 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Config
             var testPlanDefinition = GenerateTestPlanDefinition();
             testPlanDefinition.TestSuite = null;
             var logger = new Mock<ILogger>(MockBehavior.Strict);
+            LoggingTestHelper.SetupMock(logger);
 
             MockTestConfigParser.Setup(x => x.ParseTestConfig<TestPlanDefinition>(It.IsAny<string>(), logger.Object)).Returns(testPlanDefinition);
-            Assert.Throws<InvalidOperationException>(() => state.ParseAndSetTestState(testConfigFile, logger.Object));
+            Assert.Throws<UserInputException>(() => state.ParseAndSetTestState(testConfigFile, logger.Object));
         }
 
         [Theory]
@@ -215,9 +219,10 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Config
             var testPlanDefinition = GenerateTestPlanDefinition();
             testPlanDefinition.TestSuite.TestSuiteName = testName;
             var logger = new Mock<ILogger>(MockBehavior.Strict);
+            LoggingTestHelper.SetupMock(logger);
 
             MockTestConfigParser.Setup(x => x.ParseTestConfig<TestPlanDefinition>(It.IsAny<string>(), logger.Object)).Returns(testPlanDefinition);
-            Assert.Throws<InvalidOperationException>(() => state.ParseAndSetTestState(testConfigFile, logger.Object));
+            Assert.Throws<UserInputException>(() => state.ParseAndSetTestState(testConfigFile, logger.Object));
         }
 
         [Theory]
@@ -230,9 +235,10 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Config
             var testPlanDefinition = GenerateTestPlanDefinition();
             testPlanDefinition.TestSuite.Persona = persona;
             var logger = new Mock<ILogger>(MockBehavior.Strict);
+            LoggingTestHelper.SetupMock(logger);
 
             MockTestConfigParser.Setup(x => x.ParseTestConfig<TestPlanDefinition>(It.IsAny<string>(), logger.Object)).Returns(testPlanDefinition);
-            Assert.Throws<InvalidOperationException>(() => state.ParseAndSetTestState(testConfigFile, logger.Object));
+            Assert.Throws<UserInputException>(() => state.ParseAndSetTestState(testConfigFile, logger.Object));
         }
 
         [Theory]
@@ -248,9 +254,10 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Config
             testPlanDefinition.TestSuite.AppLogicalName = appLogicalName;
             testPlanDefinition.TestSuite.AppId = appId;
             var logger = new Mock<ILogger>(MockBehavior.Strict);
+            LoggingTestHelper.SetupMock(logger);
 
             MockTestConfigParser.Setup(x => x.ParseTestConfig<TestPlanDefinition>(It.IsAny<string>(), logger.Object)).Returns(testPlanDefinition);
-            Assert.Throws<InvalidOperationException>(() => state.ParseAndSetTestState(testConfigFile, logger.Object));
+            Assert.Throws<UserInputException>(() => state.ParseAndSetTestState(testConfigFile, logger.Object));
         }
 
         [Theory]
@@ -264,6 +271,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Config
             testPlanDefinition.TestSuite.AppLogicalName = appLogicalName;
             testPlanDefinition.TestSuite.AppId = appId;
             var logger = new Mock<ILogger>(MockBehavior.Strict);
+            LoggingTestHelper.SetupMock(logger);
 
             MockTestConfigParser.Setup(x => x.ParseTestConfig<TestPlanDefinition>(It.IsAny<string>(), logger.Object)).Returns(testPlanDefinition);
             state.ParseAndSetTestState(testConfigFile, logger.Object);
@@ -279,9 +287,10 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Config
             var testPlanDefinition = GenerateTestPlanDefinition();
             testPlanDefinition.TestSuite.TestCases = new List<TestCase>();
             var logger = new Mock<ILogger>(MockBehavior.Strict);
+            LoggingTestHelper.SetupMock(logger);
 
             MockTestConfigParser.Setup(x => x.ParseTestConfig<TestPlanDefinition>(It.IsAny<string>(), logger.Object)).Returns(testPlanDefinition);
-            Assert.Throws<InvalidOperationException>(() => state.ParseAndSetTestState(testConfigFile, logger.Object));
+            Assert.Throws<UserInputException>(() => state.ParseAndSetTestState(testConfigFile, logger.Object));
         }
 
         [Theory]
@@ -294,9 +303,10 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Config
             var testPlanDefinition = GenerateTestPlanDefinition();
             testPlanDefinition.TestSuite.TestCases[0].TestCaseName = testCaseName;
             var logger = new Mock<ILogger>(MockBehavior.Strict);
+            LoggingTestHelper.SetupMock(logger);
 
             MockTestConfigParser.Setup(x => x.ParseTestConfig<TestPlanDefinition>(It.IsAny<string>(), logger.Object)).Returns(testPlanDefinition);
-            Assert.Throws<InvalidOperationException>(() => state.ParseAndSetTestState(testConfigFile, logger.Object));
+            Assert.Throws<UserInputException>(() => state.ParseAndSetTestState(testConfigFile, logger.Object));
         }
 
         [Theory]
@@ -309,9 +319,10 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Config
             var testPlanDefinition = GenerateTestPlanDefinition();
             testPlanDefinition.TestSuite.TestCases[0].TestSteps = testSteps;
             var logger = new Mock<ILogger>(MockBehavior.Strict);
+            LoggingTestHelper.SetupMock(logger);
 
             MockTestConfigParser.Setup(x => x.ParseTestConfig<TestPlanDefinition>(It.IsAny<string>(), logger.Object)).Returns(testPlanDefinition);
-            Assert.Throws<InvalidOperationException>(() => state.ParseAndSetTestState(testConfigFile, logger.Object));
+            Assert.Throws<UserInputException>(() => state.ParseAndSetTestState(testConfigFile, logger.Object));
         }
 
         [Fact]
@@ -322,9 +333,10 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Config
             var testPlanDefinition = GenerateTestPlanDefinition();
             testPlanDefinition.TestSettings = null;
             var logger = new Mock<ILogger>(MockBehavior.Strict);
+            LoggingTestHelper.SetupMock(logger);
 
             MockTestConfigParser.Setup(x => x.ParseTestConfig<TestPlanDefinition>(It.IsAny<string>(), logger.Object)).Returns(testPlanDefinition);
-            Assert.Throws<InvalidOperationException>(() => state.ParseAndSetTestState(testConfigFile, logger.Object));
+            Assert.Throws<UserInputException>(() => state.ParseAndSetTestState(testConfigFile, logger.Object));
         }
 
         [Fact]
@@ -335,9 +347,10 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Config
             var testPlanDefinition = GenerateTestPlanDefinition();
             testPlanDefinition.TestSettings.BrowserConfigurations = null;
             var logger = new Mock<ILogger>(MockBehavior.Strict);
+            LoggingTestHelper.SetupMock(logger);
 
             MockTestConfigParser.Setup(x => x.ParseTestConfig<TestPlanDefinition>(It.IsAny<string>(), logger.Object)).Returns(testPlanDefinition);
-            Assert.Throws<InvalidOperationException>(() => state.ParseAndSetTestState(testConfigFile, logger.Object));
+            Assert.Throws<UserInputException>(() => state.ParseAndSetTestState(testConfigFile, logger.Object));
         }
 
         [Fact]
@@ -348,9 +361,10 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Config
             var testPlanDefinition = GenerateTestPlanDefinition();
             testPlanDefinition.TestSettings.BrowserConfigurations = new List<BrowserConfiguration>();
             var logger = new Mock<ILogger>(MockBehavior.Strict);
+            LoggingTestHelper.SetupMock(logger);
 
             MockTestConfigParser.Setup(x => x.ParseTestConfig<TestPlanDefinition>(It.IsAny<string>(), logger.Object)).Returns(testPlanDefinition);
-            Assert.Throws<InvalidOperationException>(() => state.ParseAndSetTestState(testConfigFile, logger.Object));
+            Assert.Throws<UserInputException>(() => state.ParseAndSetTestState(testConfigFile, logger.Object));
         }
 
         [Theory]
@@ -363,9 +377,10 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Config
             var testPlanDefinition = GenerateTestPlanDefinition();
             testPlanDefinition.TestSettings.BrowserConfigurations.Add(new BrowserConfiguration() { Browser = browser });
             var logger = new Mock<ILogger>(MockBehavior.Strict);
+            LoggingTestHelper.SetupMock(logger);
 
             MockTestConfigParser.Setup(x => x.ParseTestConfig<TestPlanDefinition>(It.IsAny<string>(), logger.Object)).Returns(testPlanDefinition);
-            Assert.Throws<InvalidOperationException>(() => state.ParseAndSetTestState(testConfigFile, logger.Object));
+            Assert.Throws<UserInputException>(() => state.ParseAndSetTestState(testConfigFile, logger.Object));
         }
 
         [Theory]
@@ -383,9 +398,10 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Config
                 ScreenHeight = screenHeight
             });
             var logger = new Mock<ILogger>(MockBehavior.Strict);
+            LoggingTestHelper.SetupMock(logger);
 
             MockTestConfigParser.Setup(x => x.ParseTestConfig<TestPlanDefinition>(It.IsAny<string>(), logger.Object)).Returns(testPlanDefinition);
-            Assert.Throws<InvalidOperationException>(() => state.ParseAndSetTestState(testConfigFile, logger.Object));
+            Assert.Throws<UserInputException>(() => state.ParseAndSetTestState(testConfigFile, logger.Object));
         }
 
         [Fact]
@@ -396,9 +412,10 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Config
             var testPlanDefinition = GenerateTestPlanDefinition();
             testPlanDefinition.EnvironmentVariables = null;
             var logger = new Mock<ILogger>(MockBehavior.Strict);
+            LoggingTestHelper.SetupMock(logger);
 
             MockTestConfigParser.Setup(x => x.ParseTestConfig<TestPlanDefinition>(It.IsAny<string>(), logger.Object)).Returns(testPlanDefinition);
-            Assert.Throws<InvalidOperationException>(() => state.ParseAndSetTestState(testConfigFile, logger.Object));
+            Assert.Throws<UserInputException>(() => state.ParseAndSetTestState(testConfigFile, logger.Object));
         }
 
         [Fact]
@@ -409,9 +426,10 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Config
             var testPlanDefinition = GenerateTestPlanDefinition();
             testPlanDefinition.EnvironmentVariables.Users = null;
             var logger = new Mock<ILogger>(MockBehavior.Strict);
+            LoggingTestHelper.SetupMock(logger);
 
             MockTestConfigParser.Setup(x => x.ParseTestConfig<TestPlanDefinition>(It.IsAny<string>(), logger.Object)).Returns(testPlanDefinition);
-            Assert.Throws<InvalidOperationException>(() => state.ParseAndSetTestState(testConfigFile, logger.Object));
+            Assert.Throws<UserInputException>(() => state.ParseAndSetTestState(testConfigFile, logger.Object));
         }
 
         [Fact]
@@ -422,9 +440,10 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Config
             var testPlanDefinition = GenerateTestPlanDefinition();
             testPlanDefinition.EnvironmentVariables.Users = new List<UserConfiguration>();
             var logger = new Mock<ILogger>(MockBehavior.Strict);
+            LoggingTestHelper.SetupMock(logger);
 
             MockTestConfigParser.Setup(x => x.ParseTestConfig<TestPlanDefinition>(It.IsAny<string>(), logger.Object)).Returns(testPlanDefinition);
-            Assert.Throws<InvalidOperationException>(() => state.ParseAndSetTestState(testConfigFile, logger.Object));
+            Assert.Throws<UserInputException>(() => state.ParseAndSetTestState(testConfigFile, logger.Object));
         }
 
         [Theory]
@@ -437,9 +456,10 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Config
             var testPlanDefinition = GenerateTestPlanDefinition();
             testPlanDefinition.EnvironmentVariables.Users[0].PersonaName = personaName;
             var logger = new Mock<ILogger>(MockBehavior.Strict);
+            LoggingTestHelper.SetupMock(logger);
 
             MockTestConfigParser.Setup(x => x.ParseTestConfig<TestPlanDefinition>(It.IsAny<string>(), logger.Object)).Returns(testPlanDefinition);
-            Assert.Throws<InvalidOperationException>(() => state.ParseAndSetTestState(testConfigFile, logger.Object));
+            Assert.Throws<UserInputException>(() => state.ParseAndSetTestState(testConfigFile, logger.Object));
         }
 
         [Theory]
@@ -452,9 +472,10 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Config
             var testPlanDefinition = GenerateTestPlanDefinition();
             testPlanDefinition.EnvironmentVariables.Users[0].EmailKey = emailKey;
             var logger = new Mock<ILogger>(MockBehavior.Strict);
+            LoggingTestHelper.SetupMock(logger);
 
             MockTestConfigParser.Setup(x => x.ParseTestConfig<TestPlanDefinition>(It.IsAny<string>(), logger.Object)).Returns(testPlanDefinition);
-            Assert.Throws<InvalidOperationException>(() => state.ParseAndSetTestState(testConfigFile, logger.Object));
+            Assert.Throws<UserInputException>(() => state.ParseAndSetTestState(testConfigFile, logger.Object));
         }
 
         [Theory]
@@ -467,9 +488,10 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Config
             var testPlanDefinition = GenerateTestPlanDefinition();
             testPlanDefinition.EnvironmentVariables.Users[0].PasswordKey = passwordKey;
             var logger = new Mock<ILogger>(MockBehavior.Strict);
+            LoggingTestHelper.SetupMock(logger);
 
             MockTestConfigParser.Setup(x => x.ParseTestConfig<TestPlanDefinition>(It.IsAny<string>(), logger.Object)).Returns(testPlanDefinition);
-            Assert.Throws<InvalidOperationException>(() => state.ParseAndSetTestState(testConfigFile, logger.Object));
+            Assert.Throws<UserInputException>(() => state.ParseAndSetTestState(testConfigFile, logger.Object));
         }
 
         [Fact]
@@ -480,9 +502,10 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Config
             var testPlanDefinition = GenerateTestPlanDefinition();
             testPlanDefinition.TestSuite.Persona = Guid.NewGuid().ToString();
             var logger = new Mock<ILogger>(MockBehavior.Strict);
+            LoggingTestHelper.SetupMock(logger);
 
             MockTestConfigParser.Setup(x => x.ParseTestConfig<TestPlanDefinition>(It.IsAny<string>(), logger.Object)).Returns(testPlanDefinition);
-            Assert.Throws<InvalidOperationException>(() => state.ParseAndSetTestState(testConfigFile, logger.Object));
+            Assert.Throws<UserInputException>(() => state.ParseAndSetTestState(testConfigFile, logger.Object));
         }
 
         [Theory]

--- a/src/Microsoft.PowerApps.TestEngine.Tests/Config/TestStateTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/Config/TestStateTests.cs
@@ -524,7 +524,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Config
             testPlanDefinition.EnvironmentVariables.Users[0].EmailKey = emailKey;
             MockLoggerFactory.Setup(x => x.CreateLogger(It.IsAny<string>())).Returns(MockLogger.Object);
             LoggingTestHelper.SetupMock(MockLogger);
-            var expectedErrorMessage = "Invalid User Input(s): Missing email key, Persona specified in test is not listed in environment variables";
+            var expectedErrorMessage = "Invalid User Input(s): Missing email key";
             MockTestConfigParser.Setup(x => x.ParseTestConfig<TestPlanDefinition>(It.IsAny<string>(), MockLogger.Object)).Returns(testPlanDefinition);
 
             var ex = Assert.Throws<UserInputException>(() => state.ParseAndSetTestState(testConfigFile, MockLogger.Object));
@@ -543,7 +543,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Config
             testPlanDefinition.EnvironmentVariables.Users[0].PasswordKey = passwordKey;
             MockLoggerFactory.Setup(x => x.CreateLogger(It.IsAny<string>())).Returns(MockLogger.Object);
             LoggingTestHelper.SetupMock(MockLogger);
-            var expectedErrorMessage = "Invalid User Input(s): Missing password key, Persona specified in test is not listed in environment variables";
+            var expectedErrorMessage = "Invalid User Input(s): Missing password key";
             MockTestConfigParser.Setup(x => x.ParseTestConfig<TestPlanDefinition>(It.IsAny<string>(), MockLogger.Object)).Returns(testPlanDefinition);
 
             var ex = Assert.Throws<UserInputException>(() => state.ParseAndSetTestState(testConfigFile, MockLogger.Object));

--- a/src/Microsoft.PowerApps.TestEngine.Tests/Config/TestStateTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/Config/TestStateTests.cs
@@ -505,9 +505,12 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Config
             testPlanDefinition.EnvironmentVariables.Users[0].PersonaName = personaName;
             MockLoggerFactory.Setup(x => x.CreateLogger(It.IsAny<string>())).Returns(MockLogger.Object);
             LoggingTestHelper.SetupMock(MockLogger);
-
+            var expectedErrorMessage = "Invalid User Input(s): Missing persona name, Persona specified in test is not listed in environment variables";
             MockTestConfigParser.Setup(x => x.ParseTestConfig<TestPlanDefinition>(It.IsAny<string>(), MockLogger.Object)).Returns(testPlanDefinition);
-            Assert.Throws<UserInputException>(() => state.ParseAndSetTestState(testConfigFile, MockLogger.Object));
+
+            var ex = Assert.Throws<UserInputException>(() => state.ParseAndSetTestState(testConfigFile, MockLogger.Object));
+            Assert.Equal(UserInputException.errorMapping.UserInputExceptionTestConfig.ToString(), ex.Message);
+            LoggingTestHelper.VerifyLogging(MockLogger, expectedErrorMessage, LogLevel.Error, Times.Once());
         }
 
         [Theory]
@@ -521,9 +524,12 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Config
             testPlanDefinition.EnvironmentVariables.Users[0].EmailKey = emailKey;
             MockLoggerFactory.Setup(x => x.CreateLogger(It.IsAny<string>())).Returns(MockLogger.Object);
             LoggingTestHelper.SetupMock(MockLogger);
-
+            var expectedErrorMessage = "Invalid User Input(s): Missing email key, Persona specified in test is not listed in environment variables";
             MockTestConfigParser.Setup(x => x.ParseTestConfig<TestPlanDefinition>(It.IsAny<string>(), MockLogger.Object)).Returns(testPlanDefinition);
-            Assert.Throws<UserInputException>(() => state.ParseAndSetTestState(testConfigFile, MockLogger.Object));
+
+            var ex = Assert.Throws<UserInputException>(() => state.ParseAndSetTestState(testConfigFile, MockLogger.Object));
+            Assert.Equal(UserInputException.errorMapping.UserInputExceptionTestConfig.ToString(), ex.Message);
+            LoggingTestHelper.VerifyLogging(MockLogger, expectedErrorMessage, LogLevel.Error, Times.Once());
         }
 
         [Theory]
@@ -537,9 +543,12 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Config
             testPlanDefinition.EnvironmentVariables.Users[0].PasswordKey = passwordKey;
             MockLoggerFactory.Setup(x => x.CreateLogger(It.IsAny<string>())).Returns(MockLogger.Object);
             LoggingTestHelper.SetupMock(MockLogger);
-
+            var expectedErrorMessage = "Invalid User Input(s): Missing password key, Persona specified in test is not listed in environment variables";
             MockTestConfigParser.Setup(x => x.ParseTestConfig<TestPlanDefinition>(It.IsAny<string>(), MockLogger.Object)).Returns(testPlanDefinition);
-            Assert.Throws<UserInputException>(() => state.ParseAndSetTestState(testConfigFile, MockLogger.Object));
+
+            var ex = Assert.Throws<UserInputException>(() => state.ParseAndSetTestState(testConfigFile, MockLogger.Object));
+            Assert.Equal(UserInputException.errorMapping.UserInputExceptionTestConfig.ToString(), ex.Message);
+            LoggingTestHelper.VerifyLogging(MockLogger, expectedErrorMessage, LogLevel.Error, Times.Once());
         }
 
         [Fact]
@@ -551,9 +560,34 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Config
             testPlanDefinition.TestSuite.Persona = Guid.NewGuid().ToString();
             MockLoggerFactory.Setup(x => x.CreateLogger(It.IsAny<string>())).Returns(MockLogger.Object);
             LoggingTestHelper.SetupMock(MockLogger);
-
+            var expectedErrorMessage = "Invalid User Input(s): Persona specified in test is not listed in environment variables";
             MockTestConfigParser.Setup(x => x.ParseTestConfig<TestPlanDefinition>(It.IsAny<string>(), MockLogger.Object)).Returns(testPlanDefinition);
-            Assert.Throws<UserInputException>(() => state.ParseAndSetTestState(testConfigFile, MockLogger.Object));
+
+            var ex = Assert.Throws<UserInputException>(() => state.ParseAndSetTestState(testConfigFile, MockLogger.Object));
+            Assert.Equal(UserInputException.errorMapping.UserInputExceptionTestConfig.ToString(), ex.Message);
+            LoggingTestHelper.VerifyLogging(MockLogger, expectedErrorMessage, LogLevel.Error, Times.Once());
+        }
+
+        [Fact]
+        public void ParseAndSetTestStateThrowsOnMulitpleMissingValues()
+        {
+            var state = new TestState(MockTestConfigParser.Object);
+            var testConfigFile = "testPlan.fx.yaml";
+            var testPlanDefinition = GenerateTestPlanDefinition();
+            var expectedErrorMessage = "Invalid User Input(s): Must be at least one test case, Missing test settings from test plan, Missing browser configuration from test plan, Persona specified in test is not listed in environment variables";
+
+            // setting testcases to null
+            testPlanDefinition.TestSuite.TestCases = null;
+            testPlanDefinition.TestSettings = null;
+            testPlanDefinition.TestSuite.Persona = Guid.NewGuid().ToString();  
+            
+            MockLoggerFactory.Setup(x => x.CreateLogger(It.IsAny<string>())).Returns(MockLogger.Object);
+            LoggingTestHelper.SetupMock(MockLogger);
+            MockTestConfigParser.Setup(x => x.ParseTestConfig<TestPlanDefinition>(It.IsAny<string>(), MockLogger.Object)).Returns(testPlanDefinition);
+
+            var ex = Assert.Throws<UserInputException>(() => state.ParseAndSetTestState(testConfigFile, MockLogger.Object));
+            Assert.Equal(UserInputException.errorMapping.UserInputExceptionTestConfig.ToString(), ex.Message);
+            LoggingTestHelper.VerifyLogging(MockLogger, expectedErrorMessage, LogLevel.Error, Times.Once());
         }
 
         [Theory]

--- a/src/Microsoft.PowerApps.TestEngine.Tests/Config/YamlTestConfigParserTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/Config/YamlTestConfigParserTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 using System;
+using Microsoft.Extensions.Logging;
 using Microsoft.PowerApps.TestEngine.Config;
 using Microsoft.PowerApps.TestEngine.System;
 using Moq;
@@ -59,7 +60,9 @@ environmentVariables:
 
             var filePath = "testplan.fx.yaml";
             mockFileSystem.Setup(f => f.ReadAllText(It.IsAny<string>())).Returns(yamlFile);
-            var testPlan = parser.ParseTestConfig<TestPlanDefinition>(filePath);
+            var logger = new Mock<ILogger>(MockBehavior.Strict);
+            var testPlan = parser.ParseTestConfig<TestPlanDefinition>(filePath, logger.Object);
+
             Assert.NotNull(testPlan);
             Assert.Equal("Button Clicker", testPlan.TestSuite?.TestSuiteName);
             Assert.Equal("Verifies that counter increments when the button is clicked", testPlan.TestSuite?.TestSuiteDescription);
@@ -136,7 +139,9 @@ environmentVariables:
 
             var filePath = "testplan.fx.yaml";
             mockFileSystem.Setup(f => f.ReadAllText(It.IsAny<string>())).Returns(yamlFile);
-            var testPlan = parser.ParseTestConfig<TestPlanDefinition>(filePath);
+            var logger = new Mock<ILogger>(MockBehavior.Strict);
+            var testPlan = parser.ParseTestConfig<TestPlanDefinition>(filePath, logger.Object);
+
             Assert.NotNull(testPlan);
             Assert.Equal("Button Clicker", testPlan.TestSuite?.TestSuiteName);
             Assert.Equal("Verifies that counter increments when the button is clicked", testPlan.TestSuite?.TestSuiteDescription);
@@ -214,7 +219,9 @@ environmentVariables:
 
             var filePath = "testplan.fx.yaml";
             mockFileSystem.Setup(f => f.ReadAllText(It.IsAny<string>())).Returns(yamlFile);
-            var testPlan = parser.ParseTestConfig<TestPlanDefinition>(filePath);
+            var logger = new Mock<ILogger>(MockBehavior.Strict);
+            var testPlan = parser.ParseTestConfig<TestPlanDefinition>(filePath, logger.Object);
+
             Assert.NotNull(testPlan);
             Assert.Equal("Button Clicker", testPlan.TestSuite?.TestSuiteName);
             Assert.Equal("Verifies that counter increments when the button is clicked", testPlan.TestSuite?.TestSuiteDescription);
@@ -257,7 +264,9 @@ environmentVariables:
 
             var filePath = "environmentVariables.fx.yaml";
             mockFileSystem.Setup(f => f.ReadAllText(It.IsAny<string>())).Returns(environmentVariablesFile);
-            var environmentVariables = parser.ParseTestConfig<EnvironmentVariables>(filePath);
+            var logger = new Mock<ILogger>(MockBehavior.Strict);
+            var environmentVariables = parser.ParseTestConfig<EnvironmentVariables>(filePath, logger.Object);
+
             Assert.NotNull(environmentVariables);
             Assert.Single(environmentVariables.Users);
             Assert.Equal("User1", environmentVariables.Users[0].PersonaName);
@@ -280,7 +289,9 @@ enablePowerFxOverlay: false";
 
             var filePath = "testSettings.fx.yaml";
             mockFileSystem.Setup(f => f.ReadAllText(It.IsAny<string>())).Returns(testSettingsFile);
-            var testSettings = parser.ParseTestConfig<TestSettings>(filePath);
+            var logger = new Mock<ILogger>(MockBehavior.Strict);
+            var testSettings = parser.ParseTestConfig<TestSettings>(filePath, logger.Object);
+
             Assert.NotNull(testSettings);
             Assert.True(testSettings.RecordVideo);
             Assert.False(testSettings.Headless);
@@ -306,7 +317,9 @@ enablePowerFxOverlay: false";
 
             var filePath = "testSettings.fx.yaml";
             mockFileSystem.Setup(f => f.ReadAllText(It.IsAny<string>())).Returns(testSettingsFile);
-            var testSettings = parser.ParseTestConfig<TestSettings>(filePath);
+            var logger = new Mock<ILogger>(MockBehavior.Strict);
+            var testSettings = parser.ParseTestConfig<TestSettings>(filePath, logger.Object);
+
             Assert.NotNull(testSettings);
             Assert.True(testSettings.RecordVideo);
             Assert.False(testSettings.Headless);
@@ -324,7 +337,9 @@ enablePowerFxOverlay: false";
         {
             var mockFileSystem = new Mock<IFileSystem>(MockBehavior.Strict);
             var parser = new YamlTestConfigParser(mockFileSystem.Object);
-            Assert.Throws<ArgumentNullException>(() => parser.ParseTestConfig<TestPlanDefinition>(filePath));
+            var logger = new Mock<ILogger>(MockBehavior.Strict);
+
+            Assert.Throws<ArgumentNullException>(() => parser.ParseTestConfig<TestPlanDefinition>(filePath, logger.Object));
         }
     }
 }

--- a/src/Microsoft.PowerApps.TestEngine.Tests/Config/YamlTestConfigParserTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/Config/YamlTestConfigParserTests.cs
@@ -60,6 +60,7 @@ environmentVariables:
 
             var filePath = "testplan.fx.yaml";
             mockFileSystem.Setup(f => f.ReadAllText(It.IsAny<string>())).Returns(yamlFile);
+            mockFileSystem.Setup(f => f.fileExists(It.IsAny<string>())).Returns(true);
             var logger = new Mock<ILogger>(MockBehavior.Strict);
             var testPlan = parser.ParseTestConfig<TestPlanDefinition>(filePath, logger.Object);
 
@@ -139,7 +140,9 @@ environmentVariables:
 
             var filePath = "testplan.fx.yaml";
             mockFileSystem.Setup(f => f.ReadAllText(It.IsAny<string>())).Returns(yamlFile);
+            mockFileSystem.Setup(f => f.fileExists(It.IsAny<string>())).Returns(true);
             var logger = new Mock<ILogger>(MockBehavior.Strict);
+
             var testPlan = parser.ParseTestConfig<TestPlanDefinition>(filePath, logger.Object);
 
             Assert.NotNull(testPlan);
@@ -219,7 +222,9 @@ environmentVariables:
 
             var filePath = "testplan.fx.yaml";
             mockFileSystem.Setup(f => f.ReadAllText(It.IsAny<string>())).Returns(yamlFile);
+            mockFileSystem.Setup(f => f.fileExists(It.IsAny<string>())).Returns(true);
             var logger = new Mock<ILogger>(MockBehavior.Strict);
+
             var testPlan = parser.ParseTestConfig<TestPlanDefinition>(filePath, logger.Object);
 
             Assert.NotNull(testPlan);
@@ -264,7 +269,9 @@ environmentVariables:
 
             var filePath = "environmentVariables.fx.yaml";
             mockFileSystem.Setup(f => f.ReadAllText(It.IsAny<string>())).Returns(environmentVariablesFile);
+            mockFileSystem.Setup(f => f.fileExists(It.IsAny<string>())).Returns(true);
             var logger = new Mock<ILogger>(MockBehavior.Strict);
+
             var environmentVariables = parser.ParseTestConfig<EnvironmentVariables>(filePath, logger.Object);
 
             Assert.NotNull(environmentVariables);
@@ -289,7 +296,9 @@ enablePowerFxOverlay: false";
 
             var filePath = "testSettings.fx.yaml";
             mockFileSystem.Setup(f => f.ReadAllText(It.IsAny<string>())).Returns(testSettingsFile);
+            mockFileSystem.Setup(f => f.fileExists(It.IsAny<string>())).Returns(true);
             var logger = new Mock<ILogger>(MockBehavior.Strict);
+
             var testSettings = parser.ParseTestConfig<TestSettings>(filePath, logger.Object);
 
             Assert.NotNull(testSettings);
@@ -317,7 +326,9 @@ enablePowerFxOverlay: false";
 
             var filePath = "testSettings.fx.yaml";
             mockFileSystem.Setup(f => f.ReadAllText(It.IsAny<string>())).Returns(testSettingsFile);
+            mockFileSystem.Setup(f => f.fileExists(It.IsAny<string>())).Returns(true);
             var logger = new Mock<ILogger>(MockBehavior.Strict);
+
             var testSettings = parser.ParseTestConfig<TestSettings>(filePath, logger.Object);
 
             Assert.NotNull(testSettings);

--- a/src/Microsoft.PowerApps.TestEngine.Tests/ConsoleOutputTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/ConsoleOutputTests.cs
@@ -2,23 +2,8 @@
 // Licensed under the MIT license.
 
 using System;
-using System.Collections.Generic;
-using System.Dynamic;
-using System.Globalization;
 using System.IO;
-using System.Linq;
-using System.Threading.Tasks;
-using Microsoft.Extensions.Logging;
-using Microsoft.PowerApps.TestEngine.Config;
-using Microsoft.PowerApps.TestEngine.PowerApps;
-using Microsoft.PowerApps.TestEngine.PowerFx;
-using Microsoft.PowerApps.TestEngine.Reporting;
 using Microsoft.PowerApps.TestEngine.System;
-using Microsoft.PowerApps.TestEngine.TestInfra;
-using Microsoft.PowerApps.TestEngine.Tests.Helpers;
-using Microsoft.PowerApps.TestEngine.Users;
-using Microsoft.PowerFx.Types;
-using Moq;
 using Xunit;
 
 namespace Microsoft.PowerApps.TestEngine.Tests
@@ -174,6 +159,45 @@ namespace Microsoft.PowerApps.TestEngine.Tests
 
             // Assert none of the browser runs failed to show incorrect failed cases
             Assert.DoesNotContain("Cases failed: 0", printer.ToString());
+        }
+
+        [Fact]
+        public void TestEncounteredUserAppException()
+        {
+            // Specify expected result and output object
+            var expected = "[Critical Error] Could not access PowerApps. For more details, check the logs.";
+            var printer = new StringWriter();
+            Exception ex = new UserAppException();
+
+            // Set output
+            Console.SetOut(printer);
+
+            // Run function
+            _testEngineEventHandler.EncounteredException(ex);
+
+            // Assert that the expected output matches the console output of the function
+            Assert.Contains(expected, printer.ToString());
+        }
+
+        [Theory]
+        [InlineData(nameof(UserInputException.errorMapping.UserInputExceptionInvalidFilePath), "Invalid file path. For more details, check the logs.")]
+        [InlineData(nameof(UserInputException.errorMapping.UserInputExceptionLoginCredential), "Invalid login credential(s). For more details, check the logs.")]
+        [InlineData(nameof(UserInputException.errorMapping.UserInputExceptionTestConfig), "Invalid test config. For more details, check the logs.")]
+        [InlineData(nameof(UserInputException.errorMapping.UserInputExceptionYAMLFormat), "Invalid YAML format. For more details, check the logs.")]
+        public void TestEncounteredUserInputException(string exceptionName, string expectedMessage)
+        {
+            // Specify expected result and output object
+            var printer = new StringWriter();
+            Exception ex = new UserInputException(exceptionName);
+
+            // Set output
+            Console.SetOut(printer);
+
+            // Run function
+            _testEngineEventHandler.EncounteredException(ex);
+
+            // Assert that the expected output matches the console output of the function
+            Assert.Contains(expectedMessage, printer.ToString());
         }
     }
 }

--- a/src/Microsoft.PowerApps.TestEngine.Tests/Helpers/LoggingHelpersTest.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/Helpers/LoggingHelpersTest.cs
@@ -109,6 +109,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Helpers
 
             // Verify UserAppException is passed to TestEngineEventHandler
             MockTestEngineEventHandler.Verify(x => x.EncounteredException(It.IsAny<UserAppException>()), Times.Once());
+            LoggingTestHelper.VerifyLogging(MockLogger, "Issue getting DebugInfo. This can be a result of not being properly logged in.", LogLevel.Debug, Times.Once());
         }
     }
 }

--- a/src/Microsoft.PowerApps.TestEngine.Tests/Helpers/LoggingHelpersTest.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/Helpers/LoggingHelpersTest.cs
@@ -43,7 +43,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Helpers
         public async Task DebugInfoWithSessionTest()
         {
             var obj = new ExpandoObject();
-            obj.TryAdd("sessionID", "somesessionId");
+            obj.TryAdd("sessionId", "somesessionId");
 
             MockPowerAppFunctions.Setup(x => x.GetDebugInfo()).Returns(Task.FromResult((object)obj));
             var loggingHelper = new LoggingHelper(MockPowerAppFunctions.Object, MockSingleTestInstanceState.Object);
@@ -51,7 +51,28 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Helpers
 
             MockPowerAppFunctions.Verify(x => x.GetDebugInfo(), Times.Once());
             LoggingTestHelper.VerifyLogging(MockLogger, "------------------------------\n Debug Info \n------------------------------", LogLevel.Information, Times.Once());
-            LoggingTestHelper.VerifyLogging(MockLogger, "sessionID:\tsomesessionId", LogLevel.Information, Times.Once());
+            LoggingTestHelper.VerifyLogging(MockLogger, "sessionId:\tsomesessionId", LogLevel.Information, Times.Once());
+        }
+
+        [Fact]
+        public async Task DebugInfoReturnsDetailsTest()
+        {
+            var obj = new ExpandoObject();
+            obj.TryAdd("appId", "someAppId");
+            obj.TryAdd("appVersion", "someAppVersionId");
+            obj.TryAdd("environmentId", "someEnvironmentId");
+            obj.TryAdd("sessionId", "someSessionId");
+
+            MockPowerAppFunctions.Setup(x => x.GetDebugInfo()).Returns(Task.FromResult((object)obj));
+            var loggingHelper = new LoggingHelper(MockPowerAppFunctions.Object, MockSingleTestInstanceState.Object);
+            loggingHelper.DebugInfo();
+
+            MockPowerAppFunctions.Verify(x => x.GetDebugInfo(), Times.Once());
+            LoggingTestHelper.VerifyLogging(MockLogger, "------------------------------\n Debug Info \n------------------------------", LogLevel.Information, Times.Once());
+            LoggingTestHelper.VerifyLogging(MockLogger, "appId:\tsomeAppId", LogLevel.Information, Times.Once());
+            LoggingTestHelper.VerifyLogging(MockLogger, "appVersion:\tsomeAppVersionId", LogLevel.Information, Times.Once());
+            LoggingTestHelper.VerifyLogging(MockLogger, "environmentId:\tsomeEnvironmentId", LogLevel.Information, Times.Once());
+            LoggingTestHelper.VerifyLogging(MockLogger, "sessionId:\tsomeSessionId", LogLevel.Information, Times.Once());
         }
     }
 }

--- a/src/Microsoft.PowerApps.TestEngine.Tests/Helpers/LoggingHelpersTest.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/Helpers/LoggingHelpersTest.cs
@@ -43,7 +43,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Helpers
         public async Task DebugInfoWithSessionTest()
         {
             var obj = new ExpandoObject();
-            obj.TryAdd("sessionId", "somesessionId");
+            obj.TryAdd("sessionID", "somesessionId");
 
             MockPowerAppFunctions.Setup(x => x.GetDebugInfo()).Returns(Task.FromResult((object)obj));
             var loggingHelper = new LoggingHelper(MockPowerAppFunctions.Object, MockSingleTestInstanceState.Object);
@@ -51,28 +51,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Helpers
 
             MockPowerAppFunctions.Verify(x => x.GetDebugInfo(), Times.Once());
             LoggingTestHelper.VerifyLogging(MockLogger, "------------------------------\n Debug Info \n------------------------------", LogLevel.Information, Times.Once());
-            LoggingTestHelper.VerifyLogging(MockLogger, "sessionId:\tsomesessionId", LogLevel.Information, Times.Once());
-        }
-
-        [Fact]
-        public async Task DebugInfoReturnsDetailsTest()
-        {
-            var obj = new ExpandoObject();
-            obj.TryAdd("appId", "someAppId");
-            obj.TryAdd("appVersion", "someAppVersionId");
-            obj.TryAdd("environmentId", "someEnvironmentId");
-            obj.TryAdd("sessionId", "someSessionId");
-
-            MockPowerAppFunctions.Setup(x => x.GetDebugInfo()).Returns(Task.FromResult((object)obj));
-            var loggingHelper = new LoggingHelper(MockPowerAppFunctions.Object, MockSingleTestInstanceState.Object);
-            loggingHelper.DebugInfo();
-
-            MockPowerAppFunctions.Verify(x => x.GetDebugInfo(), Times.Once());
-            LoggingTestHelper.VerifyLogging(MockLogger, "------------------------------\n Debug Info \n------------------------------", LogLevel.Information, Times.Once());
-            LoggingTestHelper.VerifyLogging(MockLogger, "appId:\tsomeAppId", LogLevel.Information, Times.Once());
-            LoggingTestHelper.VerifyLogging(MockLogger, "appVersion:\tsomeAppVersionId", LogLevel.Information, Times.Once());
-            LoggingTestHelper.VerifyLogging(MockLogger, "environmentId:\tsomeEnvironmentId", LogLevel.Information, Times.Once());
-            LoggingTestHelper.VerifyLogging(MockLogger, "sessionId:\tsomeSessionId", LogLevel.Information, Times.Once());
+            LoggingTestHelper.VerifyLogging(MockLogger, "sessionID:\tsomesessionId", LogLevel.Information, Times.Once());
         }
     }
 }

--- a/src/Microsoft.PowerApps.TestEngine.Tests/PowerApps/PowerAppFunctionsTest.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/PowerApps/PowerAppFunctionsTest.cs
@@ -600,7 +600,10 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerApps
             MockSingleTestInstanceState.Setup(x => x.GetLogger()).Returns(MockLogger.Object);
 
             var newSession = new ExpandoObject();
-            newSession.TryAdd("sessionID", "somesessionId");
+            newSession.TryAdd("appId", "someAppId");
+            newSession.TryAdd("appVersion", "someAppVersionId");
+            newSession.TryAdd("environmentId", "someEnvironmentId");
+            newSession.TryAdd("sessionId", "someSessionId");
 
             MockTestInfraFunctions.Setup(x => x.AddScriptTagAsync(It.IsAny<string>(), It.IsAny<string>())).Returns(Task.CompletedTask);
             MockTestInfraFunctions.SetupSequence(x => x.RunJavascriptAsync<object>("PowerAppsTestEngine.debugInfo"))

--- a/src/Microsoft.PowerApps.TestEngine.Tests/PowerApps/PowerAppFunctionsTest.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/PowerApps/PowerAppFunctionsTest.cs
@@ -600,10 +600,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerApps
             MockSingleTestInstanceState.Setup(x => x.GetLogger()).Returns(MockLogger.Object);
 
             var newSession = new ExpandoObject();
-            newSession.TryAdd("appId", "someAppId");
-            newSession.TryAdd("appVersion", "someAppVersionId");
-            newSession.TryAdd("environmentId", "someEnvironmentId");
-            newSession.TryAdd("sessionId", "someSessionId");
+            newSession.TryAdd("sessionID", "somesessionId");
 
             MockTestInfraFunctions.Setup(x => x.AddScriptTagAsync(It.IsAny<string>(), It.IsAny<string>())).Returns(Task.CompletedTask);
             MockTestInfraFunctions.SetupSequence(x => x.RunJavascriptAsync<object>("PowerAppsTestEngine.debugInfo"))

--- a/src/Microsoft.PowerApps.TestEngine.Tests/SingleTestRunnerTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/SingleTestRunnerTests.cs
@@ -419,6 +419,35 @@ namespace Microsoft.PowerApps.TestEngine.Tests
             VerifyFinallyExecution(testData.testResultDirectory, 1, 1, 0);
         }
 
+        [Fact]
+        public async Task UserInputExceptionHandlingTest()
+        {
+            // Arrange
+            var singleTestRunner = new SingleTestRunner(MockTestReporter.Object,
+                                                           MockPowerFxEngine.Object,
+                                                           MockTestInfraFunctions.Object,
+                                                           MockUserManager.Object,
+                                                           MockTestState.Object,
+                                                           MockUrlMapper.Object,
+                                                           MockFileSystem.Object,
+                                                           MockLoggerFactory.Object,
+                                                           MockTestEngineEventHandler.Object);
+
+            var testData = new TestDataOne();
+            SetupMocks(testData.testRunId, testData.testSuiteId, testData.testId, testData.appUrl, testData.testSuiteDefinition, true, testData.additionalFiles, testData.testSuiteLocale);
+            var locale = string.IsNullOrEmpty(testData.testSuiteLocale) ? CultureInfo.CurrentCulture : new CultureInfo(testData.testSuiteLocale);
+
+            // Specific setup for this test
+            var exceptionToThrow = new UserInputException(UserInputException.errorMapping.UserInputExceptionLoginCredential.ToString());
+            MockUserManager.Setup(x => x.LoginAsUserAsync(It.IsAny<string>())).Throws(exceptionToThrow);
+            MockTestEngineEventHandler.Setup(x => x.EncounteredException(It.IsAny<Exception>()));            
+
+            // Act
+            await singleTestRunner.RunTestAsync(testData.testRunId, testData.testRunDirectory, testData.testSuiteDefinition, testData.browserConfig, "", "", locale);
+
+            // Assert
+            MockTestEngineEventHandler.Verify(x => x.EncounteredException(exceptionToThrow), Times.Once());
+        } 
         // Sample Test Data for test with OnTestCaseStart, OnTestCaseComplete and OnTestSuiteComplete
         class TestDataOne
         {

--- a/src/Microsoft.PowerApps.TestEngine.Tests/SingleTestRunnerTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/SingleTestRunnerTests.cs
@@ -298,13 +298,10 @@ namespace Microsoft.PowerApps.TestEngine.Tests
 
             SetupMocks(testData.testRunId, testData.testSuiteId, testData.testId, testData.appUrl, testData.testSuiteDefinition, true, testData.additionalFiles, testData.testSuiteLocale);
 
-            var debugObj = new ExpandoObject();
-            debugObj.TryAdd("appId", "someAppId");
-            debugObj.TryAdd("appVersion", "someAppVersionId");
-            debugObj.TryAdd("environmentId", "someEnvironmentId");
-            debugObj.TryAdd("sessionId", "someSessionId");
+            var obj = new ExpandoObject();
+            obj.TryAdd("sessionID", "somesessionId");
 
-            MockPowerAppFunctions.Setup(x => x.GetDebugInfo()).Returns(Task.FromResult((object)debugObj));
+            MockPowerAppFunctions.Setup(x => x.GetDebugInfo()).Returns(Task.FromResult((object)obj));
 
             var exceptionToThrow = new InvalidOperationException("Test exception");
             additionalMockSetup(exceptionToThrow);

--- a/src/Microsoft.PowerApps.TestEngine.Tests/SingleTestRunnerTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/SingleTestRunnerTests.cs
@@ -298,10 +298,13 @@ namespace Microsoft.PowerApps.TestEngine.Tests
 
             SetupMocks(testData.testRunId, testData.testSuiteId, testData.testId, testData.appUrl, testData.testSuiteDefinition, true, testData.additionalFiles, testData.testSuiteLocale);
 
-            var obj = new ExpandoObject();
-            obj.TryAdd("sessionID", "somesessionId");
+            var debugObj = new ExpandoObject();
+            debugObj.TryAdd("appId", "someAppId");
+            debugObj.TryAdd("appVersion", "someAppVersionId");
+            debugObj.TryAdd("environmentId", "someEnvironmentId");
+            debugObj.TryAdd("sessionId", "someSessionId");
 
-            MockPowerAppFunctions.Setup(x => x.GetDebugInfo()).Returns(Task.FromResult((object)obj));
+            MockPowerAppFunctions.Setup(x => x.GetDebugInfo()).Returns(Task.FromResult((object)debugObj));
 
             var exceptionToThrow = new InvalidOperationException("Test exception");
             additionalMockSetup(exceptionToThrow);

--- a/src/Microsoft.PowerApps.TestEngine.Tests/TestEngineTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/TestEngineTests.cs
@@ -356,7 +356,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
 
             var testResultsDirectory = await testEngine.RunTestAsync(testConfigFile, environmentId, tenantId, outputDirectory, domain, "");
             // UserInput Exception is handled within TestEngineEventHandler, and then returns the test results directory path
-            Assert.Equal("MockOutputDirectory\\abcdef", testResultsDirectory);
+            Assert.NotNull(testResultsDirectory);
         }
         class TestDataGenerator : TheoryData<DirectoryInfo, string, TestSettings, TestSuiteDefinition>
         {

--- a/src/Microsoft.PowerApps.TestEngine.Tests/TestEngineTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/TestEngineTests.cs
@@ -347,7 +347,8 @@ namespace Microsoft.PowerApps.TestEngine.Tests
             MockState.Setup(x => x.GetOutputDirectory()).Returns("MockOutputDirectory");            
             MockFileSystem.Setup(x => x.CreateDirectory(It.IsAny<string>()));
 
-            MockState.Setup(x => x.ParseAndSetTestState(testConfigFilePath, MockLogger.Object)).Throws(new UserInputException());
+            var exceptionToThrow = new UserInputException();
+            MockState.Setup(x => x.ParseAndSetTestState(testConfigFilePath, MockLogger.Object)).Throws(exceptionToThrow);
             MockTestEngineEventHandler.Setup(x => x.EncounteredException(It.IsAny<Exception>()));
 
             var testEngine = new TestEngine(MockState.Object, ServiceProvider, MockTestReporter.Object, MockFileSystem.Object, MockLoggerFactory.Object, MockTestEngineEventHandler.Object);
@@ -356,6 +357,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
 
             var testResultsDirectory = await testEngine.RunTestAsync(testConfigFile, environmentId, tenantId, outputDirectory, domain, "");
             // UserInput Exception is handled within TestEngineEventHandler, and then returns the test results directory path
+            MockTestEngineEventHandler.Verify(x => x.EncounteredException(exceptionToThrow), Times.Once());
             Assert.NotNull(testResultsDirectory);
         }
         class TestDataGenerator : TheoryData<DirectoryInfo, string, TestSettings, TestSuiteDefinition>

--- a/src/Microsoft.PowerApps.TestEngine.Tests/TestEngineTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/TestEngineTests.cs
@@ -82,16 +82,15 @@ namespace Microsoft.PowerApps.TestEngine.Tests
             var domain = "apps.powerapps.com";
 
             var expectedTestReportPath = "C:\\test.trx";
-            var logger = new Mock<ILogger>(MockBehavior.Strict);
 
-            SetupMocks(expectedOutputDirectory, testSettings, testSuiteDefinition, testRunId, expectedTestReportPath, logger);
+            SetupMocks(expectedOutputDirectory, testSettings, testSuiteDefinition, testRunId, expectedTestReportPath);
 
             var testEngine = new TestEngine(MockState.Object, ServiceProvider, MockTestReporter.Object, MockFileSystem.Object, MockLoggerFactory.Object, MockTestEngineEventHandler.Object);
             var testReportPath = await testEngine.RunTestAsync(testConfigFile, environmentId, tenantId, outputDirectory, domain, "");
 
             Assert.Equal(expectedTestReportPath, testReportPath);
 
-            Verify(testConfigFile.FullName, environmentId, tenantId.ToString(), domain, "", expectedOutputDirectory, testRunId, testRunDirectory, testSuiteDefinition, testSettings, logger);
+            Verify(testConfigFile.FullName, environmentId, tenantId.ToString(), domain, "", expectedOutputDirectory, testRunId, testRunDirectory, testSuiteDefinition, testSettings);
         }
 
         [Fact]
@@ -119,9 +118,8 @@ namespace Microsoft.PowerApps.TestEngine.Tests
             var domain = "apps.powerapps.com";
 
             var expectedTestReportPath = "C:\\test.trx";
-            var logger = new Mock<ILogger>(MockBehavior.Strict);
 
-            SetupMocks(expectedOutputDirectory, testSettings, testSuiteDefinition, testRunId, expectedTestReportPath, logger);
+            SetupMocks(expectedOutputDirectory, testSettings, testSuiteDefinition, testRunId, expectedTestReportPath);
 
             var testEngine = new TestEngine(MockState.Object, ServiceProvider, MockTestReporter.Object, MockFileSystem.Object, MockLoggerFactory.Object, MockTestEngineEventHandler.Object);
 
@@ -152,9 +150,8 @@ namespace Microsoft.PowerApps.TestEngine.Tests
             var domain = "apps.powerapps.com";
 
             var expectedTestReportPath = "C:\\test.trx";
-            var logger = new Mock<ILogger>(MockBehavior.Strict);
 
-            SetupMocks(expectedOutputDirectory, testSettings, testSuiteDefinition, testRunId, expectedTestReportPath, logger);
+            SetupMocks(expectedOutputDirectory, testSettings, testSuiteDefinition, testRunId, expectedTestReportPath);
 
             var testEngine = new TestEngine(MockState.Object, ServiceProvider, MockTestReporter.Object, MockFileSystem.Object, MockLoggerFactory.Object, MockTestEngineEventHandler.Object);
             var testReportPath = await testEngine.RunTestAsync(testConfigFile, environmentId, tenantId, outputDirectory, domain, "");
@@ -162,7 +159,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
             Assert.Equal(expectedTestReportPath, testReportPath);
             LoggingTestHelper.VerifyLogging(MockLogger, $"Locale property not specified in testSettings. Using current system locale: {CultureInfo.CurrentCulture.Name}", LogLevel.Debug, Times.Once());
 
-            Verify(testConfigFile.FullName, environmentId, tenantId.ToString(), domain, "", expectedOutputDirectory, testRunId, testRunDirectory, testSuiteDefinition, testSettings, logger);
+            Verify(testConfigFile.FullName, environmentId, tenantId.ToString(), domain, "", expectedOutputDirectory, testRunId, testRunDirectory, testSuiteDefinition, testSettings);
         }
 
         [Fact]
@@ -194,16 +191,15 @@ namespace Microsoft.PowerApps.TestEngine.Tests
             var domain = "apps.powerapps.com";
 
             var expectedTestReportPath = "C:\\test.trx";
-            var logger = new Mock<ILogger>(MockBehavior.Strict);
 
-            SetupMocks(expectedOutputDirectory, testSettings, testSuiteDefinition, testRunId, expectedTestReportPath, logger);
+            SetupMocks(expectedOutputDirectory, testSettings, testSuiteDefinition, testRunId, expectedTestReportPath);
 
             var testEngine = new TestEngine(MockState.Object, ServiceProvider, MockTestReporter.Object, MockFileSystem.Object, MockLoggerFactory.Object, MockTestEngineEventHandler.Object);
             var testReportPath = await testEngine.RunTestAsync(testConfigFile, environmentId, tenantId, outputDirectory, domain, "");
 
             Assert.Equal(expectedTestReportPath, testReportPath);
 
-            Verify(testConfigFile.FullName, environmentId, tenantId.ToString(), domain, "", expectedOutputDirectory, testRunId, testRunDirectory, testSuiteDefinition, testSettings, logger);
+            Verify(testConfigFile.FullName, environmentId, tenantId.ToString(), domain, "", expectedOutputDirectory, testRunId, testRunDirectory, testSuiteDefinition, testSettings);
         }
 
         private TestSuiteDefinition GetDefaultTestSuiteDefinition()
@@ -248,21 +244,23 @@ namespace Microsoft.PowerApps.TestEngine.Tests
             }
 
             var expectedTestReportPath = "C:\\test.trx";
-            var logger = new Mock<ILogger>(MockBehavior.Strict);
 
-            SetupMocks(expectedOutputDirectory.FullName, testSettings, testSuiteDefinition, testRunId, expectedTestReportPath, logger);
+            SetupMocks(expectedOutputDirectory.FullName, testSettings, testSuiteDefinition, testRunId, expectedTestReportPath);
 
             var testEngine = new TestEngine(MockState.Object, ServiceProvider, MockTestReporter.Object, MockFileSystem.Object, MockLoggerFactory.Object, MockTestEngineEventHandler.Object);
             var testReportPath = await testEngine.RunTestAsync(testConfigFile, environmentId, tenantId, outputDirectory, domain, "");
 
             Assert.Equal(expectedTestReportPath, testReportPath);
 
-            Verify(testConfigFile.FullName, environmentId, tenantId.ToString(), domain, "", expectedOutputDirectory.FullName, testRunId, testRunDirectory, testSuiteDefinition, testSettings, logger);
+            Verify(testConfigFile.FullName, environmentId, tenantId.ToString(), domain, "", expectedOutputDirectory.FullName, testRunId, testRunDirectory, testSuiteDefinition, testSettings);
         }
 
-        private void SetupMocks(string outputDirectory, TestSettings testSettings, TestSuiteDefinition testSuiteDefinition, string testRunId, string testReportPath, Mock<ILogger> logger)
+        private void SetupMocks(string outputDirectory, TestSettings testSettings, TestSuiteDefinition testSuiteDefinition, string testRunId, string testReportPath)
         {
-            MockState.Setup(x => x.ParseAndSetTestState(It.IsAny<string>(), logger.Object));
+            MockLoggerFactory.Setup(x => x.CreateLogger(It.IsAny<string>())).Returns(MockLogger.Object);
+            LoggingTestHelper.SetupMock(MockLogger);
+
+            MockState.Setup(x => x.ParseAndSetTestState(It.IsAny<string>(), MockLogger.Object));
             MockState.Setup(x => x.SetEnvironment(It.IsAny<string>()));
             MockState.Setup(x => x.SetTenant(It.IsAny<string>()));
             MockState.Setup(x => x.SetDomain(It.IsAny<string>()));
@@ -278,17 +276,14 @@ namespace Microsoft.PowerApps.TestEngine.Tests
 
             MockFileSystem.Setup(x => x.CreateDirectory(It.IsAny<string>()));
 
-            MockSingleTestRunner.Setup(x => x.RunTestAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<TestSuiteDefinition>(), It.IsAny<BrowserConfiguration>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CultureInfo>())).Returns(Task.CompletedTask);
-
-            MockLoggerFactory.Setup(x => x.CreateLogger(It.IsAny<string>())).Returns(MockLogger.Object);
-            LoggingTestHelper.SetupMock(MockLogger);
+            MockSingleTestRunner.Setup(x => x.RunTestAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<TestSuiteDefinition>(), It.IsAny<BrowserConfiguration>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CultureInfo>())).Returns(Task.CompletedTask);          
         }
 
 
         private void Verify(string testConfigFile, string environmentId, string tenantId, string domain, string queryParams,
-            string outputDirectory, string testRunId, string testRunDirectory, TestSuiteDefinition testSuiteDefinition, TestSettings testSettings, Mock<ILogger> logger)
+            string outputDirectory, string testRunId, string testRunDirectory, TestSuiteDefinition testSuiteDefinition, TestSettings testSettings)
         {
-            MockState.Verify(x => x.ParseAndSetTestState(testConfigFile, logger.Object), Times.Once());
+            MockState.Verify(x => x.ParseAndSetTestState(testConfigFile, MockLogger.Object), Times.Once());
             MockState.Verify(x => x.SetEnvironment(environmentId), Times.Once());
             MockState.Verify(x => x.SetTenant(tenantId), Times.Once());
             MockState.Verify(x => x.SetDomain(domain), Times.Once());

--- a/src/Microsoft.PowerApps.TestEngine.Tests/TestEngineTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/TestEngineTests.cs
@@ -27,6 +27,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
         private Mock<ILoggerFactory> MockLoggerFactory;
         private Mock<ILogger> MockLogger;
         private Mock<ITestEngineEvents> MockTestEngineEventHandler;
+        private Mock<ILoggerProvider> MockTestLoggerProvider;
 
         public TestEngineTests()
         {
@@ -40,6 +41,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
             MockLoggerFactory = new Mock<ILoggerFactory>(MockBehavior.Strict);
             MockLogger = new Mock<ILogger>(MockBehavior.Strict);
             MockTestEngineEventHandler = new Mock<ITestEngineEvents>(MockBehavior.Strict);
+            MockTestLoggerProvider = new Mock<ILoggerProvider>(MockBehavior.Strict);
         }
 
         [Fact]
@@ -346,6 +348,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
             MockState.Setup(x => x.SetOutputDirectory(It.IsAny<string>()));
             MockState.Setup(x => x.GetOutputDirectory()).Returns("MockOutputDirectory");            
             MockFileSystem.Setup(x => x.CreateDirectory(It.IsAny<string>()));
+            MockTestLoggerProvider.Setup(x => x.CreateLogger(It.IsAny<string>())).Returns(MockLogger.Object);
 
             var exceptionToThrow = new UserInputException();
             MockState.Setup(x => x.ParseAndSetTestState(testConfigFilePath, MockLogger.Object)).Throws(exceptionToThrow);

--- a/src/Microsoft.PowerApps.TestEngine.Tests/TestEngineTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/TestEngineTests.cs
@@ -82,15 +82,16 @@ namespace Microsoft.PowerApps.TestEngine.Tests
             var domain = "apps.powerapps.com";
 
             var expectedTestReportPath = "C:\\test.trx";
+            var logger = new Mock<ILogger>(MockBehavior.Strict);
 
-            SetupMocks(expectedOutputDirectory, testSettings, testSuiteDefinition, testRunId, expectedTestReportPath);
+            SetupMocks(expectedOutputDirectory, testSettings, testSuiteDefinition, testRunId, expectedTestReportPath, logger);
 
-            var testEngine = new TestEngine(MockState.Object, ServiceProvider, MockTestReporter.Object, MockFileSystem.Object, MockLoggerFactory.Object);
+            var testEngine = new TestEngine(MockState.Object, ServiceProvider, MockTestReporter.Object, MockFileSystem.Object, MockLoggerFactory.Object, MockTestEngineEventHandler.Object);
             var testReportPath = await testEngine.RunTestAsync(testConfigFile, environmentId, tenantId, outputDirectory, domain, "");
 
             Assert.Equal(expectedTestReportPath, testReportPath);
 
-            Verify(testConfigFile.FullName, environmentId, tenantId.ToString(), domain, "", expectedOutputDirectory, testRunId, testRunDirectory, testSuiteDefinition, testSettings);
+            Verify(testConfigFile.FullName, environmentId, tenantId.ToString(), domain, "", expectedOutputDirectory, testRunId, testRunDirectory, testSuiteDefinition, testSettings, logger);
         }
 
         [Fact]
@@ -118,10 +119,11 @@ namespace Microsoft.PowerApps.TestEngine.Tests
             var domain = "apps.powerapps.com";
 
             var expectedTestReportPath = "C:\\test.trx";
+            var logger = new Mock<ILogger>(MockBehavior.Strict);
 
-            SetupMocks(expectedOutputDirectory, testSettings, testSuiteDefinition, testRunId, expectedTestReportPath);
+            SetupMocks(expectedOutputDirectory, testSettings, testSuiteDefinition, testRunId, expectedTestReportPath, logger);
 
-            var testEngine = new TestEngine(MockState.Object, ServiceProvider, MockTestReporter.Object, MockFileSystem.Object, MockLoggerFactory.Object);
+            var testEngine = new TestEngine(MockState.Object, ServiceProvider, MockTestReporter.Object, MockFileSystem.Object, MockLoggerFactory.Object, MockTestEngineEventHandler.Object);
 
             await Assert.ThrowsAsync<CultureNotFoundException>(() => testEngine.RunTestAsync(testConfigFile, environmentId, tenantId, outputDirectory, domain, ""));
         }
@@ -150,16 +152,17 @@ namespace Microsoft.PowerApps.TestEngine.Tests
             var domain = "apps.powerapps.com";
 
             var expectedTestReportPath = "C:\\test.trx";
+            var logger = new Mock<ILogger>(MockBehavior.Strict);
 
-            SetupMocks(expectedOutputDirectory, testSettings, testSuiteDefinition, testRunId, expectedTestReportPath);
+            SetupMocks(expectedOutputDirectory, testSettings, testSuiteDefinition, testRunId, expectedTestReportPath, logger);
 
-            var testEngine = new TestEngine(MockState.Object, ServiceProvider, MockTestReporter.Object, MockFileSystem.Object, MockLoggerFactory.Object);
+            var testEngine = new TestEngine(MockState.Object, ServiceProvider, MockTestReporter.Object, MockFileSystem.Object, MockLoggerFactory.Object, MockTestEngineEventHandler.Object);
             var testReportPath = await testEngine.RunTestAsync(testConfigFile, environmentId, tenantId, outputDirectory, domain, "");
 
             Assert.Equal(expectedTestReportPath, testReportPath);
             LoggingTestHelper.VerifyLogging(MockLogger, $"Locale property not specified in testSettings. Using current system locale: {CultureInfo.CurrentCulture.Name}", LogLevel.Debug, Times.Once());
 
-            Verify(testConfigFile.FullName, environmentId, tenantId.ToString(), domain, "", expectedOutputDirectory, testRunId, testRunDirectory, testSuiteDefinition, testSettings);
+            Verify(testConfigFile.FullName, environmentId, tenantId.ToString(), domain, "", expectedOutputDirectory, testRunId, testRunDirectory, testSuiteDefinition, testSettings, logger);
         }
 
         [Fact]
@@ -191,15 +194,16 @@ namespace Microsoft.PowerApps.TestEngine.Tests
             var domain = "apps.powerapps.com";
 
             var expectedTestReportPath = "C:\\test.trx";
+            var logger = new Mock<ILogger>(MockBehavior.Strict);
 
-            SetupMocks(expectedOutputDirectory, testSettings, testSuiteDefinition, testRunId, expectedTestReportPath);
+            SetupMocks(expectedOutputDirectory, testSettings, testSuiteDefinition, testRunId, expectedTestReportPath, logger);
 
-            var testEngine = new TestEngine(MockState.Object, ServiceProvider, MockTestReporter.Object, MockFileSystem.Object, MockLoggerFactory.Object);
+            var testEngine = new TestEngine(MockState.Object, ServiceProvider, MockTestReporter.Object, MockFileSystem.Object, MockLoggerFactory.Object, MockTestEngineEventHandler.Object);
             var testReportPath = await testEngine.RunTestAsync(testConfigFile, environmentId, tenantId, outputDirectory, domain, "");
 
             Assert.Equal(expectedTestReportPath, testReportPath);
 
-            Verify(testConfigFile.FullName, environmentId, tenantId.ToString(), domain, "", expectedOutputDirectory, testRunId, testRunDirectory, testSuiteDefinition, testSettings);
+            Verify(testConfigFile.FullName, environmentId, tenantId.ToString(), domain, "", expectedOutputDirectory, testRunId, testRunDirectory, testSuiteDefinition, testSettings, logger);
         }
 
         private TestSuiteDefinition GetDefaultTestSuiteDefinition()
@@ -244,20 +248,21 @@ namespace Microsoft.PowerApps.TestEngine.Tests
             }
 
             var expectedTestReportPath = "C:\\test.trx";
+            var logger = new Mock<ILogger>(MockBehavior.Strict);
 
-            SetupMocks(expectedOutputDirectory.FullName, testSettings, testSuiteDefinition, testRunId, expectedTestReportPath);
+            SetupMocks(expectedOutputDirectory.FullName, testSettings, testSuiteDefinition, testRunId, expectedTestReportPath, logger);
 
-            var testEngine = new TestEngine(MockState.Object, ServiceProvider, MockTestReporter.Object, MockFileSystem.Object, MockLoggerFactory.Object);
+            var testEngine = new TestEngine(MockState.Object, ServiceProvider, MockTestReporter.Object, MockFileSystem.Object, MockLoggerFactory.Object, MockTestEngineEventHandler.Object);
             var testReportPath = await testEngine.RunTestAsync(testConfigFile, environmentId, tenantId, outputDirectory, domain, "");
 
             Assert.Equal(expectedTestReportPath, testReportPath);
 
-            Verify(testConfigFile.FullName, environmentId, tenantId.ToString(), domain, "", expectedOutputDirectory.FullName, testRunId, testRunDirectory, testSuiteDefinition, testSettings);
+            Verify(testConfigFile.FullName, environmentId, tenantId.ToString(), domain, "", expectedOutputDirectory.FullName, testRunId, testRunDirectory, testSuiteDefinition, testSettings, logger);
         }
 
-        private void SetupMocks(string outputDirectory, TestSettings testSettings, TestSuiteDefinition testSuiteDefinition, string testRunId, string testReportPath)
+        private void SetupMocks(string outputDirectory, TestSettings testSettings, TestSuiteDefinition testSuiteDefinition, string testRunId, string testReportPath, Mock<ILogger> logger)
         {
-            MockState.Setup(x => x.ParseAndSetTestState(It.IsAny<string>()));
+            MockState.Setup(x => x.ParseAndSetTestState(It.IsAny<string>(), logger.Object));
             MockState.Setup(x => x.SetEnvironment(It.IsAny<string>()));
             MockState.Setup(x => x.SetTenant(It.IsAny<string>()));
             MockState.Setup(x => x.SetDomain(It.IsAny<string>()));
@@ -281,9 +286,9 @@ namespace Microsoft.PowerApps.TestEngine.Tests
 
 
         private void Verify(string testConfigFile, string environmentId, string tenantId, string domain, string queryParams,
-            string outputDirectory, string testRunId, string testRunDirectory, TestSuiteDefinition testSuiteDefinition, TestSettings testSettings)
+            string outputDirectory, string testRunId, string testRunDirectory, TestSuiteDefinition testSuiteDefinition, TestSettings testSettings, Mock<ILogger> logger)
         {
-            MockState.Verify(x => x.ParseAndSetTestState(testConfigFile), Times.Once());
+            MockState.Verify(x => x.ParseAndSetTestState(testConfigFile, logger.Object), Times.Once());
             MockState.Verify(x => x.SetEnvironment(environmentId), Times.Once());
             MockState.Verify(x => x.SetTenant(tenantId), Times.Once());
             MockState.Verify(x => x.SetDomain(domain), Times.Once());
@@ -318,7 +323,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
             MockState.Setup(x => x.SetOutputDirectory(It.IsAny<string>()));
             MockState.Setup(x => x.GetOutputDirectory()).Returns("MockOutputDirectory");
             MockFileSystem.Setup(x => x.CreateDirectory(It.IsAny<string>()));
-            var testEngine = new TestEngine(MockState.Object, ServiceProvider, MockTestReporter.Object, MockFileSystem.Object, MockLoggerFactory.Object);
+            var testEngine = new TestEngine(MockState.Object, ServiceProvider, MockTestReporter.Object, MockFileSystem.Object, MockLoggerFactory.Object, MockTestEngineEventHandler.Object);
 
             FileInfo testConfigFile;
             if (string.IsNullOrEmpty(testConfigFilePath))

--- a/src/Microsoft.PowerApps.TestEngine.Tests/TestEngineTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/TestEngineTests.cs
@@ -337,10 +337,14 @@ namespace Microsoft.PowerApps.TestEngine.Tests
             await Assert.ThrowsAsync<ArgumentNullException>(async () => await testEngine.RunTestAsync(testConfigFile, environmentId, tenantId, outputDirectory, domain, ""));
         }
 
-        [Theory]
-        [InlineData("C:\\testPlan.fx.yaml", "Default-EnvironmentId", "a01af035-a529-4aaf-aded-011ad676f976", "apps.powerapps.com")]
-        public async Task TestEngineReturnsPathOnUserInputErrors(string testConfigFilePath, string environmentId, Guid tenantId, string domain)
+        [Fact]
+        public async Task TestEngineReturnsPathOnUserInputErrors()
         {
+            FileInfo testConfigFile = new FileInfo("C:\\testPlan.fx.yaml");
+            string environmentId = "defaultEnviroment";
+            Guid tenantId = new Guid("a01af035-a529-4aaf-aded-011ad676f976");
+            string domain = "apps.powerapps.com";
+
             MockTestReporter.Setup(x => x.CreateTestRun(It.IsAny<string>(), It.IsAny<string>())).Returns("abcdef");
             MockTestReporter.Setup(x => x.StartTestRun(It.IsAny<string>()));
             MockLoggerFactory.Setup(x => x.CreateLogger(It.IsAny<string>())).Returns(MockLogger.Object);
@@ -351,11 +355,10 @@ namespace Microsoft.PowerApps.TestEngine.Tests
             MockTestLoggerProvider.Setup(x => x.CreateLogger(It.IsAny<string>())).Returns(MockLogger.Object);
 
             var exceptionToThrow = new UserInputException();
-            MockState.Setup(x => x.ParseAndSetTestState(testConfigFilePath, MockLogger.Object)).Throws(exceptionToThrow);
+            MockState.Setup(x => x.ParseAndSetTestState(testConfigFile.FullName, MockLogger.Object)).Throws(exceptionToThrow);
             MockTestEngineEventHandler.Setup(x => x.EncounteredException(It.IsAny<Exception>()));
 
             var testEngine = new TestEngine(MockState.Object, ServiceProvider, MockTestReporter.Object, MockFileSystem.Object, MockLoggerFactory.Object, MockTestEngineEventHandler.Object);
-            FileInfo testConfigFile = new FileInfo(testConfigFilePath);
             var outputDirectory = new DirectoryInfo("TestOutput");
 
             var testResultsDirectory = await testEngine.RunTestAsync(testConfigFile, environmentId, tenantId, outputDirectory, domain, "");

--- a/src/Microsoft.PowerApps.TestEngine.Tests/TestInfra/PlaywrightTestInfraFunctionTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/TestInfra/PlaywrightTestInfraFunctionTests.cs
@@ -675,10 +675,12 @@ namespace Microsoft.PowerApps.TestEngine.Tests.TestInfra
             var playwrightTestInfraFunctions = new PlaywrightTestInfraFunctions(MockTestState.Object, MockSingleTestInstanceState.Object,
                MockFileSystem.Object, browserContext: MockBrowserContext.Object, page: MockPage.Object);
 
-            await Assert.ThrowsAsync<InvalidOperationException>(async () => await playwrightTestInfraFunctions.HandleUserPasswordScreen(testSelector, testTextEntry, desiredUrl));
+            // scenario where password error or missing
+            var ex = await Assert.ThrowsAsync<UserInputException>(async () => await playwrightTestInfraFunctions.HandleUserPasswordScreen(testSelector, testTextEntry, desiredUrl));
 
             MockPage.Verify(x => x.Locator(It.Is<string>(v => v.Equals(testSelector)), null));
             MockPage.Verify(x => x.WaitForSelectorAsync("[id=\"passwordError\"]", It.Is<PageWaitForSelectorOptions>(v => v.Timeout >= 2000)));
+            Assert.Equal(UserInputException.errorMapping.UserInputExceptionLoginCredential.ToString(), ex.Message);
         }
 
         [Fact]

--- a/src/Microsoft.PowerApps.TestEngine.Tests/Users/UserManagerTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/Users/UserManagerTests.cs
@@ -187,7 +187,9 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Users
             LoggingTestHelper.SetupMock(MockLogger);
 
             var userManager = new UserManager(MockTestInfraFunctions.Object, MockTestState.Object, MockSingleTestInstanceState.Object, MockEnvironmentVariable.Object);
-            await Assert.ThrowsAsync<InvalidOperationException>(async () => await userManager.LoginAsUserAsync("*"));
+            
+            var ex = await Assert.ThrowsAsync<UserInputException>(async () => await userManager.LoginAsUserAsync("*"));
+            Assert.Equal(UserInputException.errorMapping.UserInputExceptionLoginCredential.ToString(), ex.Message);
         }
     }
 }

--- a/src/Microsoft.PowerApps.TestEngine.Tests/Users/UserManagerTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/Users/UserManagerTests.cs
@@ -190,6 +190,14 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Users
             
             var ex = await Assert.ThrowsAsync<UserInputException>(async () => await userManager.LoginAsUserAsync("*"));
             Assert.Equal(UserInputException.errorMapping.UserInputExceptionLoginCredential.ToString(), ex.Message);
+            if (String.IsNullOrEmpty(email))
+            {
+                LoggingTestHelper.VerifyLogging(MockLogger, "User email cannot be null. Please check if the environment variable is set properly.", LogLevel.Error, Times.Once());
+            }
+            if (String.IsNullOrEmpty(password))
+            {
+                LoggingTestHelper.VerifyLogging(MockLogger, "Password cannot be null. Please check if the environment variable is set properly.", LogLevel.Error, Times.Once());
+            }
         }
     }
 }

--- a/src/Microsoft.PowerApps.TestEngine/Config/ITestConfigParser.cs
+++ b/src/Microsoft.PowerApps.TestEngine/Config/ITestConfigParser.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+using Microsoft.Extensions.Logging;
+
 namespace Microsoft.PowerApps.TestEngine.Config
 {
     /// <summary>
@@ -8,6 +10,11 @@ namespace Microsoft.PowerApps.TestEngine.Config
     /// </summary>
     public interface ITestConfigParser
     {
-        public T ParseTestConfig<T>(string testConfigFilePath);
+        /// <summary>
+        /// Parses test config paths.
+        /// </summary>
+        /// <param name="testConfigFilePath">Config file path for test</param>
+        /// <param name="logger">Logger</param>
+        public T ParseTestConfig<T>(string testConfigFilePath, ILogger logger);
     }
 }

--- a/src/Microsoft.PowerApps.TestEngine/Config/ITestState.cs
+++ b/src/Microsoft.PowerApps.TestEngine/Config/ITestState.cs
@@ -14,7 +14,7 @@ namespace Microsoft.PowerApps.TestEngine.Config
         /// Parses and sets up the test state.
         /// </summary>
         /// <param name="testConfigFile">Config file for test</param>
-        public void ParseAndSetTestState(string testConfigFile);
+        public void ParseAndSetTestState(string testConfigFile, ILogger logger = null);
 
         /// <summary>
         /// Gets the test suite defined for the test run.

--- a/src/Microsoft.PowerApps.TestEngine/Config/ITestState.cs
+++ b/src/Microsoft.PowerApps.TestEngine/Config/ITestState.cs
@@ -14,7 +14,8 @@ namespace Microsoft.PowerApps.TestEngine.Config
         /// Parses and sets up the test state.
         /// </summary>
         /// <param name="testConfigFile">Config file for test</param>
-        public void ParseAndSetTestState(string testConfigFile, ILogger logger = null);
+        /// <param name="logger">Logger</param>
+        public void ParseAndSetTestState(string testConfigFile, ILogger logger);
 
         /// <summary>
         /// Gets the test suite defined for the test run.

--- a/src/Microsoft.PowerApps.TestEngine/Config/TestState.cs
+++ b/src/Microsoft.PowerApps.TestEngine/Config/TestState.cs
@@ -102,7 +102,8 @@ namespace Microsoft.PowerApps.TestEngine.Config
                 {
                     userInputExceptionMessages.Add("Missing browser configuration from test plan");
                 }
-                else { 
+                else 
+                {
                     foreach (var browserConfig in TestPlanDefinition.TestSettings?.BrowserConfigurations)
                     {
                         if (string.IsNullOrWhiteSpace(browserConfig.Browser))
@@ -117,6 +118,7 @@ namespace Microsoft.PowerApps.TestEngine.Config
                         }
                     }
                 }
+
                 if (TestPlanDefinition.EnvironmentVariables == null)
                 {
                     userInputExceptionMessages.Add("Missing environment variables from test plan");

--- a/src/Microsoft.PowerApps.TestEngine/Config/TestState.cs
+++ b/src/Microsoft.PowerApps.TestEngine/Config/TestState.cs
@@ -49,7 +49,7 @@ namespace Microsoft.PowerApps.TestEngine.Config
             List<string> userInputExceptionMessages = new List<string>();
             try
             {
-                TestPlanDefinition = _testConfigParser.ParseTestConfig<TestPlanDefinition>(testConfigFile);
+                TestPlanDefinition = _testConfigParser.ParseTestConfig<TestPlanDefinition>(testConfigFile, logger);
                 if (TestPlanDefinition.TestSuite != null)
                 {
                     TestCases = TestPlanDefinition.TestSuite.TestCases;
@@ -94,7 +94,7 @@ namespace Microsoft.PowerApps.TestEngine.Config
                 }
                 else if (!string.IsNullOrEmpty(TestPlanDefinition.TestSettings.FilePath))
                 {
-                    TestPlanDefinition.TestSettings = _testConfigParser.ParseTestConfig<TestSettings>(TestPlanDefinition.TestSettings.FilePath);
+                    TestPlanDefinition.TestSettings = _testConfigParser.ParseTestConfig<TestSettings>(TestPlanDefinition.TestSettings.FilePath, logger);
                 }
 
                 if (TestPlanDefinition.TestSettings.BrowserConfigurations == null
@@ -123,7 +123,7 @@ namespace Microsoft.PowerApps.TestEngine.Config
                 }
                 else if (!string.IsNullOrEmpty(TestPlanDefinition.EnvironmentVariables.FilePath))
                 {
-                    TestPlanDefinition.EnvironmentVariables = _testConfigParser.ParseTestConfig<EnvironmentVariables>(TestPlanDefinition.EnvironmentVariables.FilePath);
+                    TestPlanDefinition.EnvironmentVariables = _testConfigParser.ParseTestConfig<EnvironmentVariables>(TestPlanDefinition.EnvironmentVariables.FilePath, logger);
                 }
 
                 if (TestPlanDefinition.EnvironmentVariables.Users == null
@@ -157,7 +157,6 @@ namespace Microsoft.PowerApps.TestEngine.Config
             }
             catch (UserInputException ex)
             {
-                logger.LogError($"Invalid User Input(s): {String.Join(", ",userInputExceptionMessages)}");
                 throw new UserInputException(ex.Message);
             }
 

--- a/src/Microsoft.PowerApps.TestEngine/Config/TestState.cs
+++ b/src/Microsoft.PowerApps.TestEngine/Config/TestState.cs
@@ -70,21 +70,23 @@ namespace Microsoft.PowerApps.TestEngine.Config
                     }
                 }
 
-                if (TestCases.Count == 0)
+                if (TestCases == null || TestCases?.Count == 0)
                 {
                     userInputExceptionMessages.Add("Must be at least one test case");
                 }
-
-                foreach (var testCase in TestCases)
+                else
                 {
-                    if (string.IsNullOrEmpty(testCase.TestCaseName))
+                    foreach (var testCase in TestCases)
                     {
-                        userInputExceptionMessages.Add("Missing test case name from test definition");
-                    }
+                        if (string.IsNullOrEmpty(testCase.TestCaseName))
+                        {
+                            userInputExceptionMessages.Add("Missing test case name from test definition");
+                        }
 
-                    if (string.IsNullOrEmpty(testCase.TestSteps))
-                    {
-                        userInputExceptionMessages.Add("Missing test steps from test case");
+                        if (string.IsNullOrEmpty(testCase.TestSteps))
+                        {
+                            userInputExceptionMessages.Add("Missing test steps from test case");
+                        }
                     }
                 }
 

--- a/src/Microsoft.PowerApps.TestEngine/Config/TestState.cs
+++ b/src/Microsoft.PowerApps.TestEngine/Config/TestState.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+using System.Linq;
 using Microsoft.Extensions.Logging;
+using Microsoft.PowerApps.TestEngine.System;
 
 namespace Microsoft.PowerApps.TestEngine.Config
 {
@@ -37,117 +39,132 @@ namespace Microsoft.PowerApps.TestEngine.Config
             return TestCases;
         }
 
-        public void ParseAndSetTestState(string testConfigFile)
+        public void ParseAndSetTestState(string testConfigFile, ILogger logger)
         {
             if (string.IsNullOrEmpty(testConfigFile))
             {
                 throw new ArgumentNullException(nameof(testConfigFile));
             }
 
-            TestPlanDefinition = _testConfigParser.ParseTestConfig<TestPlanDefinition>(testConfigFile);
-            if (TestPlanDefinition.TestSuite != null)
+            List<string> userInputExceptionMessages = new List<string>();
+            try
             {
-                TestCases = TestPlanDefinition.TestSuite.TestCases;
-
-                if (string.IsNullOrEmpty(TestPlanDefinition.TestSuite.TestSuiteName))
+                TestPlanDefinition = _testConfigParser.ParseTestConfig<TestPlanDefinition>(testConfigFile);
+                if (TestPlanDefinition.TestSuite != null)
                 {
-                    throw new InvalidOperationException("Missing test suite name from test suite definition");
+                    TestCases = TestPlanDefinition.TestSuite.TestCases;
+
+                    if (string.IsNullOrEmpty(TestPlanDefinition.TestSuite.TestSuiteName))
+                    {
+                        userInputExceptionMessages.Add("Missing test suite name from test suite definition");
+                    }
+
+                    if (string.IsNullOrEmpty(TestPlanDefinition.TestSuite.Persona))
+                    {
+                        userInputExceptionMessages.Add("Missing persona from test suite definition");
+                    }
+
+                    if (string.IsNullOrEmpty(TestPlanDefinition.TestSuite.AppLogicalName) && string.IsNullOrEmpty(TestPlanDefinition.TestSuite.AppId))
+                    {
+                        userInputExceptionMessages.Add("At least one of the app logical name or app id must be present in test suite definition");
+                    }
                 }
 
-                if (string.IsNullOrEmpty(TestPlanDefinition.TestSuite.Persona))
+                if (TestCases.Count == 0)
                 {
-                    throw new InvalidOperationException("Missing persona from test suite definition");
+                    userInputExceptionMessages.Add("Must be at least one test case");
                 }
 
-                if (string.IsNullOrEmpty(TestPlanDefinition.TestSuite.AppLogicalName) && string.IsNullOrEmpty(TestPlanDefinition.TestSuite.AppId))
+                foreach (var testCase in TestCases)
                 {
-                    throw new InvalidOperationException("At least one of the app logical name or app id must be present in test suite definition");
-                }
-            }
+                    if (string.IsNullOrEmpty(testCase.TestCaseName))
+                    {
+                        userInputExceptionMessages.Add("Missing test case name from test definition");
+                    }
 
-            if (TestCases.Count == 0)
-            {
-                throw new InvalidOperationException("Must be at least one test case");
-            }
-
-            foreach (var testCase in TestCases)
-            {
-                if (string.IsNullOrEmpty(testCase.TestCaseName))
-                {
-                    throw new InvalidOperationException("Missing test case name from test definition");
+                    if (string.IsNullOrEmpty(testCase.TestSteps))
+                    {
+                        userInputExceptionMessages.Add("Missing test steps from test case");
+                    }
                 }
 
-                if (string.IsNullOrEmpty(testCase.TestSteps))
+                if (TestPlanDefinition.TestSettings == null)
                 {
-                    throw new InvalidOperationException("Missing test steps from test case");
+                    userInputExceptionMessages.Add("Missing test settings from test plan");
                 }
-            }
-
-            if (TestPlanDefinition.TestSettings == null)
-            {
-                throw new InvalidOperationException("Missing test settings from test plan");
-            }
-            else if (!string.IsNullOrEmpty(TestPlanDefinition.TestSettings.FilePath))
-            {
-                TestPlanDefinition.TestSettings = _testConfigParser.ParseTestConfig<TestSettings>(TestPlanDefinition.TestSettings.FilePath);
-            }
-
-            if (TestPlanDefinition.TestSettings.BrowserConfigurations == null
-                || TestPlanDefinition.TestSettings.BrowserConfigurations.Count == 0)
-            {
-                throw new InvalidOperationException("Missing browser configuration from test plan");
-            }
-
-            foreach (var browserConfig in TestPlanDefinition.TestSettings.BrowserConfigurations)
-            {
-                if (string.IsNullOrWhiteSpace(browserConfig.Browser))
+                else if (!string.IsNullOrEmpty(TestPlanDefinition.TestSettings.FilePath))
                 {
-                    throw new InvalidOperationException("Missing browser from browser configuration");
+                    TestPlanDefinition.TestSettings = _testConfigParser.ParseTestConfig<TestSettings>(TestPlanDefinition.TestSettings.FilePath);
                 }
 
-                if (browserConfig.ScreenWidth == null && browserConfig.ScreenHeight != null
-                    || browserConfig.ScreenHeight == null && browserConfig.ScreenWidth != null)
+                if (TestPlanDefinition.TestSettings.BrowserConfigurations == null
+                    || TestPlanDefinition.TestSettings.BrowserConfigurations.Count == 0)
                 {
-                    throw new InvalidOperationException("Screen width and height both need to be specified or not specified");
-                }
-            }
-
-            if (TestPlanDefinition.EnvironmentVariables == null)
-            {
-                throw new InvalidOperationException("Missing environment variables from test plan");
-            }
-            else if (!string.IsNullOrEmpty(TestPlanDefinition.EnvironmentVariables.FilePath))
-            {
-                TestPlanDefinition.EnvironmentVariables = _testConfigParser.ParseTestConfig<EnvironmentVariables>(TestPlanDefinition.EnvironmentVariables.FilePath);
-            }
-
-            if (TestPlanDefinition.EnvironmentVariables.Users == null
-                || TestPlanDefinition.EnvironmentVariables.Users.Count == 0)
-            {
-                throw new InvalidOperationException("At least one user must be specified");
-            }
-
-            foreach (var userConfig in TestPlanDefinition.EnvironmentVariables.Users)
-            {
-                if (string.IsNullOrEmpty(userConfig.PersonaName))
-                {
-                    throw new InvalidOperationException("Missing persona name");
+                    userInputExceptionMessages.Add("Missing browser configuration from test plan");
                 }
 
-                if (string.IsNullOrEmpty(userConfig.EmailKey))
+                foreach (var browserConfig in TestPlanDefinition.TestSettings.BrowserConfigurations)
                 {
-                    throw new InvalidOperationException("Missing email key");
+                    if (string.IsNullOrWhiteSpace(browserConfig.Browser))
+                    {
+                        userInputExceptionMessages.Add("Missing browser from browser configuration");
+                    }
+
+                    if (browserConfig.ScreenWidth == null && browserConfig.ScreenHeight != null
+                        || browserConfig.ScreenHeight == null && browserConfig.ScreenWidth != null)
+                    {
+                        userInputExceptionMessages.Add("Screen width and height both need to be specified or not specified");
+                    }
                 }
 
-                if (string.IsNullOrEmpty(userConfig.PasswordKey))
+                if (TestPlanDefinition.EnvironmentVariables == null)
                 {
-                    throw new InvalidOperationException("Missing password key");
+                    userInputExceptionMessages.Add("Missing environment variables from test plan");
+                }
+                else if (!string.IsNullOrEmpty(TestPlanDefinition.EnvironmentVariables.FilePath))
+                {
+                    TestPlanDefinition.EnvironmentVariables = _testConfigParser.ParseTestConfig<EnvironmentVariables>(TestPlanDefinition.EnvironmentVariables.FilePath);
+                }
+
+                if (TestPlanDefinition.EnvironmentVariables.Users == null
+                    || TestPlanDefinition.EnvironmentVariables.Users.Count == 0)
+                {
+                    userInputExceptionMessages.Add("At least one user must be specified");
+                }
+
+                foreach (var userConfig in TestPlanDefinition.EnvironmentVariables.Users)
+                {
+                    if (string.IsNullOrEmpty(userConfig.PersonaName))
+                    {
+                        userInputExceptionMessages.Add("Missing persona name");
+                    }
+
+                    if (string.IsNullOrEmpty(userConfig.EmailKey))
+                    {
+                        userInputExceptionMessages.Add("Missing email key");
+                    }
+
+                    if (string.IsNullOrEmpty(userConfig.PasswordKey))
+                    {
+                        userInputExceptionMessages.Add("Missing password key");
+                    }
+                }
+
+                if (TestPlanDefinition.EnvironmentVariables.Users.Where(x => x.PersonaName == TestPlanDefinition.TestSuite?.Persona).FirstOrDefault() == null)
+                {
+                    userInputExceptionMessages.Add("Persona specified in test is not listed in environment variables");
                 }
             }
-
-            if (TestPlanDefinition.EnvironmentVariables.Users.Where(x => x.PersonaName == TestPlanDefinition.TestSuite?.Persona).FirstOrDefault() == null)
+            catch (UserInputException ex)
             {
-                throw new InvalidOperationException("Persona specified in test is not listed in environment variables");
+                logger.LogError($"Invalid User Input(s): {String.Join(", ",userInputExceptionMessages)}");
+                throw new UserInputException(ex.Message);
+            }
+
+            if (userInputExceptionMessages.Count() > 0)
+            {
+                logger.LogError($"Invalid User Input(s): {String.Join(", ", userInputExceptionMessages)}");
+                throw new UserInputException(UserInputException.errorMapping.UserInputExceptionTestConfig.ToString());               
             }
 
             IsValid = true;

--- a/src/Microsoft.PowerApps.TestEngine/Config/TestState.cs
+++ b/src/Microsoft.PowerApps.TestEngine/Config/TestState.cs
@@ -92,31 +92,31 @@ namespace Microsoft.PowerApps.TestEngine.Config
                 {
                     userInputExceptionMessages.Add("Missing test settings from test plan");
                 }
-                else if (!string.IsNullOrEmpty(TestPlanDefinition.TestSettings.FilePath))
+                else if (!string.IsNullOrEmpty(TestPlanDefinition.TestSettings?.FilePath))
                 {
                     TestPlanDefinition.TestSettings = _testConfigParser.ParseTestConfig<TestSettings>(TestPlanDefinition.TestSettings.FilePath, logger);
                 }
 
-                if (TestPlanDefinition.TestSettings.BrowserConfigurations == null
-                    || TestPlanDefinition.TestSettings.BrowserConfigurations.Count == 0)
+                if (TestPlanDefinition.TestSettings?.BrowserConfigurations == null
+                    || TestPlanDefinition.TestSettings?.BrowserConfigurations?.Count == 0)
                 {
                     userInputExceptionMessages.Add("Missing browser configuration from test plan");
                 }
-
-                foreach (var browserConfig in TestPlanDefinition.TestSettings.BrowserConfigurations)
-                {
-                    if (string.IsNullOrWhiteSpace(browserConfig.Browser))
+                else { 
+                    foreach (var browserConfig in TestPlanDefinition.TestSettings?.BrowserConfigurations)
                     {
-                        userInputExceptionMessages.Add("Missing browser from browser configuration");
-                    }
+                        if (string.IsNullOrWhiteSpace(browserConfig.Browser))
+                        {
+                            userInputExceptionMessages.Add("Missing browser from browser configuration");
+                        }
 
-                    if (browserConfig.ScreenWidth == null && browserConfig.ScreenHeight != null
-                        || browserConfig.ScreenHeight == null && browserConfig.ScreenWidth != null)
-                    {
-                        userInputExceptionMessages.Add("Screen width and height both need to be specified or not specified");
+                        if (browserConfig.ScreenWidth == null && browserConfig.ScreenHeight != null
+                            || browserConfig.ScreenHeight == null && browserConfig.ScreenWidth != null)
+                        {
+                            userInputExceptionMessages.Add("Screen width and height both need to be specified or not specified");
+                        }
                     }
                 }
-
                 if (TestPlanDefinition.EnvironmentVariables == null)
                 {
                     userInputExceptionMessages.Add("Missing environment variables from test plan");
@@ -126,31 +126,33 @@ namespace Microsoft.PowerApps.TestEngine.Config
                     TestPlanDefinition.EnvironmentVariables = _testConfigParser.ParseTestConfig<EnvironmentVariables>(TestPlanDefinition.EnvironmentVariables.FilePath, logger);
                 }
 
-                if (TestPlanDefinition.EnvironmentVariables.Users == null
-                    || TestPlanDefinition.EnvironmentVariables.Users.Count == 0)
+                if (TestPlanDefinition.EnvironmentVariables?.Users == null
+                    || TestPlanDefinition.EnvironmentVariables?.Users?.Count == 0)
                 {
                     userInputExceptionMessages.Add("At least one user must be specified");
                 }
-
-                foreach (var userConfig in TestPlanDefinition.EnvironmentVariables.Users)
+                else
                 {
-                    if (string.IsNullOrEmpty(userConfig.PersonaName))
+                    foreach (var userConfig in TestPlanDefinition.EnvironmentVariables?.Users)
                     {
-                        userInputExceptionMessages.Add("Missing persona name");
-                    }
+                        if (string.IsNullOrEmpty(userConfig.PersonaName))
+                        {
+                            userInputExceptionMessages.Add("Missing persona name");
+                        }
 
-                    if (string.IsNullOrEmpty(userConfig.EmailKey))
-                    {
-                        userInputExceptionMessages.Add("Missing email key");
-                    }
+                        if (string.IsNullOrEmpty(userConfig.EmailKey))
+                        {
+                            userInputExceptionMessages.Add("Missing email key");
+                        }
 
-                    if (string.IsNullOrEmpty(userConfig.PasswordKey))
-                    {
-                        userInputExceptionMessages.Add("Missing password key");
+                        if (string.IsNullOrEmpty(userConfig.PasswordKey))
+                        {
+                            userInputExceptionMessages.Add("Missing password key");
+                        }
                     }
                 }
 
-                if (TestPlanDefinition.EnvironmentVariables.Users.Where(x => x.PersonaName == TestPlanDefinition.TestSuite?.Persona).FirstOrDefault() == null)
+                if (TestPlanDefinition.EnvironmentVariables?.Users?.Where(x => x.PersonaName == TestPlanDefinition.TestSuite?.Persona).FirstOrDefault() == null)
                 {
                     userInputExceptionMessages.Add("Persona specified in test is not listed in environment variables");
                 }

--- a/src/Microsoft.PowerApps.TestEngine/Config/TestState.cs
+++ b/src/Microsoft.PowerApps.TestEngine/Config/TestState.cs
@@ -102,7 +102,7 @@ namespace Microsoft.PowerApps.TestEngine.Config
                 {
                     userInputExceptionMessages.Add("Missing browser configuration from test plan");
                 }
-                else 
+                else
                 {
                     foreach (var browserConfig in TestPlanDefinition.TestSettings?.BrowserConfigurations)
                     {

--- a/src/Microsoft.PowerApps.TestEngine/Config/TestState.cs
+++ b/src/Microsoft.PowerApps.TestEngine/Config/TestState.cs
@@ -163,7 +163,7 @@ namespace Microsoft.PowerApps.TestEngine.Config
             if (userInputExceptionMessages.Count() > 0)
             {
                 logger.LogError($"Invalid User Input(s): {String.Join(", ", userInputExceptionMessages)}");
-                throw new UserInputException(UserInputException.errorMapping.UserInputExceptionTestConfig.ToString());               
+                throw new UserInputException(UserInputException.errorMapping.UserInputExceptionTestConfig.ToString());
             }
 
             IsValid = true;

--- a/src/Microsoft.PowerApps.TestEngine/Config/YamlTestConfigParser.cs
+++ b/src/Microsoft.PowerApps.TestEngine/Config/YamlTestConfigParser.cs
@@ -29,7 +29,7 @@ namespace Microsoft.PowerApps.TestEngine.Config
                     throw new ArgumentNullException(nameof(testConfigFilePath));
                 }
 
-                if (!File.Exists(testConfigFilePath))
+                if (!_fileSystem.fileExists(testConfigFilePath))
                 {
                     logger.LogError($"Invalid User Input: {typeof(T).Name} in test config file.");
                     throw new UserInputException(UserInputException.errorMapping.UserInputExceptionInvalidFilePath.ToString());

--- a/src/Microsoft.PowerApps.TestEngine/Config/YamlTestConfigParser.cs
+++ b/src/Microsoft.PowerApps.TestEngine/Config/YamlTestConfigParser.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+using Microsoft.Extensions.Logging;
 using Microsoft.PowerApps.TestEngine.System;
 using YamlDotNet.Core;
 using YamlDotNet.Serialization.NamingConventions;
@@ -19,7 +20,7 @@ namespace Microsoft.PowerApps.TestEngine.Config
             _fileSystem = fileSytem;
         }
 
-        public T ParseTestConfig<T>(string testConfigFilePath)
+        public T ParseTestConfig<T>(string testConfigFilePath, ILogger logger)
         {
             try
             {
@@ -30,6 +31,7 @@ namespace Microsoft.PowerApps.TestEngine.Config
 
                 if (!File.Exists(testConfigFilePath))
                 {
+                    logger.LogError($"Invalid User Input: {typeof(T).Name} in test config file.");
                     throw new UserInputException(UserInputException.errorMapping.UserInputExceptionInvalidFilePath.ToString());
                 }
 
@@ -41,6 +43,7 @@ namespace Microsoft.PowerApps.TestEngine.Config
             }
             catch (YamlException)
             {
+                logger.LogError($"Invalid User Input: {typeof(T).Name} in test config file.");
                 throw new UserInputException(UserInputException.errorMapping.UserInputExceptionYAMLFormat.ToString());
             }
         }

--- a/src/Microsoft.PowerApps.TestEngine/Config/YamlTestConfigParser.cs
+++ b/src/Microsoft.PowerApps.TestEngine/Config/YamlTestConfigParser.cs
@@ -31,7 +31,7 @@ namespace Microsoft.PowerApps.TestEngine.Config
 
                 if (!_fileSystem.fileExists(testConfigFilePath))
                 {
-                    logger.LogError($"Invalid User Input: {typeof(T).Name} in test config file.");
+                    logger.LogError($"Invalid file path: {typeof(T).Name} in test config file.");
                     throw new UserInputException(UserInputException.errorMapping.UserInputExceptionInvalidFilePath.ToString());
                 }
 
@@ -43,7 +43,7 @@ namespace Microsoft.PowerApps.TestEngine.Config
             }
             catch (YamlException)
             {
-                logger.LogError($"Invalid User Input: {typeof(T).Name} in test config file.");
+                logger.LogError($"Invalid YAML format: {typeof(T).Name} in test config file.");
                 throw new UserInputException(UserInputException.errorMapping.UserInputExceptionYAMLFormat.ToString());
             }
         }

--- a/src/Microsoft.PowerApps.TestEngine/Helpers/LoggingHelper.cs
+++ b/src/Microsoft.PowerApps.TestEngine/Helpers/LoggingHelper.cs
@@ -16,20 +16,22 @@ namespace Microsoft.PowerApps.TestEngine.Helpers
     {
         private readonly IPowerAppFunctions _powerAppFunctions;
         private readonly ISingleTestInstanceState _singleTestInstanceState;
+        private readonly ITestEngineEvents _eventHandler;
         private ILogger Logger { get { return _singleTestInstanceState.GetLogger(); } }
 
         public LoggingHelper(IPowerAppFunctions powerAppFunctions,
-                             ISingleTestInstanceState singleTestInstanceState)
+                             ISingleTestInstanceState singleTestInstanceState, ITestEngineEvents eventHandler)
         {
             _powerAppFunctions = powerAppFunctions;
             _singleTestInstanceState = singleTestInstanceState;
+            _eventHandler = eventHandler;
         }
 
         public async void DebugInfo()
         {
             try
             {
-                ExpandoObject debugInfo = (ExpandoObject)await _powerAppFunctions.GetDebugInfo();
+                ExpandoObject debugInfo = (ExpandoObject)await _powerAppFunctions.GetDebugInfo();                
                 if (debugInfo != null && debugInfo.ToString() != "undefined")
                 {
                     Logger.LogInformation($"------------------------------\n Debug Info \n------------------------------");
@@ -43,7 +45,7 @@ namespace Microsoft.PowerApps.TestEngine.Helpers
             {
                 Logger.LogDebug("Issue getting DebugInfo. This can be a result of not being properly logged in.");
                 Logger.LogDebug(ex.ToString());
-                Console.WriteLine("[Critical Error]: Could not access PowerApps. Confirm you are logged in properly.");
+                _eventHandler.EncounteredException(new UserAppException());
             }
         }
     }

--- a/src/Microsoft.PowerApps.TestEngine/Helpers/LoggingHelper.cs
+++ b/src/Microsoft.PowerApps.TestEngine/Helpers/LoggingHelper.cs
@@ -31,7 +31,7 @@ namespace Microsoft.PowerApps.TestEngine.Helpers
         {
             try
             {
-                ExpandoObject debugInfo = (ExpandoObject)await _powerAppFunctions.GetDebugInfo();                
+                ExpandoObject debugInfo = (ExpandoObject)await _powerAppFunctions.GetDebugInfo();
                 if (debugInfo != null && debugInfo.ToString() != "undefined")
                 {
                     Logger.LogInformation($"------------------------------\n Debug Info \n------------------------------");

--- a/src/Microsoft.PowerApps.TestEngine/JS/CanvasAppSdk.js
+++ b/src/Microsoft.PowerApps.TestEngine/JS/CanvasAppSdk.js
@@ -151,6 +151,9 @@ var PowerAppsTestEngine = {
     },
 
     debugInfo: {
-        sessionID: Core.Telemetry?.Log?._sessionId
+        appId: Core.Telemetry?.Log?.getAppId(),
+        appVersion: Core.Telemetry?.Log?.getAppVersion(),
+        environmentId: Core.Telemetry?.Log?.getEnvironmentId(),
+        sessionId: Core.Telemetry?.Log?._sessionId,
     }
 }

--- a/src/Microsoft.PowerApps.TestEngine/JS/CanvasAppSdk.js
+++ b/src/Microsoft.PowerApps.TestEngine/JS/CanvasAppSdk.js
@@ -151,9 +151,6 @@ var PowerAppsTestEngine = {
     },
 
     debugInfo: {
-        appId: Core.Telemetry?.Log?.getAppId(),
-        appVersion: Core.Telemetry?.Log?.getAppVersion(),
-        environmentId: Core.Telemetry?.Log?.getEnvironmentId(),
-        sessionId: Core.Telemetry?.Log?._sessionId,
+        sessionID: Core.Telemetry?.Log?._sessionId
     }
 }

--- a/src/Microsoft.PowerApps.TestEngine/Reporting/TestLogger.cs
+++ b/src/Microsoft.PowerApps.TestEngine/Reporting/TestLogger.cs
@@ -62,7 +62,6 @@ namespace Microsoft.PowerApps.TestEngine.Reporting
 
                 if (!_fileSystem.Exists(directoryPath))
                 {
-
                     _fileSystem.CreateDirectory(directoryPath);
                 }
             }

--- a/src/Microsoft.PowerApps.TestEngine/SingleTestRunner.cs
+++ b/src/Microsoft.PowerApps.TestEngine/SingleTestRunner.cs
@@ -223,6 +223,10 @@ namespace Microsoft.PowerApps.TestEngine
                     _powerFxEngine.Execute(testSuiteDefinition.OnTestSuiteComplete, locale);
                 }
             }
+            catch (UserInputException ex)
+            {
+                _eventHandler.EncounteredException(ex);
+            }
             catch (Exception ex)
             {
                 Logger.LogError("Encountered an error. See the debug log for this test suite for more information.");

--- a/src/Microsoft.PowerApps.TestEngine/SingleTestRunner.cs
+++ b/src/Microsoft.PowerApps.TestEngine/SingleTestRunner.cs
@@ -236,7 +236,7 @@ namespace Microsoft.PowerApps.TestEngine
             finally
             {
                 // Trying to log the debug info including session details
-                LoggingHelper loggingHelper = new LoggingHelper(_powerFxEngine.GetPowerAppFunctions(), _testState);
+                LoggingHelper loggingHelper = new LoggingHelper(_powerFxEngine.GetPowerAppFunctions(), _testState, _eventHandler);
                 loggingHelper.DebugInfo();
 
                 await _testInfraFunctions.EndTestRunAsync();

--- a/src/Microsoft.PowerApps.TestEngine/System/FileSystem.cs
+++ b/src/Microsoft.PowerApps.TestEngine/System/FileSystem.cs
@@ -20,6 +20,11 @@ namespace Microsoft.PowerApps.TestEngine.System
             return Directory.Exists(directoryName);
         }
 
+        public bool fileExists(string fileName)
+        {
+            return File.Exists(fileName);
+        }
+
         public string[] GetFiles(string directoryName)
         {
             return Directory.GetFiles(directoryName);

--- a/src/Microsoft.PowerApps.TestEngine/System/IFileSystem.cs
+++ b/src/Microsoft.PowerApps.TestEngine/System/IFileSystem.cs
@@ -21,6 +21,12 @@ namespace Microsoft.PowerApps.TestEngine.System
         public bool Exists(string directoryName);
 
         /// <summary>
+        /// Checks if a file exists
+        /// </summary>
+        /// <param name="directoryName">Directory name</param>
+        public bool fileExists(string fileName);
+
+        /// <summary>
         /// Gets files in a directory
         /// </summary>
         /// <param name="directoryName">Directory name</param>

--- a/src/Microsoft.PowerApps.TestEngine/System/UserAppException.cs
+++ b/src/Microsoft.PowerApps.TestEngine/System/UserAppException.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+namespace Microsoft.PowerApps.TestEngine.System
+{
+    public class UserInputException : Exception
+    {
+        // Error Mapping keys for hanlding user input exception
+        // This can be identified by the event handler for specifically handling error messages for these scenarios
+        public enum errorMapping
+        {
+            UserInputExceptionInvalidFilePath,
+            UserInputExceptionLoginCredential,
+            UserInputExceptionTestConfig,
+            UserInputExceptionYAMLFormat
+        };
+
+        public UserInputException()
+        {
+        }
+
+        public UserInputException(string message)
+            : base(message)
+        {
+        }
+
+        public UserInputException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+    }
+}

--- a/src/Microsoft.PowerApps.TestEngine/System/UserAppException.cs
+++ b/src/Microsoft.PowerApps.TestEngine/System/UserAppException.cs
@@ -3,28 +3,19 @@
 
 namespace Microsoft.PowerApps.TestEngine.System
 {
-    public class UserInputException : Exception
+    public class UserAppException : Exception
     {
-        // Error Mapping keys for hanlding user input exception
-        // This can be identified by the event handler for specifically handling error messages for these scenarios
-        public enum errorMapping
-        {
-            UserInputExceptionInvalidFilePath,
-            UserInputExceptionLoginCredential,
-            UserInputExceptionTestConfig,
-            UserInputExceptionYAMLFormat
-        };
 
-        public UserInputException()
+        public UserAppException()
         {
         }
 
-        public UserInputException(string message)
+        public UserAppException(string message)
             : base(message)
         {
         }
 
-        public UserInputException(string message, Exception innerException)
+        public UserAppException(string message, Exception innerException)
             : base(message, innerException)
         {
         }

--- a/src/Microsoft.PowerApps.TestEngine/System/UserInputException.cs
+++ b/src/Microsoft.PowerApps.TestEngine/System/UserInputException.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+namespace Microsoft.PowerApps.TestEngine.System
+{
+    public class UserInputException : Exception
+    {
+        public enum errorMapping
+        {
+          UserInputExceptionAppURL,
+          UserInputExceptionInvalidFilePath,
+          UserInputExceptionLoginCredential,
+          UserInputExceptionTestConfig,          
+          UserInputExceptionYAMLFormat
+        };
+
+        public UserInputException()
+        {
+        }
+
+        public UserInputException(string message)
+            : base(message)
+        {
+        }
+
+        public UserInputException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+    }
+}

--- a/src/Microsoft.PowerApps.TestEngine/System/UserInputException.cs
+++ b/src/Microsoft.PowerApps.TestEngine/System/UserInputException.cs
@@ -10,7 +10,7 @@ namespace Microsoft.PowerApps.TestEngine.System
             UserInputExceptionAppURL,
             UserInputExceptionInvalidFilePath,
             UserInputExceptionLoginCredential,
-            UserInputExceptionTestConfig,          
+            UserInputExceptionTestConfig,
             UserInputExceptionYAMLFormat
         };
 

--- a/src/Microsoft.PowerApps.TestEngine/System/UserInputException.cs
+++ b/src/Microsoft.PowerApps.TestEngine/System/UserInputException.cs
@@ -3,29 +3,19 @@
 
 namespace Microsoft.PowerApps.TestEngine.System
 {
-    public class UserInputException : Exception
+    public class UserAppException : Exception
     {
-        // Error Mapping keys for hanlding user input exception
-        // This can be identified by the event handler for specifically handling error messages for these scenarios
-        public enum errorMapping
-        {
-            UserInputExceptionAppURL,
-            UserInputExceptionInvalidFilePath,
-            UserInputExceptionLoginCredential,
-            UserInputExceptionTestConfig,
-            UserInputExceptionYAMLFormat
-        };
 
-        public UserInputException()
+        public UserAppException()
         {
         }
 
-        public UserInputException(string message)
+        public UserAppException(string message)
             : base(message)
         {
         }
 
-        public UserInputException(string message, Exception innerException)
+        public UserAppException(string message, Exception innerException)
             : base(message, innerException)
         {
         }

--- a/src/Microsoft.PowerApps.TestEngine/System/UserInputException.cs
+++ b/src/Microsoft.PowerApps.TestEngine/System/UserInputException.cs
@@ -3,19 +3,28 @@
 
 namespace Microsoft.PowerApps.TestEngine.System
 {
-    public class UserAppException : Exception
+    public class UserInputException : Exception
     {
+        // Error Mapping keys for hanlding user input exception
+        // This can be identified by the event handler for specifically handling error messages for these scenarios
+        public enum errorMapping
+        {
+            UserInputExceptionInvalidFilePath,
+            UserInputExceptionLoginCredential,
+            UserInputExceptionTestConfig,
+            UserInputExceptionYAMLFormat
+        };
 
-        public UserAppException()
+        public UserInputException()
         {
         }
 
-        public UserAppException(string message)
+        public UserInputException(string message)
             : base(message)
         {
         }
 
-        public UserAppException(string message, Exception innerException)
+        public UserInputException(string message, Exception innerException)
             : base(message, innerException)
         {
         }

--- a/src/Microsoft.PowerApps.TestEngine/System/UserInputException.cs
+++ b/src/Microsoft.PowerApps.TestEngine/System/UserInputException.cs
@@ -5,6 +5,8 @@ namespace Microsoft.PowerApps.TestEngine.System
 {
     public class UserInputException : Exception
     {
+        // Error Mapping keys for hanlding user input exception
+        // This can be identified by the event handler for specifically handling error messages for these scenarios
         public enum errorMapping
         {
             UserInputExceptionAppURL,

--- a/src/Microsoft.PowerApps.TestEngine/System/UserInputException.cs
+++ b/src/Microsoft.PowerApps.TestEngine/System/UserInputException.cs
@@ -7,11 +7,11 @@ namespace Microsoft.PowerApps.TestEngine.System
     {
         public enum errorMapping
         {
-          UserInputExceptionAppURL,
-          UserInputExceptionInvalidFilePath,
-          UserInputExceptionLoginCredential,
-          UserInputExceptionTestConfig,          
-          UserInputExceptionYAMLFormat
+            UserInputExceptionAppURL,
+            UserInputExceptionInvalidFilePath,
+            UserInputExceptionLoginCredential,
+            UserInputExceptionTestConfig,          
+            UserInputExceptionYAMLFormat
         };
 
         public UserInputException()

--- a/src/Microsoft.PowerApps.TestEngine/TestEngine.cs
+++ b/src/Microsoft.PowerApps.TestEngine/TestEngine.cs
@@ -120,8 +120,8 @@ namespace Microsoft.PowerApps.TestEngine
                 _testReporter.EndTestRun(testRunId);
                 return _testReporter.GenerateTestReport(testRunId, testRunDirectory);
             }
-            catch (UserInputException e) 
-            { 
+            catch (UserInputException e)
+            {
                _eventHandler.EncounteredException(e);
                 return testRunDirectory;
             }

--- a/src/Microsoft.PowerApps.TestEngine/TestEngine.cs
+++ b/src/Microsoft.PowerApps.TestEngine/TestEngine.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+using System;
 using System.Globalization;
+using System.Net;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.PowerApps.TestEngine.Config;
@@ -20,6 +22,7 @@ namespace Microsoft.PowerApps.TestEngine
         private readonly ITestReporter _testReporter;
         private readonly IFileSystem _fileSystem;
         private readonly ILoggerFactory _loggerFactory;
+        private readonly ITestEngineEvents _eventHandler;
 
         private ILogger Logger { get; set; }
 
@@ -27,13 +30,15 @@ namespace Microsoft.PowerApps.TestEngine
                           IServiceProvider serviceProvider,
                           ITestReporter testReporter,
                           IFileSystem fileSystem,
-                          ILoggerFactory loggerFactory)
+                          ILoggerFactory loggerFactory,
+                          ITestEngineEvents eventHandler)
         {
             _state = state;
             _serviceProvider = serviceProvider;
             _testReporter = testReporter;
             _fileSystem = fileSystem;
             _loggerFactory = loggerFactory;
+            _eventHandler = eventHandler;
         }
 
         /// <summary>
@@ -104,7 +109,7 @@ namespace Microsoft.PowerApps.TestEngine
                 _fileSystem.CreateDirectory(testRunDirectory);
                 Logger.LogInformation($"Test results will be stored in: {testRunDirectory}");
 
-                _state.ParseAndSetTestState(testConfigFile.FullName);
+                _state.ParseAndSetTestState(testConfigFile.FullName, Logger);
                 _state.SetEnvironment(environmentId);
                 _state.SetTenant(tenantId.ToString());
 
@@ -114,6 +119,11 @@ namespace Microsoft.PowerApps.TestEngine
                 await RunTestByBrowserAsync(testRunId, testRunDirectory, domain, queryParams);
                 _testReporter.EndTestRun(testRunId);
                 return _testReporter.GenerateTestReport(testRunId, testRunDirectory);
+            }
+            catch (UserInputException e) 
+            { 
+               _eventHandler.EncounteredException(e);
+                return testRunDirectory;
             }
             catch (Exception e)
             {

--- a/src/Microsoft.PowerApps.TestEngine/TestEngine.cs
+++ b/src/Microsoft.PowerApps.TestEngine/TestEngine.cs
@@ -122,7 +122,7 @@ namespace Microsoft.PowerApps.TestEngine
             }
             catch (UserInputException e)
             {
-               _eventHandler.EncounteredException(e);
+                _eventHandler.EncounteredException(e);
                 return testRunDirectory;
             }
             catch (Exception e)

--- a/src/Microsoft.PowerApps.TestEngine/TestEngineEventHandler.cs
+++ b/src/Microsoft.PowerApps.TestEngine/TestEngineEventHandler.cs
@@ -56,7 +56,7 @@ namespace Microsoft.PowerApps.TestEngine
                         break;
                 }
             }
-            else if (ex is UserAppException) 
+            else if (ex is UserAppException)
             {
                 Console.WriteLine($"[Critical Error] Could not access PowerApps. For more details, check the logs.");
             }

--- a/src/Microsoft.PowerApps.TestEngine/TestEngineEventHandler.cs
+++ b/src/Microsoft.PowerApps.TestEngine/TestEngineEventHandler.cs
@@ -35,6 +35,30 @@ namespace Microsoft.PowerApps.TestEngine
             {
                 Console.WriteLine($"   Assertion failed: {ex.InnerException.InnerException.Message}");
             }
+            else if (ex is UserInputException)
+            {
+                switch (ex.Message)
+                {
+                    case nameof(UserInputException.errorMapping.UserInputExceptionAppURL):
+                        Console.WriteLine($"Invalid app URL. For more details, check the logs.");
+                        break;
+                    case nameof(UserInputException.errorMapping.UserInputExceptionInvalidFilePath):
+                        Console.WriteLine($"Invalid file path. For more details, check the logs.");
+                        break;
+                    case nameof(UserInputException.errorMapping.UserInputExceptionLoginCredential):
+                        Console.WriteLine($"Invalid login credential(s). For more details, check the logs.");
+                        break;
+                    case nameof(UserInputException.errorMapping.UserInputExceptionTestConfig):
+                        Console.WriteLine($"Invalid test config. For more details, check the logs.");
+                        break;
+                    case nameof(UserInputException.errorMapping.UserInputExceptionYAMLFormat):
+                        Console.WriteLine($"Invalid YAML format. For more details, check the logs.");
+                        break;
+                    default:
+                        Console.WriteLine($"   {ex.Message}");
+                        break;
+                }                
+            }
             else
             {
                 Console.WriteLine($"   {ex.Message}");

--- a/src/Microsoft.PowerApps.TestEngine/TestEngineEventHandler.cs
+++ b/src/Microsoft.PowerApps.TestEngine/TestEngineEventHandler.cs
@@ -39,9 +39,6 @@ namespace Microsoft.PowerApps.TestEngine
             {
                 switch (ex.Message)
                 {
-                    case nameof(UserInputException.errorMapping.UserInputExceptionAppURL):
-                        Console.WriteLine($"Invalid app URL. For more details, check the logs.");
-                        break;
                     case nameof(UserInputException.errorMapping.UserInputExceptionInvalidFilePath):
                         Console.WriteLine($"Invalid file path. For more details, check the logs.");
                         break;
@@ -58,6 +55,10 @@ namespace Microsoft.PowerApps.TestEngine
                         Console.WriteLine($"   {ex.Message}");
                         break;
                 }
+            }
+            else if (ex is UserAppException) 
+            {
+                Console.WriteLine($"[Critical Error] Could not access PowerApps. For more details, check the logs.");
             }
             else
             {

--- a/src/Microsoft.PowerApps.TestEngine/TestEngineEventHandler.cs
+++ b/src/Microsoft.PowerApps.TestEngine/TestEngineEventHandler.cs
@@ -57,7 +57,7 @@ namespace Microsoft.PowerApps.TestEngine
                     default:
                         Console.WriteLine($"   {ex.Message}");
                         break;
-                }           
+                }
             }
             else
             {

--- a/src/Microsoft.PowerApps.TestEngine/TestEngineEventHandler.cs
+++ b/src/Microsoft.PowerApps.TestEngine/TestEngineEventHandler.cs
@@ -57,7 +57,7 @@ namespace Microsoft.PowerApps.TestEngine
                     default:
                         Console.WriteLine($"   {ex.Message}");
                         break;
-                }                
+                }           
             }
             else
             {

--- a/src/Microsoft.PowerApps.TestEngine/TestInfra/PlaywrightTestInfraFunctions.cs
+++ b/src/Microsoft.PowerApps.TestEngine/TestInfra/PlaywrightTestInfraFunctions.cs
@@ -365,7 +365,7 @@ namespace Microsoft.PowerApps.TestEngine.TestInfra
                     if (hasPasswordError)
                     {
                         logger.LogError("Incorrect password entered. Make sure you are using the correct credentials.");
-                        throw new InvalidOperationException();
+                        throw new UserInputException(UserInputException.errorMapping.UserInputExceptionLoginCredential.ToString());
                     }
                     // If not, continue
                     else

--- a/src/Microsoft.PowerApps.TestEngine/Users/UserManager.cs
+++ b/src/Microsoft.PowerApps.TestEngine/Users/UserManager.cs
@@ -78,13 +78,13 @@ namespace Microsoft.PowerApps.TestEngine.Users
 
             if (string.IsNullOrEmpty(user))
             {
-                logger.LogError(("User email cannot be null"));
+                logger.LogError(("User email cannot be null. Please check if the environment variable is set properly."));
                 missingUserOrPassword = true;
             }
 
             if (string.IsNullOrEmpty(password))
             {
-                logger.LogError("Password cannot be null");
+                logger.LogError("Password cannot be null. Please check if the environment variable is set properly.");
                 missingUserOrPassword = true;
             }
 

--- a/src/Microsoft.PowerApps.TestEngine/Users/UserManager.cs
+++ b/src/Microsoft.PowerApps.TestEngine/Users/UserManager.cs
@@ -74,16 +74,23 @@ namespace Microsoft.PowerApps.TestEngine.Users
             var user = _environmentVariable.GetVariable(userConfig.EmailKey);
             var password = _environmentVariable.GetVariable(userConfig.PasswordKey);
 
+            bool missingUserOrPassword = false;
+
             if (string.IsNullOrEmpty(user))
             {
                 logger.LogError(("User email cannot be null"));
-                throw new InvalidOperationException();
+                missingUserOrPassword = true; 
             }
 
             if (string.IsNullOrEmpty(password))
             {
                 logger.LogError("Password cannot be null");
-                throw new InvalidOperationException();
+                missingUserOrPassword = true;
+            }
+
+            if(missingUserOrPassword)
+            {
+                throw new UserInputException(UserInputException.errorMapping.UserInputExceptionLoginCredential.ToString());
             }
 
             await _testInfraFunctions.HandleUserEmailScreen(EmailSelector, user);

--- a/src/Microsoft.PowerApps.TestEngine/Users/UserManager.cs
+++ b/src/Microsoft.PowerApps.TestEngine/Users/UserManager.cs
@@ -79,7 +79,7 @@ namespace Microsoft.PowerApps.TestEngine.Users
             if (string.IsNullOrEmpty(user))
             {
                 logger.LogError(("User email cannot be null"));
-                missingUserOrPassword = true; 
+                missingUserOrPassword = true;
             }
 
             if (string.IsNullOrEmpty(password))
@@ -88,7 +88,7 @@ namespace Microsoft.PowerApps.TestEngine.Users
                 missingUserOrPassword = true;
             }
 
-            if(missingUserOrPassword)
+            if (missingUserOrPassword)
             {
                 throw new UserInputException(UserInputException.errorMapping.UserInputExceptionLoginCredential.ToString());
             }


### PR DESCRIPTION
**User input errors** are not handled gracefully. This is keeping in mind the behavior with the consumption of test engine in PAC CLI. Few cases below handled. 
Also updated a case to handle as **User app exception**. This will help us isolate this type and localize in PAC CLI side.
Categorizing mainly these specific errors into

1. UserInputExceptionInvalidFilePath.
2. UserInputExceptionLoginCredential.
3. UserInputExceptionTestConfig.
4. UserInputExceptionYAMLFormat
5. UserAppException

**Validation**
- Unittesting
- Manual Testing

**Console Output Scenarios** 

- <img width="800" alt="image" src="https://github.com/microsoft/PowerApps-TestEngine/assets/98551644/4e126fab-8a8a-43e6-a54c-a79f68bac0a9">

- <img width="800" alt="image" src="https://github.com/microsoft/PowerApps-TestEngine/assets/98551644/f2107f52-9782-42de-a293-60ac81303077">

- <img width="800" alt="image" src="https://github.com/microsoft/PowerApps-TestEngine/assets/98551644/05653b05-33bc-4d61-b0b7-5f8dda5bb720">

- <img width="800" alt="image" src="https://github.com/microsoft/PowerApps-TestEngine/assets/98551644/8ff061c0-601f-4101-b510-f4cc5cd4fd29">

**With this PAC test run will handle such scenarios gracefully (second run has this fix).**
<img width="800" alt="image" src="https://github.com/microsoft/PowerApps-TestEngine/assets/98551644/14c143dd-c852-435a-b869-5972686eb3da">

## Checklist

- [x] The code change is covered by unit tests. I have added tests that prove my fix is effective or that my feature works
- [x] I have performed end-to-end test locally.
- [x] New and existing unit tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I used clear names for everything
- [x] I have performed a self-review of my own code
