### PR TITLE
Remove enablePowerFxOverlay from Test Settings

### DIFF
--- a/.github/workflows/yaml-integration-tests.yml
+++ b/.github/workflows/yaml-integration-tests.yml
@@ -1,5 +1,4 @@
 name: YAML Integration Tests
-
 on:
   workflow_call:
     inputs:
@@ -13,9 +12,9 @@ jobs:
       - uses: actions/checkout@v2
       - name: Integration Test
         env:
-          user1Email: "${{ secrets.POWER_PLATFORM_USER }}"
-          user1Password: "${{ secrets.POWER_PLATFORM_PASSWORD }}"
-        run: |
+            user1Email: '${{ secrets.POWER_PLATFORM_USER }}'
+            user1Password: '${{ secrets.POWER_PLATFORM_PASSWORD }}'
+        run: |   
           cd src/PowerAppsTestEngine
           dotnet build
           cd ../../
@@ -25,15 +24,15 @@ jobs:
           ./yaml-integration-tests.sh "${{ inputs.parameters }}"       # run the script with the parameter, contains logic to run the tests
       - name: Sample Test Report
         uses: dorny/test-reporter@v1.5.0
-        if: success() || failure() # run this step even if previous step failed
+        if: success() || failure()    # run this step even if previous step failed
         with:
-          name: Sample Tests # Name of the check run which will be created
-          path: "**/*.trx"
-          reporter: dotnet-trx # Format of test results
+          name: Sample Tests          # Name of the check run which will be created
+          path: '**/*.trx'            
+          reporter: dotnet-trx        # Format of test results      
       - name: Upload a Build Artifact
         uses: actions/upload-artifact@v2
         if: ${{always()}}
         with:
-          name: "Test Run"
-          path: |
-            **/TestResults/**
+            name: 'Test Run'
+            path: |
+                **/TestResults/**

--- a/.github/workflows/yaml-integration-tests.yml
+++ b/.github/workflows/yaml-integration-tests.yml
@@ -1,4 +1,5 @@
 name: YAML Integration Tests
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/yaml-integration-tests.yml
+++ b/.github/workflows/yaml-integration-tests.yml
@@ -13,9 +13,9 @@ jobs:
       - uses: actions/checkout@v2
       - name: Integration Test
         env:
-            user1Email: '${{ secrets.POWER_PLATFORM_USER }}'
-            user1Password: '${{ secrets.POWER_PLATFORM_PASSWORD }}'
-        run: |   
+          user1Email: "${{ secrets.POWER_PLATFORM_USER }}"
+          user1Password: "${{ secrets.POWER_PLATFORM_PASSWORD }}"
+        run: |
           cd src/PowerAppsTestEngine
           dotnet build
           cd ../../
@@ -25,15 +25,15 @@ jobs:
           ./yaml-integration-tests.sh "${{ inputs.parameters }}"       # run the script with the parameter, contains logic to run the tests
       - name: Sample Test Report
         uses: dorny/test-reporter@v1.5.0
-        if: success() || failure()    # run this step even if previous step failed
+        if: success() || failure() # run this step even if previous step failed
         with:
-          name: Sample Tests          # Name of the check run which will be created
-          path: '**/*.trx'            
-          reporter: dotnet-trx        # Format of test results      
+          name: Sample Tests # Name of the check run which will be created
+          path: "**/*.trx"
+          reporter: dotnet-trx # Format of test results
       - name: Upload a Build Artifact
         uses: actions/upload-artifact@v2
         if: ${{always()}}
         with:
-            name: 'Test Run'
-            path: |
-                **/TestResults/**
+          name: "Test Run"
+          path: |
+            **/TestResults/**

--- a/docs/Yaml/testSettings.md
+++ b/docs/Yaml/testSettings.md
@@ -10,7 +10,6 @@ This is used to define settings for the tests in the test plan
 | browserConfigurations | Yes | A list of browser configurations to be tested. At least one browser must be specified. |
 | recordVideo | No | Default is false. If set to true, a video recording of the test is captured. |
 | headless | No | Default is true. If set to false, the browser will show up during test execution. |
-| enablePowerFxOverlay | No | Default is false. If set to true, an overlay with the currently running Power FX command is placed on the screen. |
 | timeout | No | Default is 30000 milliseconds(30s). Timeout value in milliseconds. If any operation takes longer than the timeout limit, it will end the test in a failure. |
 | filePath | No |  The file path to a separate yaml file with all the test settings. If provided, it will **override** all the test settings in the test plan. |
 

--- a/src/Microsoft.PowerApps.TestEngine.Tests/Config/YamlTestConfigParserTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/Config/YamlTestConfigParserTests.cs
@@ -49,7 +49,6 @@ testSettings:
         - browser: Chromium
         - browser: Firefox
     headless: false
-    enablePowerFxOverlay: false
 
 environmentVariables:
     users:
@@ -77,7 +76,6 @@ environmentVariables:
             Assert.False(string.IsNullOrEmpty(testPlan.TestSuite?.TestCases[0].TestSteps));
             Assert.True(testPlan.TestSettings?.RecordVideo);
             Assert.False(testPlan.TestSettings?.Headless);
-            Assert.False(testPlan.TestSettings?.EnablePowerFxOverlay);
             Assert.Equal(2, testPlan.TestSettings?.BrowserConfigurations?.Count);
             Assert.Equal("Chromium", testPlan.TestSettings?.BrowserConfigurations?[0].Browser);
             Assert.Equal("Firefox", testPlan.TestSettings?.BrowserConfigurations?[1].Browser);
@@ -126,7 +124,6 @@ testSettings:
         - browser: Chromium
         - browser: Firefox
     headless: false
-    enablePowerFxOverlay: false
 
 environmentVariables:
     users:
@@ -154,7 +151,6 @@ environmentVariables:
             Assert.False(string.IsNullOrEmpty(testPlan.TestSuite?.TestCases[0].TestSteps));
             Assert.True(testPlan.TestSettings?.RecordVideo);
             Assert.False(testPlan.TestSettings?.Headless);
-            Assert.False(testPlan.TestSettings?.EnablePowerFxOverlay);
             Assert.Equal(2, testPlan.TestSettings?.BrowserConfigurations?.Count);
             Assert.Equal("Chromium", testPlan.TestSettings?.BrowserConfigurations?[0].Browser);
             Assert.Equal("Firefox", testPlan.TestSettings?.BrowserConfigurations?[1].Browser);
@@ -204,7 +200,6 @@ testSettings:
         - browser: Chromium
         - browser: Firefox
     headless: false
-    enablePowerFxOverlay: false
 
 environmentVariables:
     users:
@@ -232,7 +227,6 @@ environmentVariables:
             Assert.False(string.IsNullOrEmpty(testPlan.TestSuite?.TestCases[0].TestSteps));
             Assert.True(testPlan.TestSettings?.RecordVideo);
             Assert.False(testPlan.TestSettings?.Headless);
-            Assert.False(testPlan.TestSettings?.EnablePowerFxOverlay);
             Assert.Equal(2, testPlan.TestSettings?.BrowserConfigurations?.Count);
             Assert.Equal("Chromium", testPlan.TestSettings?.BrowserConfigurations?[0].Browser);
             Assert.Equal("Firefox", testPlan.TestSettings?.BrowserConfigurations?[1].Browser);
@@ -275,8 +269,7 @@ environmentVariables:
 browserConfigurations:
     - browser: Chromium
     - browser: Firefox
-headless: false
-enablePowerFxOverlay: false";
+headless: false";
 
             var filePath = "testSettings.fx.yaml";
             mockFileSystem.Setup(f => f.ReadAllText(It.IsAny<string>())).Returns(testSettingsFile);
@@ -284,7 +277,6 @@ enablePowerFxOverlay: false";
             Assert.NotNull(testSettings);
             Assert.True(testSettings.RecordVideo);
             Assert.False(testSettings.Headless);
-            Assert.False(testSettings.EnablePowerFxOverlay);
             Assert.Equal(2, testSettings.BrowserConfigurations?.Count);
             Assert.Equal("Chromium", testSettings.BrowserConfigurations?[0].Browser);
             Assert.Equal("Firefox", testSettings.BrowserConfigurations?[1].Browser);
@@ -301,8 +293,7 @@ locale: ""de-DE""
 browserConfigurations:
     - browser: Chromium
     - browser: Firefox
-headless: false
-enablePowerFxOverlay: false";
+headless: false";
 
             var filePath = "testSettings.fx.yaml";
             mockFileSystem.Setup(f => f.ReadAllText(It.IsAny<string>())).Returns(testSettingsFile);
@@ -310,7 +301,6 @@ enablePowerFxOverlay: false";
             Assert.NotNull(testSettings);
             Assert.True(testSettings.RecordVideo);
             Assert.False(testSettings.Headless);
-            Assert.False(testSettings.EnablePowerFxOverlay);
             Assert.Equal(2, testSettings.BrowserConfigurations?.Count);
             Assert.Equal("Chromium", testSettings.BrowserConfigurations?[0].Browser);
             Assert.Equal("Firefox", testSettings.BrowserConfigurations?[1].Browser);

--- a/src/Microsoft.PowerApps.TestEngine/Config/TestSettings.cs
+++ b/src/Microsoft.PowerApps.TestEngine/Config/TestSettings.cs
@@ -40,13 +40,6 @@ namespace Microsoft.PowerApps.TestEngine.Config
         public bool Headless { get; set; } = true;
 
         /// <summary>
-        /// Gets or sets whether to show the Power FX command overlay.
-        /// Default is false.
-        /// If set to true, an overlay with the currently running Power FX command is placed on the screen.
-        /// </summary>
-        public bool EnablePowerFxOverlay { get; set; } = false;
-
-        /// <summary>
         /// Timeout in milliseconds. Default is 30000 (30s)
         /// </summary>
         public int Timeout { get; set; } = 30000;


### PR DESCRIPTION
## Description

enablePowerFxOverlay is a setting that we're not implementing in Test Engine. It appears that it was intended to be implemented at some point, but never was. Removing it for now.

## Checklist

- [x] The code change is covered by unit tests. I have added tests that prove my fix is effective or that my feature works
- [x] I have performed end-to-end test locally.
- [x] New and existing unit tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I used clear names for everything
- [x] I have performed a self-review of my own code
