### PR TITLE
Remove enablePowerFxOverlay from Test Settings doc

### DIFF
--- a/docs/Yaml/testSettings.md
+++ b/docs/Yaml/testSettings.md
@@ -10,7 +10,6 @@ This is used to define settings for the tests in the test plan
 | browserConfigurations | Yes | A list of browser configurations to be tested. At least one browser must be specified. |
 | recordVideo | No | Default is false. If set to true, a video recording of the test is captured. |
 | headless | No | Default is true. If set to false, the browser will show up during test execution. |
-| enablePowerFxOverlay | No | Default is false. If set to true, an overlay with the currently running Power FX command is placed on the screen. |
 | timeout | No | Default is 30000 milliseconds(30s). Timeout value in milliseconds. If any operation takes longer than the timeout limit, it will end the test in a failure. |
 | filePath | No |  The file path to a separate yaml file with all the test settings. If provided, it will **override** all the test settings in the test plan. |
 


### PR DESCRIPTION
## Description

enablePowerFxOverlay is a setting that we're not implementing in Test Engine. It appears that it was intended to be implemented at some point, but never was. Removing it from the doc for now.

## Checklist

- [ ] The code change is covered by unit tests. I have added tests that prove my fix is effective or that my feature works
- [ ] I have performed end-to-end test locally.
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I used clear names for everything
- [ ] I have performed a self-review of my own code
