### PR TITLE
Handling invalid user input testsettings

### DIFF
--- a/src/Microsoft.PowerApps.TestEngine.Tests/Config/TestStateTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/Config/TestStateTests.cs
@@ -211,7 +211,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Config
 
             // Act and Arrange
             var ex = Assert.Throws<UserInputException>(() => state.ParseAndSetTestState(testConfigFile, MockLogger.Object));
-            Assert.Equal(UserInputException.errorMapping.UserInputExceptionTestConfig.ToString(), ex.Message);            
+            Assert.Equal(UserInputException.ErrorMapping.UserInputExceptionTestConfig.ToString(), ex.Message);            
             LoggingTestHelper.VerifyLogging(MockLogger, expectedErrorMessage, LogLevel.Error, Times.Once());
         }
 
@@ -230,7 +230,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Config
             MockTestConfigParser.Setup(x => x.ParseTestConfig<TestPlanDefinition>(It.IsAny<string>(), MockLogger.Object)).Returns(testPlanDefinition);
 
             var ex = Assert.Throws<UserInputException>(() => state.ParseAndSetTestState(testConfigFile, MockLogger.Object));
-            Assert.Equal(UserInputException.errorMapping.UserInputExceptionTestConfig.ToString(), ex.Message);            
+            Assert.Equal(UserInputException.ErrorMapping.UserInputExceptionTestConfig.ToString(), ex.Message);            
             LoggingTestHelper.VerifyLogging(MockLogger, expectedErrorMessage, LogLevel.Error, Times.Once());
         }
 
@@ -249,7 +249,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Config
             MockTestConfigParser.Setup(x => x.ParseTestConfig<TestPlanDefinition>(It.IsAny<string>(), MockLogger.Object)).Returns(testPlanDefinition);
 
             var ex = Assert.Throws<UserInputException>(() => state.ParseAndSetTestState(testConfigFile, MockLogger.Object));
-            Assert.Equal(UserInputException.errorMapping.UserInputExceptionTestConfig.ToString(), ex.Message);          
+            Assert.Equal(UserInputException.ErrorMapping.UserInputExceptionTestConfig.ToString(), ex.Message);          
             LoggingTestHelper.VerifyLogging(MockLogger, expectedErrorMessage, LogLevel.Error, Times.Once());
         }
 
@@ -271,7 +271,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Config
             MockTestConfigParser.Setup(x => x.ParseTestConfig<TestPlanDefinition>(It.IsAny<string>(), MockLogger.Object)).Returns(testPlanDefinition);
 
             var ex = Assert.Throws<UserInputException>(() => state.ParseAndSetTestState(testConfigFile, MockLogger.Object));
-            Assert.Equal(UserInputException.errorMapping.UserInputExceptionTestConfig.ToString(), ex.Message);            
+            Assert.Equal(UserInputException.ErrorMapping.UserInputExceptionTestConfig.ToString(), ex.Message);            
             LoggingTestHelper.VerifyLogging(MockLogger, expectedErrorMessage, LogLevel.Error, Times.Once());
         }
 
@@ -307,7 +307,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Config
             MockTestConfigParser.Setup(x => x.ParseTestConfig<TestPlanDefinition>(It.IsAny<string>(), MockLogger.Object)).Returns(testPlanDefinition);
 
             var ex = Assert.Throws<UserInputException>(() => state.ParseAndSetTestState(testConfigFile, MockLogger.Object));
-            Assert.Equal(UserInputException.errorMapping.UserInputExceptionTestConfig.ToString(), ex.Message);            
+            Assert.Equal(UserInputException.ErrorMapping.UserInputExceptionTestConfig.ToString(), ex.Message);            
             LoggingTestHelper.VerifyLogging(MockLogger, expectedErrorMessage, LogLevel.Error, Times.Once());
         }
 
@@ -326,7 +326,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Config
             MockTestConfigParser.Setup(x => x.ParseTestConfig<TestPlanDefinition>(It.IsAny<string>(), MockLogger.Object)).Returns(testPlanDefinition);
 
             var ex = Assert.Throws<UserInputException>(() => state.ParseAndSetTestState(testConfigFile, MockLogger.Object));
-            Assert.Equal(UserInputException.errorMapping.UserInputExceptionTestConfig.ToString(), ex.Message);            
+            Assert.Equal(UserInputException.ErrorMapping.UserInputExceptionTestConfig.ToString(), ex.Message);            
             LoggingTestHelper.VerifyLogging(MockLogger, expectedErrorMessage, LogLevel.Error, Times.Once());
         }
 
@@ -345,7 +345,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Config
             MockTestConfigParser.Setup(x => x.ParseTestConfig<TestPlanDefinition>(It.IsAny<string>(), MockLogger.Object)).Returns(testPlanDefinition);
 
             var ex = Assert.Throws<UserInputException>(() => state.ParseAndSetTestState(testConfigFile, MockLogger.Object));
-            Assert.Equal(UserInputException.errorMapping.UserInputExceptionTestConfig.ToString(), ex.Message);            
+            Assert.Equal(UserInputException.ErrorMapping.UserInputExceptionTestConfig.ToString(), ex.Message);            
             LoggingTestHelper.VerifyLogging(MockLogger, expectedErrorMessage, LogLevel.Error, Times.Once());
         }
 
@@ -362,7 +362,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Config
             MockTestConfigParser.Setup(x => x.ParseTestConfig<TestPlanDefinition>(It.IsAny<string>(), MockLogger.Object)).Returns(testPlanDefinition);
 
             var ex = Assert.Throws<UserInputException>(() => state.ParseAndSetTestState(testConfigFile, MockLogger.Object));
-            Assert.Equal(UserInputException.errorMapping.UserInputExceptionTestConfig.ToString(), ex.Message);            
+            Assert.Equal(UserInputException.ErrorMapping.UserInputExceptionTestConfig.ToString(), ex.Message);            
             LoggingTestHelper.VerifyLogging(MockLogger, expectedErrorMessage, LogLevel.Error, Times.Once());
         }
 
@@ -379,7 +379,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Config
             MockTestConfigParser.Setup(x => x.ParseTestConfig<TestPlanDefinition>(It.IsAny<string>(), MockLogger.Object)).Returns(testPlanDefinition);
 
             var ex = Assert.Throws<UserInputException>(() => state.ParseAndSetTestState(testConfigFile, MockLogger.Object));
-            Assert.Equal(UserInputException.errorMapping.UserInputExceptionTestConfig.ToString(), ex.Message);            
+            Assert.Equal(UserInputException.ErrorMapping.UserInputExceptionTestConfig.ToString(), ex.Message);            
             LoggingTestHelper.VerifyLogging(MockLogger, expectedErrorMessage, LogLevel.Error, Times.Once());
         }
 
@@ -396,7 +396,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Config
             MockTestConfigParser.Setup(x => x.ParseTestConfig<TestPlanDefinition>(It.IsAny<string>(), MockLogger.Object)).Returns(testPlanDefinition);
 
             var ex = Assert.Throws<UserInputException>(() => state.ParseAndSetTestState(testConfigFile, MockLogger.Object));
-            Assert.Equal(UserInputException.errorMapping.UserInputExceptionTestConfig.ToString(), ex.Message);            
+            Assert.Equal(UserInputException.ErrorMapping.UserInputExceptionTestConfig.ToString(), ex.Message);            
             LoggingTestHelper.VerifyLogging(MockLogger, expectedErrorMessage, LogLevel.Error, Times.Once());
         }
 
@@ -415,7 +415,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Config
             MockTestConfigParser.Setup(x => x.ParseTestConfig<TestPlanDefinition>(It.IsAny<string>(), MockLogger.Object)).Returns(testPlanDefinition);
 
             var ex = Assert.Throws<UserInputException>(() => state.ParseAndSetTestState(testConfigFile, MockLogger.Object));
-            Assert.Equal(UserInputException.errorMapping.UserInputExceptionTestConfig.ToString(), ex.Message);            
+            Assert.Equal(UserInputException.ErrorMapping.UserInputExceptionTestConfig.ToString(), ex.Message);            
             LoggingTestHelper.VerifyLogging(MockLogger, expectedErrorMessage, LogLevel.Error, Times.Once());
         }
 
@@ -439,7 +439,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Config
             MockTestConfigParser.Setup(x => x.ParseTestConfig<TestPlanDefinition>(It.IsAny<string>(), MockLogger.Object)).Returns(testPlanDefinition);
 
             var ex = Assert.Throws<UserInputException>(() => state.ParseAndSetTestState(testConfigFile, MockLogger.Object));
-            Assert.Equal(UserInputException.errorMapping.UserInputExceptionTestConfig.ToString(), ex.Message);            
+            Assert.Equal(UserInputException.ErrorMapping.UserInputExceptionTestConfig.ToString(), ex.Message);            
             LoggingTestHelper.VerifyLogging(MockLogger, expectedErrorMessage, LogLevel.Error, Times.Once());
         }
 
@@ -456,7 +456,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Config
             MockTestConfigParser.Setup(x => x.ParseTestConfig<TestPlanDefinition>(It.IsAny<string>(), MockLogger.Object)).Returns(testPlanDefinition);
 
             var ex = Assert.Throws<UserInputException>(() => state.ParseAndSetTestState(testConfigFile, MockLogger.Object));
-            Assert.Equal(UserInputException.errorMapping.UserInputExceptionTestConfig.ToString(), ex.Message);
+            Assert.Equal(UserInputException.ErrorMapping.UserInputExceptionTestConfig.ToString(), ex.Message);
             LoggingTestHelper.VerifyLogging(MockLogger, expectedErrorMessage, LogLevel.Error, Times.Once());
         }
 
@@ -473,7 +473,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Config
             MockTestConfigParser.Setup(x => x.ParseTestConfig<TestPlanDefinition>(It.IsAny<string>(), MockLogger.Object)).Returns(testPlanDefinition);
 
             var ex = Assert.Throws<UserInputException>(() => state.ParseAndSetTestState(testConfigFile, MockLogger.Object));
-            Assert.Equal(UserInputException.errorMapping.UserInputExceptionTestConfig.ToString(), ex.Message);
+            Assert.Equal(UserInputException.ErrorMapping.UserInputExceptionTestConfig.ToString(), ex.Message);
             LoggingTestHelper.VerifyLogging(MockLogger, expectedErrorMessage, LogLevel.Error, Times.Once());
         }
 
@@ -490,7 +490,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Config
             MockTestConfigParser.Setup(x => x.ParseTestConfig<TestPlanDefinition>(It.IsAny<string>(), MockLogger.Object)).Returns(testPlanDefinition);
 
             var ex = Assert.Throws<UserInputException>(() => state.ParseAndSetTestState(testConfigFile, MockLogger.Object));
-            Assert.Equal(UserInputException.errorMapping.UserInputExceptionTestConfig.ToString(), ex.Message);
+            Assert.Equal(UserInputException.ErrorMapping.UserInputExceptionTestConfig.ToString(), ex.Message);
             LoggingTestHelper.VerifyLogging(MockLogger, expectedErrorMessage, LogLevel.Error, Times.Once());
         }
 
@@ -509,7 +509,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Config
             MockTestConfigParser.Setup(x => x.ParseTestConfig<TestPlanDefinition>(It.IsAny<string>(), MockLogger.Object)).Returns(testPlanDefinition);
 
             var ex = Assert.Throws<UserInputException>(() => state.ParseAndSetTestState(testConfigFile, MockLogger.Object));
-            Assert.Equal(UserInputException.errorMapping.UserInputExceptionTestConfig.ToString(), ex.Message);
+            Assert.Equal(UserInputException.ErrorMapping.UserInputExceptionTestConfig.ToString(), ex.Message);
             LoggingTestHelper.VerifyLogging(MockLogger, expectedErrorMessage, LogLevel.Error, Times.Once());
         }
 
@@ -528,7 +528,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Config
             MockTestConfigParser.Setup(x => x.ParseTestConfig<TestPlanDefinition>(It.IsAny<string>(), MockLogger.Object)).Returns(testPlanDefinition);
 
             var ex = Assert.Throws<UserInputException>(() => state.ParseAndSetTestState(testConfigFile, MockLogger.Object));
-            Assert.Equal(UserInputException.errorMapping.UserInputExceptionTestConfig.ToString(), ex.Message);
+            Assert.Equal(UserInputException.ErrorMapping.UserInputExceptionTestConfig.ToString(), ex.Message);
             LoggingTestHelper.VerifyLogging(MockLogger, expectedErrorMessage, LogLevel.Error, Times.Once());
         }
 
@@ -547,7 +547,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Config
             MockTestConfigParser.Setup(x => x.ParseTestConfig<TestPlanDefinition>(It.IsAny<string>(), MockLogger.Object)).Returns(testPlanDefinition);
 
             var ex = Assert.Throws<UserInputException>(() => state.ParseAndSetTestState(testConfigFile, MockLogger.Object));
-            Assert.Equal(UserInputException.errorMapping.UserInputExceptionTestConfig.ToString(), ex.Message);
+            Assert.Equal(UserInputException.ErrorMapping.UserInputExceptionTestConfig.ToString(), ex.Message);
             LoggingTestHelper.VerifyLogging(MockLogger, expectedErrorMessage, LogLevel.Error, Times.Once());
         }
 
@@ -564,7 +564,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Config
             MockTestConfigParser.Setup(x => x.ParseTestConfig<TestPlanDefinition>(It.IsAny<string>(), MockLogger.Object)).Returns(testPlanDefinition);
 
             var ex = Assert.Throws<UserInputException>(() => state.ParseAndSetTestState(testConfigFile, MockLogger.Object));
-            Assert.Equal(UserInputException.errorMapping.UserInputExceptionTestConfig.ToString(), ex.Message);
+            Assert.Equal(UserInputException.ErrorMapping.UserInputExceptionTestConfig.ToString(), ex.Message);
             LoggingTestHelper.VerifyLogging(MockLogger, expectedErrorMessage, LogLevel.Error, Times.Once());
         }
 
@@ -586,7 +586,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Config
             MockTestConfigParser.Setup(x => x.ParseTestConfig<TestPlanDefinition>(It.IsAny<string>(), MockLogger.Object)).Returns(testPlanDefinition);
 
             var ex = Assert.Throws<UserInputException>(() => state.ParseAndSetTestState(testConfigFile, MockLogger.Object));
-            Assert.Equal(UserInputException.errorMapping.UserInputExceptionTestConfig.ToString(), ex.Message);
+            Assert.Equal(UserInputException.ErrorMapping.UserInputExceptionTestConfig.ToString(), ex.Message);
             LoggingTestHelper.VerifyLogging(MockLogger, expectedErrorMessage, LogLevel.Error, Times.Once());
         }
 

--- a/src/Microsoft.PowerApps.TestEngine.Tests/Config/YamlTestConfigParserTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/Config/YamlTestConfigParserTests.cs
@@ -374,7 +374,7 @@ enablePowerFxOverlay: false";
             LoggingTestHelper.SetupMock(MockLogger);
 
             var ex = Assert.Throws<UserInputException>(() => parser.ParseTestConfig<TestSettings>("some invalid file path", MockLogger.Object));
-            Assert.Equal(ex.Message, UserInputException.errorMapping.UserInputExceptionInvalidFilePath.ToString());
+            Assert.Equal(ex.Message, UserInputException.ErrorMapping.UserInputExceptionInvalidFilePath.ToString());
             // Verify the message is logged in this case
             LoggingTestHelper.VerifyLogging(MockLogger, "Invalid file path: TestSettings in test config file.", LogLevel.Error, Times.Once());
         }
@@ -390,7 +390,7 @@ enablePowerFxOverlay: false";
             LoggingTestHelper.SetupMock(MockLogger);
 
             var ex = Assert.Throws<UserInputException>(() => parser.ParseTestConfig<TestSettings>("validFilePath.yaml", MockLogger.Object));
-            Assert.Equal(ex.Message,UserInputException.errorMapping.UserInputExceptionYAMLFormat.ToString());
+            Assert.Equal(ex.Message,UserInputException.ErrorMapping.UserInputExceptionYAMLFormat.ToString());
             // Verify the message is logged in this case
             LoggingTestHelper.VerifyLogging(MockLogger, "Invalid YAML format: TestSettings in test config file.", LogLevel.Error, Times.Once());
         }

--- a/src/Microsoft.PowerApps.TestEngine.Tests/ConsoleOutputTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/ConsoleOutputTests.cs
@@ -203,7 +203,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
         {
             public UserInputExceptionDataGenerator()
             {
-                Add(nameof(UserInputException.errorMapping.UserInputExceptionInvalidLocale), TestEngineEventHandler.UserInputExceptionInvalidLocaleMessage);
+                Add(nameof(UserInputException.errorMapping.UserInputExceptionInvalidTestSettings), TestEngineEventHandler.UserInputExceptionInvalidTestSettingsMessage);
                 Add(nameof(UserInputException.errorMapping.UserInputExceptionInvalidFilePath), TestEngineEventHandler.UserInputExceptionInvalidFilePathMessage);
                 Add(nameof(UserInputException.errorMapping.UserInputExceptionLoginCredential), TestEngineEventHandler.UserInputExceptionLoginCredentialMessage);
                 Add(nameof(UserInputException.errorMapping.UserInputExceptionTestConfig), TestEngineEventHandler.UserInputExceptionTestConfigMessage);

--- a/src/Microsoft.PowerApps.TestEngine.Tests/ConsoleOutputTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/ConsoleOutputTests.cs
@@ -2,7 +2,9 @@
 // Licensed under the MIT license.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
+using Microsoft.PowerApps.TestEngine.Config;
 using Microsoft.PowerApps.TestEngine.System;
 using Xunit;
 
@@ -165,7 +167,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
         public void TestEncounteredUserAppException()
         {
             // Specify expected result and output object
-            var expected = "[Critical Error] Could not access PowerApps. For more details, check the logs.";
+            var expected = TestEngineEventHandler.UserAppExceptionMessage;
             var printer = new StringWriter();
             Exception ex = new UserAppException();
 
@@ -175,15 +177,12 @@ namespace Microsoft.PowerApps.TestEngine.Tests
             // Run function
             _testEngineEventHandler.EncounteredException(ex);
 
-            // Assert that the expected output matches the console output of the function
+            // Assert that the expected output matches the console output
             Assert.Contains(expected, printer.ToString());
         }
 
         [Theory]
-        [InlineData(nameof(UserInputException.errorMapping.UserInputExceptionInvalidFilePath), "Invalid file path. For more details, check the logs.")]
-        [InlineData(nameof(UserInputException.errorMapping.UserInputExceptionLoginCredential), "Invalid login credential(s). For more details, check the logs.")]
-        [InlineData(nameof(UserInputException.errorMapping.UserInputExceptionTestConfig), "Invalid test config. For more details, check the logs.")]
-        [InlineData(nameof(UserInputException.errorMapping.UserInputExceptionYAMLFormat), "Invalid YAML format. For more details, check the logs.")]
+        [ClassData(typeof(UserInputExceptionDataGenerator))]
         public void TestEncounteredUserInputException(string exceptionName, string expectedMessage)
         {
             // Specify expected result and output object
@@ -196,8 +195,20 @@ namespace Microsoft.PowerApps.TestEngine.Tests
             // Run function
             _testEngineEventHandler.EncounteredException(ex);
 
-            // Assert that the expected output matches the console output of the function
+            // Assert that the expected output matches the console output
             Assert.Contains(expectedMessage, printer.ToString());
+        }
+
+        class UserInputExceptionDataGenerator : TheoryData<string, string>
+        {
+            public UserInputExceptionDataGenerator()
+            {
+                Add(nameof(UserInputException.errorMapping.UserInputExceptionInvalidLocale), TestEngineEventHandler.UserInputExceptionInvalidLocaleMessage);
+                Add(nameof(UserInputException.errorMapping.UserInputExceptionInvalidFilePath), TestEngineEventHandler.UserInputExceptionInvalidFilePathMessage);
+                Add(nameof(UserInputException.errorMapping.UserInputExceptionLoginCredential), TestEngineEventHandler.UserInputExceptionLoginCredentialMessage);
+                Add(nameof(UserInputException.errorMapping.UserInputExceptionTestConfig), TestEngineEventHandler.UserInputExceptionTestConfigMessage);
+                Add(nameof(UserInputException.errorMapping.UserInputExceptionYAMLFormat), TestEngineEventHandler.UserInputExceptionYAMLFormatMessage);
+            }
         }
     }
 }

--- a/src/Microsoft.PowerApps.TestEngine.Tests/ConsoleOutputTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/ConsoleOutputTests.cs
@@ -203,11 +203,11 @@ namespace Microsoft.PowerApps.TestEngine.Tests
         {
             public UserInputExceptionDataGenerator()
             {
-                Add(nameof(UserInputException.errorMapping.UserInputExceptionInvalidTestSettings), TestEngineEventHandler.UserInputExceptionInvalidTestSettingsMessage);
-                Add(nameof(UserInputException.errorMapping.UserInputExceptionInvalidFilePath), TestEngineEventHandler.UserInputExceptionInvalidFilePathMessage);
-                Add(nameof(UserInputException.errorMapping.UserInputExceptionLoginCredential), TestEngineEventHandler.UserInputExceptionLoginCredentialMessage);
-                Add(nameof(UserInputException.errorMapping.UserInputExceptionTestConfig), TestEngineEventHandler.UserInputExceptionTestConfigMessage);
-                Add(nameof(UserInputException.errorMapping.UserInputExceptionYAMLFormat), TestEngineEventHandler.UserInputExceptionYAMLFormatMessage);
+                Add(nameof(UserInputException.ErrorMapping.UserInputExceptionInvalidTestSettings), TestEngineEventHandler.UserInputExceptionInvalidTestSettingsMessage);
+                Add(nameof(UserInputException.ErrorMapping.UserInputExceptionInvalidFilePath), TestEngineEventHandler.UserInputExceptionInvalidFilePathMessage);
+                Add(nameof(UserInputException.ErrorMapping.UserInputExceptionLoginCredential), TestEngineEventHandler.UserInputExceptionLoginCredentialMessage);
+                Add(nameof(UserInputException.ErrorMapping.UserInputExceptionTestConfig), TestEngineEventHandler.UserInputExceptionTestConfigMessage);
+                Add(nameof(UserInputException.ErrorMapping.UserInputExceptionYAMLFormat), TestEngineEventHandler.UserInputExceptionYAMLFormatMessage);
             }
         }
     }

--- a/src/Microsoft.PowerApps.TestEngine.Tests/SingleTestRunnerTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/SingleTestRunnerTests.cs
@@ -438,7 +438,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
             var locale = string.IsNullOrEmpty(testData.testSuiteLocale) ? CultureInfo.CurrentCulture : new CultureInfo(testData.testSuiteLocale);
 
             // Specific setup for this test
-            var exceptionToThrow = new UserInputException(UserInputException.errorMapping.UserInputExceptionLoginCredential.ToString());
+            var exceptionToThrow = new UserInputException(UserInputException.ErrorMapping.UserInputExceptionLoginCredential.ToString());
             MockUserManager.Setup(x => x.LoginAsUserAsync(It.IsAny<string>())).Throws(exceptionToThrow);
             MockTestEngineEventHandler.Setup(x => x.EncounteredException(It.IsAny<Exception>()));            
 

--- a/src/Microsoft.PowerApps.TestEngine.Tests/TestEngineTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/TestEngineTests.cs
@@ -406,7 +406,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
 
             // Assert
             var ex = Assert.Throws<UserInputException>(() => testEngine.GetLocaleFromTestSettings(localeInput));
-            Assert.Equal(UserInputException.errorMapping.UserInputExceptionInvalidTestSettings.ToString(), ex.Message);
+            Assert.Equal(UserInputException.ErrorMapping.UserInputExceptionInvalidTestSettings.ToString(), ex.Message);
             LoggingTestHelper.VerifyLogging(MockLogger, $"Locale from test suite definition {localeInput} unrecognized.", LogLevel.Error, Times.Once());
         }
 

--- a/src/Microsoft.PowerApps.TestEngine.Tests/TestEngineTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/TestEngineTests.cs
@@ -126,7 +126,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
 
             var testEngine = new TestEngine(MockState.Object, ServiceProvider, MockTestReporter.Object, MockFileSystem.Object, MockLoggerFactory.Object, MockTestEngineEventHandler.Object);
 
-            await Assert.ThrowsAsync<CultureNotFoundException>(() => testEngine.RunTestAsync(testConfigFile, environmentId, tenantId, outputDirectory, domain, ""));
+            await Assert.ThrowsAsync<UserInputException>(() => testEngine.RunTestAsync(testConfigFile, environmentId, tenantId, outputDirectory, domain, ""));
         }
 
         [Fact]

--- a/src/Microsoft.PowerApps.TestEngine.Tests/TestEngineTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/TestEngineTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -366,6 +367,42 @@ namespace Microsoft.PowerApps.TestEngine.Tests
             MockTestEngineEventHandler.Verify(x => x.EncounteredException(exceptionToThrow), Times.Once());
             Assert.NotNull(testResultsDirectory);
         }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public async Task GetLocaleFromTestSettingsUseSystemLocaleIfNull(string localeInput)
+        {
+            // Arrange
+            LoggingTestHelper.SetupMock(MockLogger);
+
+            // Act
+            var testEngine = new TestEngine(MockState.Object, ServiceProvider, MockTestReporter.Object, MockFileSystem.Object, MockLoggerFactory.Object, MockTestEngineEventHandler.Object);
+            testEngine.Logger = MockLogger.Object;
+
+            // Assert
+            var locale = testEngine.GetLocaleFromTestSettings(localeInput);
+            Assert.Equal(CultureInfo.CurrentCulture, locale);
+            LoggingTestHelper.VerifyLogging(MockLogger, $"Locale property not specified in testSettings. Using current system locale: {locale.Name}", LogLevel.Debug, Times.Once());
+        }
+
+        [Fact]
+        public async Task GetLocaleFromTestSettingsThrowsUserInputExceptionOnInvalidLocale()
+        {
+            // Arrange
+            LoggingTestHelper.SetupMock(MockLogger);
+            var localeInput = "invalidLocaleName";
+
+            // Act
+            var testEngine = new TestEngine(MockState.Object, ServiceProvider, MockTestReporter.Object, MockFileSystem.Object, MockLoggerFactory.Object, MockTestEngineEventHandler.Object);
+            testEngine.Logger = MockLogger.Object;
+
+            // Assert
+            var ex = Assert.Throws<UserInputException>(() => testEngine.GetLocaleFromTestSettings(localeInput));
+            Assert.Equal(UserInputException.errorMapping.UserInputExceptionInvalidLocale.ToString(), ex.Message);
+            LoggingTestHelper.VerifyLogging(MockLogger, $"Locale from test suite definition {localeInput} unrecognized.", LogLevel.Error, Times.Once());
+        }
+
         class TestDataGenerator : TheoryData<DirectoryInfo, string, TestSettings, TestSuiteDefinition>
         {
             public TestDataGenerator()

--- a/src/Microsoft.PowerApps.TestEngine.Tests/TestEngineTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/TestEngineTests.cs
@@ -406,7 +406,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
 
             // Assert
             var ex = Assert.Throws<UserInputException>(() => testEngine.GetLocaleFromTestSettings(localeInput));
-            Assert.Equal(UserInputException.errorMapping.UserInputExceptionInvalidLocale.ToString(), ex.Message);
+            Assert.Equal(UserInputException.errorMapping.UserInputExceptionInvalidTestSettings.ToString(), ex.Message);
             LoggingTestHelper.VerifyLogging(MockLogger, $"Locale from test suite definition {localeInput} unrecognized.", LogLevel.Error, Times.Once());
         }
 

--- a/src/Microsoft.PowerApps.TestEngine.Tests/TestInfra/PlaywrightTestInfraFunctionTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/TestInfra/PlaywrightTestInfraFunctionTests.cs
@@ -198,7 +198,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.TestInfra
 
             // Act and Assert
             var ex = await Assert.ThrowsAsync<UserInputException>(async () => await playwrightTestInfraFunctions.SetupAsync());
-            Assert.Equal(UserInputException.errorMapping.UserInputExceptionInvalidTestSettings.ToString(), ex.Message);
+            Assert.Equal(UserInputException.ErrorMapping.UserInputExceptionInvalidTestSettings.ToString(), ex.Message);
             LoggingTestHelper.VerifyLogging(MockLogger, PlaywrightTestInfraFunctions.BrowserNotSupportedErrorMessage, LogLevel.Error, Times.Once());
         }
 
@@ -708,7 +708,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.TestInfra
 
             MockPage.Verify(x => x.Locator(It.Is<string>(v => v.Equals(testSelector)), null));
             MockPage.Verify(x => x.WaitForSelectorAsync("[id=\"passwordError\"]", It.Is<PageWaitForSelectorOptions>(v => v.Timeout >= 2000)));
-            Assert.Equal(UserInputException.errorMapping.UserInputExceptionLoginCredential.ToString(), ex.Message);
+            Assert.Equal(UserInputException.ErrorMapping.UserInputExceptionLoginCredential.ToString(), ex.Message);
         }
 
         [Fact]

--- a/src/Microsoft.PowerApps.TestEngine.Tests/TestInfra/PlaywrightTestInfraFunctionTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/TestInfra/PlaywrightTestInfraFunctionTests.cs
@@ -148,6 +148,30 @@ namespace Microsoft.PowerApps.TestEngine.Tests.TestInfra
         [Theory]
         [InlineData("")]
         [InlineData(null)]
+        public async Task SetupAsyncThrowsOnNullOrEmptyBrowserTest(string browser)
+        {
+            var browserConfig = new BrowserConfiguration()
+            {
+                Browser = browser
+            };
+            MockSingleTestInstanceState.Setup(x => x.GetBrowserConfig()).Returns(browserConfig);
+            MockSingleTestInstanceState.Setup(x => x.GetLogger()).Returns(MockLogger.Object);
+            LoggingTestHelper.SetupMock(MockLogger);
+
+            var testSettings = new TestSettings()
+            {
+                Headless = true,
+                Timeout = 15
+            };
+
+            MockTestState.Setup(x => x.GetTestSettings()).Returns(testSettings);
+
+            var playwrightTestInfraFunctions = new PlaywrightTestInfraFunctions(MockTestState.Object, MockSingleTestInstanceState.Object,
+                MockFileSystem.Object, null);
+            await Assert.ThrowsAsync<InvalidOperationException>(async () => await playwrightTestInfraFunctions.SetupAsync());
+        }
+
+        [Theory]
         [InlineData("Chrome")]
         [InlineData("Safari")]
         [InlineData("INVALID_BROWSER_NAME")]
@@ -171,7 +195,11 @@ namespace Microsoft.PowerApps.TestEngine.Tests.TestInfra
 
             var playwrightTestInfraFunctions = new PlaywrightTestInfraFunctions(MockTestState.Object, MockSingleTestInstanceState.Object,
                 MockFileSystem.Object, null);
-            await Assert.ThrowsAsync<InvalidOperationException>(async () => await playwrightTestInfraFunctions.SetupAsync());
+
+            // Act and Assert
+            var ex = await Assert.ThrowsAsync<UserInputException>(async () => await playwrightTestInfraFunctions.SetupAsync());
+            Assert.Equal(UserInputException.errorMapping.UserInputExceptionInvalidTestSettings.ToString(), ex.Message);
+            LoggingTestHelper.VerifyLogging(MockLogger, PlaywrightTestInfraFunctions.BrowserNotSupportedErrorMessage, LogLevel.Error, Times.Once());
         }
 
         [Fact]

--- a/src/Microsoft.PowerApps.TestEngine.Tests/Users/UserManagerTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/Users/UserManagerTests.cs
@@ -189,7 +189,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Users
             var userManager = new UserManager(MockTestInfraFunctions.Object, MockTestState.Object, MockSingleTestInstanceState.Object, MockEnvironmentVariable.Object);
             
             var ex = await Assert.ThrowsAsync<UserInputException>(async () => await userManager.LoginAsUserAsync("*"));
-            Assert.Equal(UserInputException.errorMapping.UserInputExceptionLoginCredential.ToString(), ex.Message);
+            Assert.Equal(UserInputException.ErrorMapping.UserInputExceptionLoginCredential.ToString(), ex.Message);
             if (String.IsNullOrEmpty(email))
             {
                 LoggingTestHelper.VerifyLogging(MockLogger, "User email cannot be null. Please check if the environment variable is set properly.", LogLevel.Error, Times.Once());

--- a/src/Microsoft.PowerApps.TestEngine/Config/TestState.cs
+++ b/src/Microsoft.PowerApps.TestEngine/Config/TestState.cs
@@ -169,7 +169,7 @@ namespace Microsoft.PowerApps.TestEngine.Config
             if (userInputExceptionMessages.Count() > 0)
             {
                 logger.LogError($"Invalid User Input(s): {String.Join(", ", userInputExceptionMessages)}");
-                throw new UserInputException(UserInputException.errorMapping.UserInputExceptionTestConfig.ToString());
+                throw new UserInputException(UserInputException.ErrorMapping.UserInputExceptionTestConfig.ToString());
             }
 
             IsValid = true;

--- a/src/Microsoft.PowerApps.TestEngine/Config/YamlTestConfigParser.cs
+++ b/src/Microsoft.PowerApps.TestEngine/Config/YamlTestConfigParser.cs
@@ -32,7 +32,7 @@ namespace Microsoft.PowerApps.TestEngine.Config
                 if (!_fileSystem.fileExists(testConfigFilePath))
                 {
                     logger.LogError($"Invalid file path: {typeof(T).Name} in test config file.");
-                    throw new UserInputException(UserInputException.errorMapping.UserInputExceptionInvalidFilePath.ToString());
+                    throw new UserInputException(UserInputException.ErrorMapping.UserInputExceptionInvalidFilePath.ToString());
                 }
 
                 var deserializer = new YamlDotNet.Serialization.DeserializerBuilder()
@@ -44,7 +44,7 @@ namespace Microsoft.PowerApps.TestEngine.Config
             catch (YamlException)
             {
                 logger.LogError($"Invalid YAML format: {typeof(T).Name} in test config file.");
-                throw new UserInputException(UserInputException.errorMapping.UserInputExceptionYAMLFormat.ToString());
+                throw new UserInputException(UserInputException.ErrorMapping.UserInputExceptionYAMLFormat.ToString());
             }
         }
     }

--- a/src/Microsoft.PowerApps.TestEngine/SingleTestRunner.cs
+++ b/src/Microsoft.PowerApps.TestEngine/SingleTestRunner.cs
@@ -97,6 +97,7 @@ namespace Microsoft.PowerApps.TestEngine
 
             try
             {
+                _testReporter.TestResultsDirectory = testRunDirectory;
                 _fileSystem.CreateDirectory(testResultDirectory);
 
                 Logger.LogInformation($"\n\n---------------------------------------------------------------------------\n" +
@@ -116,8 +117,7 @@ namespace Microsoft.PowerApps.TestEngine
                 // Navigate to test url
                 await _testInfraFunctions.GoToUrlAsync(desiredUrl);
                 Logger.LogInformation("Successfully navigated to target URL");
-
-                _testReporter.TestResultsDirectory = testRunDirectory;
+                
                 _testReporter.TestRunAppURL = desiredUrl;
 
                 // Log in user

--- a/src/Microsoft.PowerApps.TestEngine/SingleTestRunner.cs
+++ b/src/Microsoft.PowerApps.TestEngine/SingleTestRunner.cs
@@ -117,7 +117,7 @@ namespace Microsoft.PowerApps.TestEngine
                 // Navigate to test url
                 await _testInfraFunctions.GoToUrlAsync(desiredUrl);
                 Logger.LogInformation("Successfully navigated to target URL");
-                
+
                 _testReporter.TestRunAppURL = desiredUrl;
 
                 // Log in user

--- a/src/Microsoft.PowerApps.TestEngine/System/UserInputException.cs
+++ b/src/Microsoft.PowerApps.TestEngine/System/UserInputException.cs
@@ -7,7 +7,7 @@ namespace Microsoft.PowerApps.TestEngine.System
     {
         // Error Mapping keys for hanlding user input exception
         // This can be identified by the event handler for specifically handling error messages for these scenarios
-        public enum errorMapping
+        public enum ErrorMapping
         {
             UserInputExceptionInvalidFilePath,
             UserInputExceptionInvalidTestSettings,

--- a/src/Microsoft.PowerApps.TestEngine/System/UserInputException.cs
+++ b/src/Microsoft.PowerApps.TestEngine/System/UserInputException.cs
@@ -10,8 +10,9 @@ namespace Microsoft.PowerApps.TestEngine.System
         public enum errorMapping
         {
             UserInputExceptionInvalidFilePath,
+            UserInputExceptionInvalidLocale,
             UserInputExceptionLoginCredential,
-            UserInputExceptionTestConfig,
+            UserInputExceptionTestConfig,            
             UserInputExceptionYAMLFormat
         };
 

--- a/src/Microsoft.PowerApps.TestEngine/System/UserInputException.cs
+++ b/src/Microsoft.PowerApps.TestEngine/System/UserInputException.cs
@@ -12,7 +12,7 @@ namespace Microsoft.PowerApps.TestEngine.System
             UserInputExceptionInvalidFilePath,
             UserInputExceptionInvalidLocale,
             UserInputExceptionLoginCredential,
-            UserInputExceptionTestConfig,            
+            UserInputExceptionTestConfig,
             UserInputExceptionYAMLFormat
         };
 

--- a/src/Microsoft.PowerApps.TestEngine/System/UserInputException.cs
+++ b/src/Microsoft.PowerApps.TestEngine/System/UserInputException.cs
@@ -10,7 +10,7 @@ namespace Microsoft.PowerApps.TestEngine.System
         public enum errorMapping
         {
             UserInputExceptionInvalidFilePath,
-            UserInputExceptionInvalidLocale,
+            UserInputExceptionInvalidTestSettings,
             UserInputExceptionLoginCredential,
             UserInputExceptionTestConfig,
             UserInputExceptionYAMLFormat

--- a/src/Microsoft.PowerApps.TestEngine/TestEngine.cs
+++ b/src/Microsoft.PowerApps.TestEngine/TestEngine.cs
@@ -24,7 +24,7 @@ namespace Microsoft.PowerApps.TestEngine
         private readonly ILoggerFactory _loggerFactory;
         private readonly ITestEngineEvents _eventHandler;
 
-        private ILogger Logger { get; set; }
+        public ILogger Logger { get; set; }
 
         public TestEngine(ITestState state,
                           IServiceProvider serviceProvider,
@@ -163,7 +163,7 @@ namespace Microsoft.PowerApps.TestEngine
             }
         }
 
-        private CultureInfo GetLocaleFromTestSettings(string strLocale)
+        public CultureInfo GetLocaleFromTestSettings(string strLocale)
         {
             var locale = CultureInfo.CurrentCulture;
             try
@@ -175,15 +175,15 @@ namespace Microsoft.PowerApps.TestEngine
                 else
                 {
                     locale = new CultureInfo(strLocale);
-                    Logger.LogDebug($"Locale: {locale.Name}");
+                    Logger.LogDebug($"Locale: {locale.Name}");                    
                 }
+                return locale;
             }
-            catch (ArgumentException)
+            catch (CultureNotFoundException)
             {
-                Logger.LogError($"Locale from test suite definition {strLocale} unrecognized");
-                throw;
+                Logger.LogError($"Locale from test suite definition {strLocale} unrecognized.");
+                throw new UserInputException(UserInputException.errorMapping.UserInputExceptionInvalidLocale.ToString());
             }
-            return locale;
         }
     }
 }

--- a/src/Microsoft.PowerApps.TestEngine/TestEngine.cs
+++ b/src/Microsoft.PowerApps.TestEngine/TestEngine.cs
@@ -175,7 +175,7 @@ namespace Microsoft.PowerApps.TestEngine
                 else
                 {
                     locale = new CultureInfo(strLocale);
-                    Logger.LogDebug($"Locale: {locale.Name}");                    
+                    Logger.LogDebug($"Locale: {locale.Name}");
                 }
                 return locale;
             }

--- a/src/Microsoft.PowerApps.TestEngine/TestEngine.cs
+++ b/src/Microsoft.PowerApps.TestEngine/TestEngine.cs
@@ -182,7 +182,7 @@ namespace Microsoft.PowerApps.TestEngine
             catch (CultureNotFoundException)
             {
                 Logger.LogError($"Locale from test suite definition {strLocale} unrecognized.");
-                throw new UserInputException(UserInputException.errorMapping.UserInputExceptionInvalidLocale.ToString());
+                throw new UserInputException(UserInputException.errorMapping.UserInputExceptionInvalidTestSettings.ToString());
             }
         }
     }

--- a/src/Microsoft.PowerApps.TestEngine/TestEngine.cs
+++ b/src/Microsoft.PowerApps.TestEngine/TestEngine.cs
@@ -182,7 +182,7 @@ namespace Microsoft.PowerApps.TestEngine
             catch (CultureNotFoundException)
             {
                 Logger.LogError($"Locale from test suite definition {strLocale} unrecognized.");
-                throw new UserInputException(UserInputException.errorMapping.UserInputExceptionInvalidTestSettings.ToString());
+                throw new UserInputException(UserInputException.ErrorMapping.UserInputExceptionInvalidTestSettings.ToString());
             }
         }
     }

--- a/src/Microsoft.PowerApps.TestEngine/TestEngineEventHandler.cs
+++ b/src/Microsoft.PowerApps.TestEngine/TestEngineEventHandler.cs
@@ -15,6 +15,16 @@ namespace Microsoft.PowerApps.TestEngine
         private int _casesTotal = 0;
         private int _casesPassed = 0;
 
+        // NOTE: Any changes to these messages need to be handled in the consuming tool's console event handler, like in pac cli tool.
+        // These console messages need to be considered for localization.
+        public static string UserInputExceptionInvalidLocaleMessage = "   Invalid locale specified in testconfig. For more details, check the logs.";
+        public static string UserInputExceptionInvalidFilePathMessage = "   Invalid file path. For more details, check the logs.";
+        public static string UserInputExceptionLoginCredentialMessage = "   Invalid login credential(s). For more details, check the logs.";
+        public static string UserInputExceptionTestConfigMessage = "   Invalid test config. For more details, check the logs.";
+        public static string UserInputExceptionYAMLFormatMessage = "   Invalid YAML format. For more details, check the logs.";
+
+        public static string UserAppExceptionMessage = "   [Critical Error] Could not access PowerApps. For more details, check the logs.";
+
         public int CasesPassed { get => _casesPassed; set => _casesPassed = value; }
         public int CasesTotal { get => _casesTotal; set => _casesTotal = value; }
 
@@ -39,17 +49,20 @@ namespace Microsoft.PowerApps.TestEngine
             {
                 switch (ex.Message)
                 {
+                    case nameof(UserInputException.errorMapping.UserInputExceptionInvalidLocale):
+                        Console.WriteLine(UserInputExceptionInvalidLocaleMessage);
+                        break;
                     case nameof(UserInputException.errorMapping.UserInputExceptionInvalidFilePath):
-                        Console.WriteLine($"Invalid file path. For more details, check the logs.");
+                        Console.WriteLine(UserInputExceptionInvalidFilePathMessage);
                         break;
                     case nameof(UserInputException.errorMapping.UserInputExceptionLoginCredential):
-                        Console.WriteLine($"Invalid login credential(s). For more details, check the logs.");
+                        Console.WriteLine(UserInputExceptionLoginCredentialMessage);
                         break;
                     case nameof(UserInputException.errorMapping.UserInputExceptionTestConfig):
-                        Console.WriteLine($"Invalid test config. For more details, check the logs.");
+                        Console.WriteLine(UserInputExceptionTestConfigMessage);
                         break;
                     case nameof(UserInputException.errorMapping.UserInputExceptionYAMLFormat):
-                        Console.WriteLine($"Invalid YAML format. For more details, check the logs.");
+                        Console.WriteLine(UserInputExceptionYAMLFormatMessage);
                         break;
                     default:
                         Console.WriteLine($"   {ex.Message}");
@@ -58,7 +71,7 @@ namespace Microsoft.PowerApps.TestEngine
             }
             else if (ex is UserAppException)
             {
-                Console.WriteLine($"[Critical Error] Could not access PowerApps. For more details, check the logs.");
+                Console.WriteLine(UserAppExceptionMessage);
             }
             else
             {

--- a/src/Microsoft.PowerApps.TestEngine/TestEngineEventHandler.cs
+++ b/src/Microsoft.PowerApps.TestEngine/TestEngineEventHandler.cs
@@ -49,19 +49,19 @@ namespace Microsoft.PowerApps.TestEngine
             {
                 switch (ex.Message)
                 {
-                    case nameof(UserInputException.errorMapping.UserInputExceptionInvalidTestSettings):
+                    case nameof(UserInputException.ErrorMapping.UserInputExceptionInvalidTestSettings):
                         Console.WriteLine(UserInputExceptionInvalidTestSettingsMessage);
                         break;
-                    case nameof(UserInputException.errorMapping.UserInputExceptionInvalidFilePath):
+                    case nameof(UserInputException.ErrorMapping.UserInputExceptionInvalidFilePath):
                         Console.WriteLine(UserInputExceptionInvalidFilePathMessage);
                         break;
-                    case nameof(UserInputException.errorMapping.UserInputExceptionLoginCredential):
+                    case nameof(UserInputException.ErrorMapping.UserInputExceptionLoginCredential):
                         Console.WriteLine(UserInputExceptionLoginCredentialMessage);
                         break;
-                    case nameof(UserInputException.errorMapping.UserInputExceptionTestConfig):
+                    case nameof(UserInputException.ErrorMapping.UserInputExceptionTestConfig):
                         Console.WriteLine(UserInputExceptionTestConfigMessage);
                         break;
-                    case nameof(UserInputException.errorMapping.UserInputExceptionYAMLFormat):
+                    case nameof(UserInputException.ErrorMapping.UserInputExceptionYAMLFormat):
                         Console.WriteLine(UserInputExceptionYAMLFormatMessage);
                         break;
                     default:

--- a/src/Microsoft.PowerApps.TestEngine/TestEngineEventHandler.cs
+++ b/src/Microsoft.PowerApps.TestEngine/TestEngineEventHandler.cs
@@ -17,7 +17,7 @@ namespace Microsoft.PowerApps.TestEngine
 
         // NOTE: Any changes to these messages need to be handled in the consuming tool's console event handler, like in pac cli tool.
         // These console messages need to be considered for localization.
-        public static string UserInputExceptionInvalidLocaleMessage = "   Invalid locale specified in testconfig. For more details, check the logs.";
+        public static string UserInputExceptionInvalidTestSettingsMessage = "   Invalid test settings specified in testconfig. For more details, check the logs.";
         public static string UserInputExceptionInvalidFilePathMessage = "   Invalid file path. For more details, check the logs.";
         public static string UserInputExceptionLoginCredentialMessage = "   Invalid login credential(s). For more details, check the logs.";
         public static string UserInputExceptionTestConfigMessage = "   Invalid test config. For more details, check the logs.";
@@ -49,8 +49,8 @@ namespace Microsoft.PowerApps.TestEngine
             {
                 switch (ex.Message)
                 {
-                    case nameof(UserInputException.errorMapping.UserInputExceptionInvalidLocale):
-                        Console.WriteLine(UserInputExceptionInvalidLocaleMessage);
+                    case nameof(UserInputException.errorMapping.UserInputExceptionInvalidTestSettings):
+                        Console.WriteLine(UserInputExceptionInvalidTestSettingsMessage);
                         break;
                     case nameof(UserInputException.errorMapping.UserInputExceptionInvalidFilePath):
                         Console.WriteLine(UserInputExceptionInvalidFilePathMessage);

--- a/src/Microsoft.PowerApps.TestEngine/TestInfra/PlaywrightTestInfraFunctions.cs
+++ b/src/Microsoft.PowerApps.TestEngine/TestInfra/PlaywrightTestInfraFunctions.cs
@@ -81,7 +81,7 @@ namespace Microsoft.PowerApps.TestEngine.TestInfra
             if (browser == null)
             {
                 _singleTestInstanceState.GetLogger().LogError("Browser not supported by Playwright, for more details check https://playwright.dev/dotnet/docs/browsers");
-                throw new UserInputException(UserInputException.errorMapping.UserInputExceptionInvalidTestSettings.ToString());
+                throw new UserInputException(UserInputException.ErrorMapping.UserInputExceptionInvalidTestSettings.ToString());
             }
 
             Browser = await browser.LaunchAsync(launchOptions);
@@ -366,7 +366,7 @@ namespace Microsoft.PowerApps.TestEngine.TestInfra
                     if (hasPasswordError)
                     {
                         logger.LogError("Incorrect password entered. Make sure you are using the correct credentials.");
-                        throw new UserInputException(UserInputException.errorMapping.UserInputExceptionLoginCredential.ToString());
+                        throw new UserInputException(UserInputException.ErrorMapping.UserInputExceptionLoginCredential.ToString());
                     }
                     // If not, continue
                     else

--- a/src/Microsoft.PowerApps.TestEngine/TestInfra/PlaywrightTestInfraFunctions.cs
+++ b/src/Microsoft.PowerApps.TestEngine/TestInfra/PlaywrightTestInfraFunctions.cs
@@ -19,6 +19,7 @@ namespace Microsoft.PowerApps.TestEngine.TestInfra
         private readonly ISingleTestInstanceState _singleTestInstanceState;
         private readonly IFileSystem _fileSystem;
 
+        public static string BrowserNotSupportedErrorMessage = "Browser not supported by Playwright, for more details check https://playwright.dev/dotnet/docs/browsers";
         private IPlaywright PlaywrightObject { get; set; }
         private IBrowser Browser { get; set; }
         private IBrowserContext BrowserContext { get; set; }
@@ -80,7 +81,7 @@ namespace Microsoft.PowerApps.TestEngine.TestInfra
             if (browser == null)
             {
                 _singleTestInstanceState.GetLogger().LogError("Browser not supported by Playwright, for more details check https://playwright.dev/dotnet/docs/browsers");
-                throw new InvalidOperationException("Browser not supported.");
+                throw new UserInputException(UserInputException.errorMapping.UserInputExceptionInvalidTestSettings.ToString());
             }
 
             Browser = await browser.LaunchAsync(launchOptions);

--- a/src/Microsoft.PowerApps.TestEngine/Users/UserManager.cs
+++ b/src/Microsoft.PowerApps.TestEngine/Users/UserManager.cs
@@ -90,7 +90,7 @@ namespace Microsoft.PowerApps.TestEngine.Users
 
             if (missingUserOrPassword)
             {
-                throw new UserInputException(UserInputException.errorMapping.UserInputExceptionLoginCredential.ToString());
+                throw new UserInputException(UserInputException.ErrorMapping.UserInputExceptionLoginCredential.ToString());
             }
 
             await _testInfraFunctions.HandleUserEmailScreen(EmailSelector, user);


### PR DESCRIPTION
Handling invalid user test settings values like locale and browser
<img width="400" alt="image" src="https://github.com/microsoft/PowerApps-TestEngine/assets/98551644/df5f41b8-5dfb-4894-bac5-3f437ed82f2a">
<img width="400" alt="image" src="https://github.com/microsoft/PowerApps-TestEngine/assets/98551644/144d3e91-8bd7-4a6c-8118-140df8759ecd">


**Currently** the exception thrown is not handled properly. This causes consuming application to encounter error.

**Proposing** handling this scenario like any other **user input exception and gracefully**.
## Checklist

- [x] The code change is covered by unit tests. I have added tests that prove my fix is effective or that my feature works
- [x] I have performed end-to-end test locally.
- [x] New and existing unit tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I used clear names for everything
- [x] I have performed a self-review of my own code
