### PR TITLE
Handle Invalid Output Directory

### DIFF
--- a/src/Microsoft.PowerApps.TestEngine.Tests/ConsoleOutputTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/ConsoleOutputTests.cs
@@ -204,6 +204,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
             public UserInputExceptionDataGenerator()
             {
                 Add(nameof(UserInputException.ErrorMapping.UserInputExceptionInvalidTestSettings), TestEngineEventHandler.UserInputExceptionInvalidTestSettingsMessage);
+                Add(nameof(UserInputException.ErrorMapping.UserInputExceptionInvalidOutputPath), TestEngineEventHandler.UserInputExceptionInvalidOutputPathMessage);
                 Add(nameof(UserInputException.ErrorMapping.UserInputExceptionInvalidFilePath), TestEngineEventHandler.UserInputExceptionInvalidFilePathMessage);
                 Add(nameof(UserInputException.ErrorMapping.UserInputExceptionLoginCredential), TestEngineEventHandler.UserInputExceptionLoginCredentialMessage);
                 Add(nameof(UserInputException.ErrorMapping.UserInputExceptionTestConfig), TestEngineEventHandler.UserInputExceptionTestConfigMessage);

--- a/src/Microsoft.PowerApps.TestEngine.Tests/ConsoleOutputTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/ConsoleOutputTests.cs
@@ -204,7 +204,6 @@ namespace Microsoft.PowerApps.TestEngine.Tests
             public UserInputExceptionDataGenerator()
             {
                 Add(nameof(UserInputException.ErrorMapping.UserInputExceptionInvalidTestSettings), TestEngineEventHandler.UserInputExceptionInvalidTestSettingsMessage);
-                Add(nameof(UserInputException.ErrorMapping.UserInputExceptionInvalidOutputPath), TestEngineEventHandler.UserInputExceptionInvalidOutputPathMessage);
                 Add(nameof(UserInputException.ErrorMapping.UserInputExceptionInvalidFilePath), TestEngineEventHandler.UserInputExceptionInvalidFilePathMessage);
                 Add(nameof(UserInputException.ErrorMapping.UserInputExceptionLoginCredential), TestEngineEventHandler.UserInputExceptionLoginCredentialMessage);
                 Add(nameof(UserInputException.ErrorMapping.UserInputExceptionTestConfig), TestEngineEventHandler.UserInputExceptionTestConfigMessage);

--- a/src/Microsoft.PowerApps.TestEngine.Tests/TestEngineTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/TestEngineTests.cs
@@ -79,7 +79,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
             var testConfigFile = new FileInfo("C:\\testPlan.fx.yaml");
             var environmentId = "defaultEnviroment";
             var tenantId = new Guid("a01af035-a529-4aaf-aded-011ad676f976");
-            var outputDirectory = new DirectoryInfo(".");
+            var outputDirectory = new DirectoryInfo("TestOutput");
             var testRunId = Guid.NewGuid().ToString();
             var expectedOutputDirectory = outputDirectory.FullName;
             var testRunDirectory = Path.Combine(expectedOutputDirectory, testRunId.Substring(0, 6));
@@ -115,7 +115,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
             var testConfigFile = new FileInfo("C:\\testPlan.fx.yaml");
             var environmentId = "defaultEnviroment";
             var tenantId = new Guid("a01af035-a529-4aaf-aded-011ad676f976");
-            var outputDirectory = new DirectoryInfo(".");
+            var outputDirectory = new DirectoryInfo("TestOutput");
             var testRunId = Guid.NewGuid().ToString();
             var expectedOutputDirectory = outputDirectory.FullName;
             var testRunDirectory = Path.Combine(expectedOutputDirectory, testRunId.Substring(0, 6));
@@ -153,7 +153,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
             var testConfigFile = new FileInfo("C:\\testPlan.fx.yaml");
             var environmentId = "defaultEnviroment";
             var tenantId = new Guid("a01af035-a529-4aaf-aded-011ad676f976");
-            var outputDirectory = new DirectoryInfo(".");
+            var outputDirectory = new DirectoryInfo("TestOutput");
             var testRunId = Guid.NewGuid().ToString();
             var expectedOutputDirectory = outputDirectory.FullName;
             var testRunDirectory = Path.Combine(expectedOutputDirectory, testRunId.Substring(0, 6));
@@ -194,7 +194,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
             var testConfigFile = new FileInfo("C:\\testPlan.fx.yaml");
             var environmentId = "defaultEnviroment";
             var tenantId = new Guid("a01af035-a529-4aaf-aded-011ad676f976");
-            var outputDirectory = new DirectoryInfo(".");
+            var outputDirectory = new DirectoryInfo("TestOutput");
             var testRunId = Guid.NewGuid().ToString();
             var expectedOutputDirectory = outputDirectory.FullName;
             var testRunDirectory = Path.Combine(expectedOutputDirectory, testRunId.Substring(0, 6));
@@ -244,7 +244,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
             var expectedOutputDirectory = outputDirectory;
             if (expectedOutputDirectory == null)
             {
-                expectedOutputDirectory = new DirectoryInfo(".");
+                expectedOutputDirectory = new DirectoryInfo("TestOutput");
             }
             var testRunDirectory = Path.Combine(expectedOutputDirectory.FullName, testRunId.Substring(0, 6));
 
@@ -341,7 +341,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
             {
                 testConfigFile = new FileInfo(testConfigFilePath);
             }
-            var outputDirectory = new DirectoryInfo(".");
+            var outputDirectory = new DirectoryInfo("TestOutput");
             await Assert.ThrowsAsync<ArgumentNullException>(async () => await testEngine.RunTestAsync(testConfigFile, environmentId, tenantId, outputDirectory, domain, ""));
         }
 
@@ -367,7 +367,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
             MockTestEngineEventHandler.Setup(x => x.EncounteredException(It.IsAny<Exception>()));
 
             var testEngine = new TestEngine(MockState.Object, ServiceProvider, MockTestReporter.Object, MockFileSystem.Object, MockLoggerFactory.Object, MockTestEngineEventHandler.Object);
-            var outputDirectory = new DirectoryInfo(".");
+            var outputDirectory = new DirectoryInfo("TestOutput");
 
             var testResultsDirectory = await testEngine.RunTestAsync(testConfigFile, environmentId, tenantId, outputDirectory, domain, "");
             // UserInput Exception is handled within TestEngineEventHandler, and then returns the test results directory path
@@ -415,7 +415,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
             public TestDataGenerator()
             {
                 // Simple test
-                Add(new DirectoryInfo("."),
+                Add(new DirectoryInfo("TestOutput"),
                     "GCC",
                     new TestSettings()
                     {
@@ -446,7 +446,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
                     });
 
                 // Simple test with null params
-                Add(new DirectoryInfo("."),
+                Add(new DirectoryInfo("TestOutput"),
                     null,
                     new TestSettings()
                     {
@@ -477,7 +477,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
                     });
 
                 // Simple test with empty string params
-                Add(new DirectoryInfo("."),
+                Add(new DirectoryInfo("TestOutput"),
                     "",
                     new TestSettings()
                     {
@@ -510,7 +510,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
                 // Simple test in en-US locale (this should be like every other test)
                 // For the rest of the tests where Locale = string.Empty, CurrentCulture should be used
                 // and the test should pass
-                Add(new DirectoryInfo("."),
+                Add(new DirectoryInfo("TestOutput"),
                     "GCC",
                     new TestSettings()
                     {
@@ -541,7 +541,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
                     });
 
                 // Simple test in a different locale
-                Add(new DirectoryInfo("."),
+                Add(new DirectoryInfo("TestOutput"),
                     "GCC",
                     new TestSettings()
                     {
@@ -572,7 +572,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
                     });
 
                 // Multiple browsers
-                Add(new DirectoryInfo("."),
+                Add(new DirectoryInfo("TestOutput"),
                     "Prod",
                     new TestSettings()
                     {
@@ -612,7 +612,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
                     });
 
                 // Multiple tests
-                Add(new DirectoryInfo("."),
+                Add(new DirectoryInfo("TestOutput"),
                     "Prod",
                     new TestSettings()
                     {
@@ -649,7 +649,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
                     });
 
                 // Multiple tests and browsers
-                Add(new DirectoryInfo("."),
+                Add(new DirectoryInfo("TestOutput"),
                     "Prod",
                     new TestSettings()
                     {

--- a/src/Microsoft.PowerApps.TestEngine.Tests/TestEngineTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/TestEngineTests.cs
@@ -79,7 +79,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
             var testConfigFile = new FileInfo("C:\\testPlan.fx.yaml");
             var environmentId = "defaultEnviroment";
             var tenantId = new Guid("a01af035-a529-4aaf-aded-011ad676f976");
-            var outputDirectory = new DirectoryInfo("TestOutput");
+            var outputDirectory = new DirectoryInfo(".\\");
             var testRunId = Guid.NewGuid().ToString();
             var expectedOutputDirectory = outputDirectory.FullName;
             var testRunDirectory = Path.Combine(expectedOutputDirectory, testRunId.Substring(0, 6));
@@ -115,7 +115,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
             var testConfigFile = new FileInfo("C:\\testPlan.fx.yaml");
             var environmentId = "defaultEnviroment";
             var tenantId = new Guid("a01af035-a529-4aaf-aded-011ad676f976");
-            var outputDirectory = new DirectoryInfo("TestOutput");
+            var outputDirectory = new DirectoryInfo(".\\");
             var testRunId = Guid.NewGuid().ToString();
             var expectedOutputDirectory = outputDirectory.FullName;
             var testRunDirectory = Path.Combine(expectedOutputDirectory, testRunId.Substring(0, 6));
@@ -153,7 +153,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
             var testConfigFile = new FileInfo("C:\\testPlan.fx.yaml");
             var environmentId = "defaultEnviroment";
             var tenantId = new Guid("a01af035-a529-4aaf-aded-011ad676f976");
-            var outputDirectory = new DirectoryInfo("TestOutput");
+            var outputDirectory = new DirectoryInfo(".\\");
             var testRunId = Guid.NewGuid().ToString();
             var expectedOutputDirectory = outputDirectory.FullName;
             var testRunDirectory = Path.Combine(expectedOutputDirectory, testRunId.Substring(0, 6));
@@ -194,7 +194,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
             var testConfigFile = new FileInfo("C:\\testPlan.fx.yaml");
             var environmentId = "defaultEnviroment";
             var tenantId = new Guid("a01af035-a529-4aaf-aded-011ad676f976");
-            var outputDirectory = new DirectoryInfo("TestOutput");
+            var outputDirectory = new DirectoryInfo(".\\");
             var testRunId = Guid.NewGuid().ToString();
             var expectedOutputDirectory = outputDirectory.FullName;
             var testRunDirectory = Path.Combine(expectedOutputDirectory, testRunId.Substring(0, 6));
@@ -244,7 +244,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
             var expectedOutputDirectory = outputDirectory;
             if (expectedOutputDirectory == null)
             {
-                expectedOutputDirectory = new DirectoryInfo("TestOutput");
+                expectedOutputDirectory = new DirectoryInfo(".\\");
             }
             var testRunDirectory = Path.Combine(expectedOutputDirectory.FullName, testRunId.Substring(0, 6));
 
@@ -341,7 +341,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
             {
                 testConfigFile = new FileInfo(testConfigFilePath);
             }
-            var outputDirectory = new DirectoryInfo("TestOutput");
+            var outputDirectory = new DirectoryInfo(".\\");
             await Assert.ThrowsAsync<ArgumentNullException>(async () => await testEngine.RunTestAsync(testConfigFile, environmentId, tenantId, outputDirectory, domain, ""));
         }
 
@@ -367,7 +367,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
             MockTestEngineEventHandler.Setup(x => x.EncounteredException(It.IsAny<Exception>()));
 
             var testEngine = new TestEngine(MockState.Object, ServiceProvider, MockTestReporter.Object, MockFileSystem.Object, MockLoggerFactory.Object, MockTestEngineEventHandler.Object);
-            var outputDirectory = new DirectoryInfo("TestOutput");
+            var outputDirectory = new DirectoryInfo(".\\");
 
             var testResultsDirectory = await testEngine.RunTestAsync(testConfigFile, environmentId, tenantId, outputDirectory, domain, "");
             // UserInput Exception is handled within TestEngineEventHandler, and then returns the test results directory path
@@ -415,7 +415,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
             public TestDataGenerator()
             {
                 // Simple test
-                Add(new DirectoryInfo("C:\\testResults"),
+                Add(new DirectoryInfo(".\\"),
                     "GCC",
                     new TestSettings()
                     {
@@ -446,7 +446,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
                     });
 
                 // Simple test with null params
-                Add(new DirectoryInfo("TestOutput"),
+                Add(new DirectoryInfo(".\\"),
                     null,
                     new TestSettings()
                     {
@@ -477,7 +477,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
                     });
 
                 // Simple test with empty string params
-                Add(new DirectoryInfo("TestOutput"),
+                Add(new DirectoryInfo(".\\"),
                     "",
                     new TestSettings()
                     {
@@ -510,7 +510,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
                 // Simple test in en-US locale (this should be like every other test)
                 // For the rest of the tests where Locale = string.Empty, CurrentCulture should be used
                 // and the test should pass
-                Add(new DirectoryInfo("C:\\testResults"),
+                Add(new DirectoryInfo(".\\"),
                     "GCC",
                     new TestSettings()
                     {
@@ -541,7 +541,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
                     });
 
                 // Simple test in a different locale
-                Add(new DirectoryInfo("C:\\testResults"),
+                Add(new DirectoryInfo(".\\"),
                     "GCC",
                     new TestSettings()
                     {
@@ -572,7 +572,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
                     });
 
                 // Multiple browsers
-                Add(new DirectoryInfo("C:\\testResults"),
+                Add(new DirectoryInfo(".\\"),
                     "Prod",
                     new TestSettings()
                     {
@@ -612,7 +612,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
                     });
 
                 // Multiple tests
-                Add(new DirectoryInfo("C:\\testResults"),
+                Add(new DirectoryInfo(".\\"),
                     "Prod",
                     new TestSettings()
                     {
@@ -649,7 +649,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
                     });
 
                 // Multiple tests and browsers
-                Add(new DirectoryInfo("C:\\testResults"),
+                Add(new DirectoryInfo(".\\"),
                     "Prod",
                     new TestSettings()
                     {

--- a/src/Microsoft.PowerApps.TestEngine.Tests/TestEngineTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/TestEngineTests.cs
@@ -415,7 +415,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
             public TestDataGenerator()
             {
                 // Simple test
-                Add(new DirectoryInfo("TestOutput"),
+                Add(new DirectoryInfo("C:\\testResults"),
                     "GCC",
                     new TestSettings()
                     {
@@ -510,7 +510,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
                 // Simple test in en-US locale (this should be like every other test)
                 // For the rest of the tests where Locale = string.Empty, CurrentCulture should be used
                 // and the test should pass
-                Add(new DirectoryInfo("TestOutput"),
+                Add(new DirectoryInfo("C:\\testResults"),
                     "GCC",
                     new TestSettings()
                     {
@@ -541,7 +541,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
                     });
 
                 // Simple test in a different locale
-                Add(new DirectoryInfo("TestOutput"),
+                Add(new DirectoryInfo("C:\\testResults"),
                     "GCC",
                     new TestSettings()
                     {
@@ -572,7 +572,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
                     });
 
                 // Multiple browsers
-                Add(new DirectoryInfo("TestOutput"),
+                Add(new DirectoryInfo("C:\\testResults"),
                     "Prod",
                     new TestSettings()
                     {
@@ -612,7 +612,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
                     });
 
                 // Multiple tests
-                Add(new DirectoryInfo("TestOutput"),
+                Add(new DirectoryInfo("C:\\testResults"),
                     "Prod",
                     new TestSettings()
                     {
@@ -649,7 +649,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
                     });
 
                 // Multiple tests and browsers
-                Add(new DirectoryInfo("TestOutput"),
+                Add(new DirectoryInfo("C:\\testResults"),
                     "Prod",
                     new TestSettings()
                     {

--- a/src/Microsoft.PowerApps.TestEngine.Tests/TestEngineTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/TestEngineTests.cs
@@ -79,7 +79,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
             var testConfigFile = new FileInfo("C:\\testPlan.fx.yaml");
             var environmentId = "defaultEnviroment";
             var tenantId = new Guid("a01af035-a529-4aaf-aded-011ad676f976");
-            var outputDirectory = new DirectoryInfo(".\\");
+            var outputDirectory = new DirectoryInfo(".");
             var testRunId = Guid.NewGuid().ToString();
             var expectedOutputDirectory = outputDirectory.FullName;
             var testRunDirectory = Path.Combine(expectedOutputDirectory, testRunId.Substring(0, 6));
@@ -115,7 +115,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
             var testConfigFile = new FileInfo("C:\\testPlan.fx.yaml");
             var environmentId = "defaultEnviroment";
             var tenantId = new Guid("a01af035-a529-4aaf-aded-011ad676f976");
-            var outputDirectory = new DirectoryInfo(".\\");
+            var outputDirectory = new DirectoryInfo(".");
             var testRunId = Guid.NewGuid().ToString();
             var expectedOutputDirectory = outputDirectory.FullName;
             var testRunDirectory = Path.Combine(expectedOutputDirectory, testRunId.Substring(0, 6));
@@ -153,7 +153,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
             var testConfigFile = new FileInfo("C:\\testPlan.fx.yaml");
             var environmentId = "defaultEnviroment";
             var tenantId = new Guid("a01af035-a529-4aaf-aded-011ad676f976");
-            var outputDirectory = new DirectoryInfo(".\\");
+            var outputDirectory = new DirectoryInfo(".");
             var testRunId = Guid.NewGuid().ToString();
             var expectedOutputDirectory = outputDirectory.FullName;
             var testRunDirectory = Path.Combine(expectedOutputDirectory, testRunId.Substring(0, 6));
@@ -194,7 +194,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
             var testConfigFile = new FileInfo("C:\\testPlan.fx.yaml");
             var environmentId = "defaultEnviroment";
             var tenantId = new Guid("a01af035-a529-4aaf-aded-011ad676f976");
-            var outputDirectory = new DirectoryInfo(".\\");
+            var outputDirectory = new DirectoryInfo(".");
             var testRunId = Guid.NewGuid().ToString();
             var expectedOutputDirectory = outputDirectory.FullName;
             var testRunDirectory = Path.Combine(expectedOutputDirectory, testRunId.Substring(0, 6));
@@ -244,7 +244,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
             var expectedOutputDirectory = outputDirectory;
             if (expectedOutputDirectory == null)
             {
-                expectedOutputDirectory = new DirectoryInfo(".\\");
+                expectedOutputDirectory = new DirectoryInfo(".");
             }
             var testRunDirectory = Path.Combine(expectedOutputDirectory.FullName, testRunId.Substring(0, 6));
 
@@ -341,7 +341,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
             {
                 testConfigFile = new FileInfo(testConfigFilePath);
             }
-            var outputDirectory = new DirectoryInfo(".\\");
+            var outputDirectory = new DirectoryInfo(".");
             await Assert.ThrowsAsync<ArgumentNullException>(async () => await testEngine.RunTestAsync(testConfigFile, environmentId, tenantId, outputDirectory, domain, ""));
         }
 
@@ -367,7 +367,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
             MockTestEngineEventHandler.Setup(x => x.EncounteredException(It.IsAny<Exception>()));
 
             var testEngine = new TestEngine(MockState.Object, ServiceProvider, MockTestReporter.Object, MockFileSystem.Object, MockLoggerFactory.Object, MockTestEngineEventHandler.Object);
-            var outputDirectory = new DirectoryInfo(".\\");
+            var outputDirectory = new DirectoryInfo(".");
 
             var testResultsDirectory = await testEngine.RunTestAsync(testConfigFile, environmentId, tenantId, outputDirectory, domain, "");
             // UserInput Exception is handled within TestEngineEventHandler, and then returns the test results directory path
@@ -415,7 +415,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
             public TestDataGenerator()
             {
                 // Simple test
-                Add(new DirectoryInfo(".\\"),
+                Add(new DirectoryInfo("."),
                     "GCC",
                     new TestSettings()
                     {
@@ -446,7 +446,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
                     });
 
                 // Simple test with null params
-                Add(new DirectoryInfo(".\\"),
+                Add(new DirectoryInfo("."),
                     null,
                     new TestSettings()
                     {
@@ -477,7 +477,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
                     });
 
                 // Simple test with empty string params
-                Add(new DirectoryInfo(".\\"),
+                Add(new DirectoryInfo("."),
                     "",
                     new TestSettings()
                     {
@@ -510,7 +510,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
                 // Simple test in en-US locale (this should be like every other test)
                 // For the rest of the tests where Locale = string.Empty, CurrentCulture should be used
                 // and the test should pass
-                Add(new DirectoryInfo(".\\"),
+                Add(new DirectoryInfo("."),
                     "GCC",
                     new TestSettings()
                     {
@@ -541,7 +541,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
                     });
 
                 // Simple test in a different locale
-                Add(new DirectoryInfo(".\\"),
+                Add(new DirectoryInfo("."),
                     "GCC",
                     new TestSettings()
                     {
@@ -572,7 +572,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
                     });
 
                 // Multiple browsers
-                Add(new DirectoryInfo(".\\"),
+                Add(new DirectoryInfo("."),
                     "Prod",
                     new TestSettings()
                     {
@@ -612,7 +612,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
                     });
 
                 // Multiple tests
-                Add(new DirectoryInfo(".\\"),
+                Add(new DirectoryInfo("."),
                     "Prod",
                     new TestSettings()
                     {
@@ -649,7 +649,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
                     });
 
                 // Multiple tests and browsers
-                Add(new DirectoryInfo(".\\"),
+                Add(new DirectoryInfo("."),
                     "Prod",
                     new TestSettings()
                     {

--- a/src/Microsoft.PowerApps.TestEngine/System/UserInputException.cs
+++ b/src/Microsoft.PowerApps.TestEngine/System/UserInputException.cs
@@ -10,6 +10,7 @@ namespace Microsoft.PowerApps.TestEngine.System
         public enum ErrorMapping
         {
             UserInputExceptionInvalidFilePath,
+            UserInputExceptionInvalidOutputPath,
             UserInputExceptionInvalidTestSettings,
             UserInputExceptionLoginCredential,
             UserInputExceptionTestConfig,

--- a/src/Microsoft.PowerApps.TestEngine/System/UserInputException.cs
+++ b/src/Microsoft.PowerApps.TestEngine/System/UserInputException.cs
@@ -10,7 +10,6 @@ namespace Microsoft.PowerApps.TestEngine.System
         public enum ErrorMapping
         {
             UserInputExceptionInvalidFilePath,
-            UserInputExceptionInvalidOutputPath,
             UserInputExceptionInvalidTestSettings,
             UserInputExceptionLoginCredential,
             UserInputExceptionTestConfig,

--- a/src/Microsoft.PowerApps.TestEngine/TestEngine.cs
+++ b/src/Microsoft.PowerApps.TestEngine/TestEngine.cs
@@ -92,6 +92,11 @@ namespace Microsoft.PowerApps.TestEngine
                     throw new ArgumentNullException(nameof(domain));
                 }
 
+                if (!Directory.Exists(outputDirectory.FullName))
+                {
+                    throw new UserInputException(UserInputException.ErrorMapping.UserInputExceptionInvalidOutputPath.ToString());
+                }
+
                 if (string.IsNullOrEmpty(queryParams))
                 {
                     Logger.LogDebug($"Using no additional query parameters.");
@@ -104,6 +109,8 @@ namespace Microsoft.PowerApps.TestEngine
                 // Create the output directory as early as possible so that any exceptions can be logged.
                 _state.SetOutputDirectory(outputDirectory.FullName);
                 Logger.LogDebug($"Using output directory: {outputDirectory.FullName}");
+
+
 
                 testRunDirectory = Path.Combine(_state.GetOutputDirectory(), testRunId.Substring(0, 6));
                 _fileSystem.CreateDirectory(testRunDirectory);

--- a/src/Microsoft.PowerApps.TestEngine/TestEngine.cs
+++ b/src/Microsoft.PowerApps.TestEngine/TestEngine.cs
@@ -129,6 +129,7 @@ namespace Microsoft.PowerApps.TestEngine
             {
                 if (e.Message.Contains("Could not find a part of the path"))
                 {
+                    _eventHandler.EncounteredException(new UserInputException(UserInputException.ErrorMapping.UserInputExceptionInvalidOutputPath.ToString()));
                     return "InvalidOutputDirectory";
                 }
                 Logger.LogError(e.Message);

--- a/src/Microsoft.PowerApps.TestEngine/TestEngine.cs
+++ b/src/Microsoft.PowerApps.TestEngine/TestEngine.cs
@@ -125,13 +125,13 @@ namespace Microsoft.PowerApps.TestEngine
                 _eventHandler.EncounteredException(e);
                 return testRunDirectory;
             }
+            catch (DirectoryNotFoundException)
+            {
+                _eventHandler.EncounteredException(new UserInputException(UserInputException.ErrorMapping.UserInputExceptionInvalidOutputPath.ToString()));
+                return "InvalidOutputDirectory";
+            }
             catch (Exception e)
             {
-                if (e.Message.Contains("Could not find a part of the path"))
-                {
-                    _eventHandler.EncounteredException(new UserInputException(UserInputException.ErrorMapping.UserInputExceptionInvalidOutputPath.ToString()));
-                    return "InvalidOutputDirectory";
-                }
                 Logger.LogError(e.Message);
                 throw;
             }

--- a/src/Microsoft.PowerApps.TestEngine/TestEngine.cs
+++ b/src/Microsoft.PowerApps.TestEngine/TestEngine.cs
@@ -92,11 +92,6 @@ namespace Microsoft.PowerApps.TestEngine
                     throw new ArgumentNullException(nameof(domain));
                 }
 
-                if (!Directory.Exists(outputDirectory.FullName))
-                {
-                    throw new UserInputException(UserInputException.ErrorMapping.UserInputExceptionInvalidOutputPath.ToString());
-                }
-
                 if (string.IsNullOrEmpty(queryParams))
                 {
                     Logger.LogDebug($"Using no additional query parameters.");
@@ -109,8 +104,6 @@ namespace Microsoft.PowerApps.TestEngine
                 // Create the output directory as early as possible so that any exceptions can be logged.
                 _state.SetOutputDirectory(outputDirectory.FullName);
                 Logger.LogDebug($"Using output directory: {outputDirectory.FullName}");
-
-
 
                 testRunDirectory = Path.Combine(_state.GetOutputDirectory(), testRunId.Substring(0, 6));
                 _fileSystem.CreateDirectory(testRunDirectory);
@@ -134,6 +127,10 @@ namespace Microsoft.PowerApps.TestEngine
             }
             catch (Exception e)
             {
+                if (e.Message.Contains("Could not find a part of the path"))
+                {
+                    return "InvalidOutputDirectory";
+                }
                 Logger.LogError(e.Message);
                 throw;
             }

--- a/src/Microsoft.PowerApps.TestEngine/TestEngineEventHandler.cs
+++ b/src/Microsoft.PowerApps.TestEngine/TestEngineEventHandler.cs
@@ -17,13 +17,13 @@ namespace Microsoft.PowerApps.TestEngine
 
         // NOTE: Any changes to these messages need to be handled in the consuming tool's console event handler, like in pac cli tool.
         // These console messages need to be considered for localization.
-        public static string UserInputExceptionInvalidTestSettingsMessage = "   Invalid test settings specified in testconfig. For more details, check the logs.";
+        public static string UserAppExceptionMessage = "   [Critical Error] Could not access PowerApps. For more details, check the logs.";
         public static string UserInputExceptionInvalidFilePathMessage = "   Invalid file path. For more details, check the logs.";
+        public static string UserInputExceptionInvalidOutputPathMessage = "Invalid output directory; does not exist. For more details, check the logs.";
+        public static string UserInputExceptionInvalidTestSettingsMessage = "   Invalid test settings specified in testconfig. For more details, check the logs.";
         public static string UserInputExceptionLoginCredentialMessage = "   Invalid login credential(s). For more details, check the logs.";
         public static string UserInputExceptionTestConfigMessage = "   Invalid test config. For more details, check the logs.";
         public static string UserInputExceptionYAMLFormatMessage = "   Invalid YAML format. For more details, check the logs.";
-        public static string UserAppExceptionMessage = "   [Critical Error] Could not access PowerApps. For more details, check the logs.";
-        public static string UserInputExceptionInvalidOutputPathMessage = "Invalid output directory; does not exist. For more details, check the logs.";
 
         public int CasesPassed { get => _casesPassed; set => _casesPassed = value; }
         public int CasesTotal { get => _casesTotal; set => _casesTotal = value; }

--- a/src/Microsoft.PowerApps.TestEngine/TestEngineEventHandler.cs
+++ b/src/Microsoft.PowerApps.TestEngine/TestEngineEventHandler.cs
@@ -22,8 +22,8 @@ namespace Microsoft.PowerApps.TestEngine
         public static string UserInputExceptionLoginCredentialMessage = "   Invalid login credential(s). For more details, check the logs.";
         public static string UserInputExceptionTestConfigMessage = "   Invalid test config. For more details, check the logs.";
         public static string UserInputExceptionYAMLFormatMessage = "   Invalid YAML format. For more details, check the logs.";
-
         public static string UserAppExceptionMessage = "   [Critical Error] Could not access PowerApps. For more details, check the logs.";
+        public static string UserInputExceptionInvalidOutputPathMessage = "Invalid output directory; does not exist. For more details, check the logs.";
 
         public int CasesPassed { get => _casesPassed; set => _casesPassed = value; }
         public int CasesTotal { get => _casesTotal; set => _casesTotal = value; }
@@ -63,6 +63,9 @@ namespace Microsoft.PowerApps.TestEngine
                         break;
                     case nameof(UserInputException.ErrorMapping.UserInputExceptionYAMLFormat):
                         Console.WriteLine(UserInputExceptionYAMLFormatMessage);
+                        break;
+                    case nameof(UserInputException.ErrorMapping.UserInputExceptionInvalidOutputPath):
+                        Console.WriteLine(UserInputExceptionInvalidOutputPathMessage);
                         break;
                     default:
                         Console.WriteLine($"   {ex.Message}");

--- a/src/Microsoft.PowerApps.TestEngine/TestEngineEventHandler.cs
+++ b/src/Microsoft.PowerApps.TestEngine/TestEngineEventHandler.cs
@@ -19,7 +19,6 @@ namespace Microsoft.PowerApps.TestEngine
         // These console messages need to be considered for localization.
         public static string UserAppExceptionMessage = "   [Critical Error] Could not access PowerApps. For more details, check the logs.";
         public static string UserInputExceptionInvalidFilePathMessage = "   Invalid file path. For more details, check the logs.";
-        public static string UserInputExceptionInvalidOutputPathMessage = "Invalid output directory; does not exist. For more details, check the logs.";
         public static string UserInputExceptionInvalidTestSettingsMessage = "   Invalid test settings specified in testconfig. For more details, check the logs.";
         public static string UserInputExceptionLoginCredentialMessage = "   Invalid login credential(s). For more details, check the logs.";
         public static string UserInputExceptionTestConfigMessage = "   Invalid test config. For more details, check the logs.";
@@ -63,9 +62,6 @@ namespace Microsoft.PowerApps.TestEngine
                         break;
                     case nameof(UserInputException.ErrorMapping.UserInputExceptionYAMLFormat):
                         Console.WriteLine(UserInputExceptionYAMLFormatMessage);
-                        break;
-                    case nameof(UserInputException.ErrorMapping.UserInputExceptionInvalidOutputPath):
-                        Console.WriteLine(UserInputExceptionInvalidOutputPathMessage);
                         break;
                     default:
                         Console.WriteLine($"   {ex.Message}");

--- a/src/Microsoft.PowerApps.TestEngine/TestEngineEventHandler.cs
+++ b/src/Microsoft.PowerApps.TestEngine/TestEngineEventHandler.cs
@@ -19,6 +19,7 @@ namespace Microsoft.PowerApps.TestEngine
         // These console messages need to be considered for localization.
         public static string UserAppExceptionMessage = "   [Critical Error] Could not access PowerApps. For more details, check the logs.";
         public static string UserInputExceptionInvalidFilePathMessage = "   Invalid file path. For more details, check the logs.";
+        public static string UserInputExceptionInvalidOutputPathMessage = "   [Critical Error]: The output directory provided is invalid.";
         public static string UserInputExceptionInvalidTestSettingsMessage = "   Invalid test settings specified in testconfig. For more details, check the logs.";
         public static string UserInputExceptionLoginCredentialMessage = "   Invalid login credential(s). For more details, check the logs.";
         public static string UserInputExceptionTestConfigMessage = "   Invalid test config. For more details, check the logs.";
@@ -62,6 +63,9 @@ namespace Microsoft.PowerApps.TestEngine
                         break;
                     case nameof(UserInputException.ErrorMapping.UserInputExceptionYAMLFormat):
                         Console.WriteLine(UserInputExceptionYAMLFormatMessage);
+                        break;
+                    case nameof(UserInputException.ErrorMapping.UserInputExceptionInvalidOutputPath):
+                        Console.WriteLine(UserInputExceptionInvalidOutputPathMessage);
                         break;
                     default:
                         Console.WriteLine($"   {ex.Message}");

--- a/src/PowerAppsTestEngine/Program.cs
+++ b/src/PowerAppsTestEngine/Program.cs
@@ -178,7 +178,15 @@ else
 
         //setting defaults for optional parameters outside RunTestAsync
         var testResult = await testEngine.RunTestAsync(testPlanFile, environmentId, tenantId, outputDirectory, domain, queryParams);
-        Console.WriteLine($"Test results can be found here: {testResult}");
+        if (testResult != "InvalidOutputDirectory")
+        {
+            Console.WriteLine($"Test results can be found here: {testResult}");
+        }
+        else
+        {
+            Console.WriteLine($"[Critical Error]: The output directory provided is invalid.");
+        }
+
     }
     catch (Exception ex)
     {

--- a/src/PowerAppsTestEngine/Program.cs
+++ b/src/PowerAppsTestEngine/Program.cs
@@ -182,10 +182,6 @@ else
         {
             Console.WriteLine($"Test results can be found here: {testResult}");
         }
-        else
-        {
-            Console.WriteLine($"[Critical Error]: The output directory provided is invalid.");
-        }
 
     }
     catch (Exception ex)


### PR DESCRIPTION
## Description

If output directory exists but is invalid, such as a drive doesn't exist, handle this properly so this doesn't throw an unknown error up the chain.

## Checklist

- [ ] The code change is covered by unit tests. I have added tests that prove my fix is effective or that my feature works
- [ ] I have performed end-to-end test locally.
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I used clear names for everything
- [ ] I have performed a self-review of my own code
