### PR TITLE
Updating setproperty for date value to set date to utc time

### DIFF
--- a/src/Microsoft.PowerApps.TestEngine.Tests/PowerApps/PowerAppFunctionsTest.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/PowerApps/PowerAppFunctionsTest.cs
@@ -158,7 +158,8 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerApps
             var result = await powerAppFunctions.SetPropertyAsync(itemPath, DateValue.NewDateOnly(dt.Date));
 
             Assert.True(result);
-            MockTestInfraFunctions.Verify(x => x.RunJavascriptAsync<bool>($"PowerAppsTestEngine.setPropertyValue({itemPathString},{{\"SelectedDate\":Date.parse(\"{((DateValue)DateValue.NewDateOnly(dt.Date)).GetConvertedValue(null)}\")}})"), Times.Once());
+            var dateTimeValue = convertDateToDateTimeUTC(dt);
+            MockTestInfraFunctions.Verify(x => x.RunJavascriptAsync<bool>($"PowerAppsTestEngine.setPropertyValue({itemPathString},{{\"SelectedDate\":Date.parse(\"{dateTimeValue}\")}})"), Times.Once());
         }
 
         [Fact]
@@ -823,7 +824,8 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerApps
             var powerAppFunctions = new PowerAppFunctions(MockTestInfraFunctions.Object, MockSingleTestInstanceState.Object, MockTestState.Object);
             await Assert.ThrowsAsync<Exception>(async () => { await powerAppFunctions.SetPropertyDateAsync(itemPath, DateValue.NewDateOnly(dt.Date)); });
 
-            MockTestInfraFunctions.Verify(x => x.RunJavascriptAsync<bool>($"PowerAppsTestEngine.setPropertyValue({itemPathString},{{\"SelectedDate\":Date.parse(\"{((DateValue)DateValue.NewDateOnly(dt.Date)).GetConvertedValue(null)}\")}})"), Times.Once());
+            var dateTimeValue = convertDateToDateTimeUTC(dt);
+            MockTestInfraFunctions.Verify(x => x.RunJavascriptAsync<bool>($"PowerAppsTestEngine.setPropertyValue({itemPathString},{{\"SelectedDate\":Date.parse(\"{dateTimeValue}\")}})"), Times.Once());
             LoggingTestHelper.VerifyLogging(MockLogger, ExceptionHandlingHelper.PublishedAppWithoutJSSDKMessage, LogLevel.Error, Times.Once());
         }
 
@@ -864,5 +866,9 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerApps
         }
 
         // End Published App JSSDK not found tests
+        private string convertDateToDateTimeUTC(DateTime dt)
+        {
+            return $"{DateValue.NewDateOnly(dt.Date).GetConvertedValue(null).ToString("yyyy-MM-dd")}{PowerAppFunctions.UTCTimeValue}";
+        }
     }
 }

--- a/src/Microsoft.PowerApps.TestEngine/PowerApps/PowerAppFunctions.cs
+++ b/src/Microsoft.PowerApps.TestEngine/PowerApps/PowerAppFunctions.cs
@@ -25,6 +25,7 @@ namespace Microsoft.PowerApps.TestEngine.PowerApps
         public static string PublishedAppIframeName = "fullscreen-app-host";
         public static string CheckPowerAppsTestEngineObject = "typeof PowerAppsTestEngine";
         public static string CheckPowerAppsTestEngineReadyFunction = "typeof PowerAppsTestEngine.testEngineReady";
+        public static string UTCTimeValue = "T00:00:00.000Z";
 
         private string GetItemCountErrorMessage = "Something went wrong when Test Engine tried to get item count.";
         private string GetPropertyValueErrorMessage = "Something went wrong when Test Engine tried to get property value.";
@@ -275,8 +276,13 @@ namespace Microsoft.PowerApps.TestEngine.PowerApps
                 var propertyNameString = JsonConvert.SerializeObject(itemPath.PropertyName);
                 var recordValue = value.GetConvertedValue(null);
 
-                // Date.parse() parses the date to unix timestamp
-                var expression = $"PowerAppsTestEngine.setPropertyValue({itemPathString},{{{propertyNameString}:Date.parse(\"{recordValue}\")}})";
+                // Date.parse() parses the date to unix timestamp.
+                // SetProperty value expected from user is Date(yyyy, MM, dd)
+                // Setting the time value to T00:00.000Z to maintain uniformity across timezones.
+                // This value explicitly specifies the UTC timezone. 
+                // This helps in fetching the date value as it is in any timezone locally without considering one-off in day value.
+                var dt = $"Date.parse(\"{recordValue.Date.ToString("yyyy-MM-dd")}{UTCTimeValue}\")";
+                var expression = $"PowerAppsTestEngine.setPropertyValue({itemPathString},{{{propertyNameString}:{dt}}})";
 
                 return await _testInfraFunctions.RunJavascriptAsync<bool>(expression);
             }


### PR DESCRIPTION
- Currently with the `SetProperty()` function when used to set  Date value no timezone is specified and hence Date.parse() converts the date to unix timestamp for the local time.  
- This could cause **discrepancy** when the value of the DatePicker control is fetched, where in the value is in UTC .  So in first step in a different timezone like IST, if the user sets the date to value lets say Date(2029/11/05). Here in this step the getProperty() will get the value in UTC that is **2029/11/04.** 
Example tests that passes.  
```
 SetProperty(DatePicker1.SelectedDate, Date(2029, 11, 05));
 Assert(DatePicker1.SelectedDate = Date(2029, 11, **04**), "Validate date was changed");
 ```
- To avoid this **discrepancy**, we need to make sure that the `SetProperty()` sets date value in UTC. Hence the datepicker control date vlaue is consistent with the UTC format, the below test runs successful. 
- So now for same user in IST,  this test below passes.
```
 SetProperty(DatePicker1.SelectedDate, Date(2029, 11, 05));
 Assert(DatePicker1.SelectedDate = Date(2029, 11, 05), "Validate date was changed");
 ```
- The changes here assures if the user  `setProperty()` to set date value for datepicker and tries to `Assert` the value, then it is consistent, since its always saved in the UTC format.

## Checklist

- [ ] The code change is covered by unit tests. I have added tests that prove my fix is effective or that my feature works
- [ ] I have performed end-to-end test locally.
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I used clear names for everything
- [ ] I have performed a self-review of my own code
