### PR TITLE
Update PowerFx to 1.1

### DIFF
--- a/src/Microsoft.PowerApps.TestEngine.Tests/PowerApps/PowerAppFunctionsTest.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/PowerApps/PowerAppFunctionsTest.cs
@@ -122,7 +122,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerApps
             var powerAppFunctions = new PowerAppFunctions(MockTestInfraFunctions.Object, MockSingleTestInstanceState.Object, MockTestState.Object);
             string itemPathString = "{\"controlName\":\"Rating1\",\"index\":null,\"parentControl\":null,\"propertyName\":\"Value\"}";
             var itemPath = JsonConvert.DeserializeObject<ItemPath>(itemPathString);
-            var value = 5;
+            var value = 5d;
             var numberValue = NumberValue.New(value);
             var jsonSerializedValue = JsonConvert.SerializeObject(numberValue.Value);
             var result = await powerAppFunctions.SetPropertyAsync(itemPath, numberValue);

--- a/src/Microsoft.PowerApps.TestEngine.Tests/PowerFx/Functions/SetPropertyFunctionTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/PowerFx/Functions/SetPropertyFunctionTests.cs
@@ -102,7 +102,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx.Functions
             var setPropertyFunction = new SetPropertyFunction(MockPowerAppFunctions.Object, MockLogger.Object);
 
             // Set the value of Rating1's 'Value' property to 5
-            var result = setPropertyFunction.Execute(recordValue, StringValue.New("Value"), NumberValue.New(5));
+            var result = setPropertyFunction.Execute(recordValue, StringValue.New("Value"), NumberValue.New(5d));
 
             // check to see if the value of Rating1's 'Value' property is 5
             Assert.IsType<BooleanValue>(result);

--- a/src/Microsoft.PowerApps.TestEngine.Tests/PowerFx/Functions/SomeOtherUntypedObject.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/PowerFx/Functions/SomeOtherUntypedObject.cs
@@ -1,12 +1,20 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+
+using System.Collections.Generic;
 using Microsoft.PowerFx.Types;
+using NotImplementedException = System.NotImplementedException;
 
 namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx.Functions
 {
     public class SomeOtherUntypedObject : IUntypedObject
     {
         public IUntypedObject this[int index] => throw new global::System.NotImplementedException();
+
+        public bool TryGetPropertyNames(out IEnumerable<string> propertyNames)
+        {
+            throw new NotImplementedException();
+        }
 
         public FormulaType Type
         {

--- a/src/Microsoft.PowerApps.TestEngine.Tests/PowerFx/Functions/SomeOtherUntypedObject.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/PowerFx/Functions/SomeOtherUntypedObject.cs
@@ -1,9 +1,9 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-using System.Collections.Generic;
 using Microsoft.PowerFx.Types;
 using NotImplementedException = System.NotImplementedException;
+using System.Collections.Generic;
 
 namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx.Functions
 {

--- a/src/Microsoft.PowerApps.TestEngine.Tests/PowerFx/Functions/WaitFunctionTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/PowerFx/Functions/WaitFunctionTests.cs
@@ -53,10 +53,10 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx.Functions
             var recordType = RecordType.Empty().Add("Text", FormulaType.Number);
             var waitFunction = new WaitFunctionNumber(Timeout, MockLogger.Object);
             var recordValue = new ControlRecordValue(recordType, MockPowerAppFunctions.Object, "Label1");
-            Assert.Throws<ArgumentNullException>(() => waitFunction.Execute(null, FormulaValue.New("Text"), FormulaValue.New(1)));
-            Assert.Throws<ArgumentNullException>(() => waitFunction.Execute(new SomeOtherRecordValue(recordType), null, FormulaValue.New(1)));
+            Assert.Throws<ArgumentNullException>(() => waitFunction.Execute(null, FormulaValue.New("Text"), FormulaValue.New(1d)));
+            Assert.Throws<ArgumentNullException>(() => waitFunction.Execute(new SomeOtherRecordValue(recordType), null, FormulaValue.New(1d)));
             Assert.Throws<ArgumentNullException>(() => waitFunction.Execute(new SomeOtherRecordValue(recordType), FormulaValue.New("Text"), null));
-            Assert.Throws<InvalidCastException>(() => waitFunction.Execute(new SomeOtherRecordValue(recordType), FormulaValue.New("Text"), FormulaValue.New(1)));
+            Assert.Throws<InvalidCastException>(() => waitFunction.Execute(new SomeOtherRecordValue(recordType), FormulaValue.New("Text"), FormulaValue.New(1d)));
         }
 
         [Fact]
@@ -141,13 +141,13 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx.Functions
         public void WaitFunctionNumberSucceedsTest()
         {
             LoggingTestHelper.SetupMock(MockLogger);
-            var valueToWaitFor = 1;
+            var valueToWaitFor = 1d;
             var recordType = RecordType.Empty().Add("Text", FormulaType.Number);
 
             var recordValue = new ControlRecordValue(recordType, MockPowerAppFunctions.Object, "Label1");
             var jsPropertyValueModel = new JSPropertyValueModel()
             {
-                PropertyValue = valueToWaitFor.ToString(),
+                PropertyValue = valueToWaitFor.ToString("G"),
             };
             var expectedItemPath = new ItemPath
             {
@@ -159,7 +159,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx.Functions
             MockTestState.Setup(x => x.GetTimeout()).Returns(Timeout);
 
             var waitFunction = new WaitFunctionNumber(Timeout, MockLogger.Object);
-            waitFunction.Execute(recordValue, FormulaValue.New("Text"), NumberValue.New(valueToWaitFor));
+            waitFunction.Execute(recordValue, FormulaValue.New("Text"), FormulaValue.New(valueToWaitFor));
 
             MockPowerAppFunctions.Verify(x => x.GetPropertyValueFromControl<string>(It.Is<ItemPath>((itemPath) => itemPath.ControlName == expectedItemPath.ControlName && itemPath.PropertyName == expectedItemPath.PropertyName)), Times.Exactly(2));
         }
@@ -185,7 +185,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx.Functions
             MockTestState.Setup(x => x.GetTimeout()).Returns(Timeout);
 
             var waitFunction = new WaitFunctionNumber(Timeout, MockLogger.Object);
-            Assert.Throws<InvalidDataException>(() => waitFunction.Execute(recordValue, FormulaValue.New("Value"), NumberValue.New(1)));
+            Assert.Throws<InvalidDataException>(() => waitFunction.Execute(recordValue, FormulaValue.New("Value"), FormulaValue.New(1d)));
         }
 
         [Fact]
@@ -405,7 +405,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx.Functions
         public void WaitFunctionNumberWaitsForValueToUpdateTest()
         {
             LoggingTestHelper.SetupMock(MockLogger);
-            var valueToWaitFor = 1;
+            var valueToWaitFor = 1d;
             var recordType = RecordType.Empty().Add("Text", FormulaType.Number);
             var recordValue = new ControlRecordValue(recordType, MockPowerAppFunctions.Object, "Label1");
             var jsPropertyValueModel = new JSPropertyValueModel()
@@ -414,7 +414,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx.Functions
             };
             var finalJsPropertyValueModel = new JSPropertyValueModel()
             {
-                PropertyValue = valueToWaitFor.ToString(),
+                PropertyValue = valueToWaitFor.ToString("G"),
             };
             var expectedItemPath = new ItemPath
             {
@@ -428,7 +428,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx.Functions
             MockTestState.Setup(x => x.GetTimeout()).Returns(Timeout);
 
             var waitFunction = new WaitFunctionNumber(Timeout, MockLogger.Object);
-            waitFunction.Execute(recordValue, FormulaValue.New("Text"), NumberValue.New(valueToWaitFor));
+            waitFunction.Execute(recordValue, FormulaValue.New("Text"), FormulaValue.New(valueToWaitFor));
 
             MockPowerAppFunctions.Verify(x => x.GetPropertyValueFromControl<string>(It.Is<ItemPath>((itemPath) => itemPath.ControlName == expectedItemPath.ControlName && itemPath.PropertyName == expectedItemPath.PropertyName)), Times.Exactly(3));
         }
@@ -554,7 +554,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx.Functions
         public void WaitFunctionNumberTimeoutTest()
         {
             LoggingTestHelper.SetupMock(MockLogger);
-            var valueToWaitFor = 1;
+            var valueToWaitFor = 1d;
             var recordType = RecordType.Empty().Add("Text", FormulaType.Number);
             var recordValue = new ControlRecordValue(recordType, MockPowerAppFunctions.Object, "Label1");
             var jsPropertyValueModel = new JSPropertyValueModel()

--- a/src/Microsoft.PowerApps.TestEngine.Tests/PowerFx/PowerFxEngineTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/PowerFx/PowerFxEngineTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.PowerApps.TestEngine.Config;
@@ -485,10 +486,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx
             });
             MockPowerAppFunctions.Setup(x => x.CheckAndHandleIfLegacyPlayerAsync()).Returns(Task.FromResult(true));
             MockPowerAppFunctions.Setup(x => x.CheckIfAppIsIdleAsync()).Returns(Task.FromResult(true));
-            MockPowerAppFunctions.Setup(x => x.SelectControlAsync(It.IsAny<ItemPath>())).Callback(async () =>
-            {
-                await powerFxEngine.UpdatePowerFxModelAsync();
-            }).Returns(Task.FromResult(true));
+            MockPowerAppFunctions.Setup(x => x.SelectControlAsync(It.IsAny<ItemPath>())).Returns(Task.FromResult(true));
 
             var oldUICulture = CultureInfo.CurrentUICulture;
             var frenchCulture = new CultureInfo("fr");

--- a/src/Microsoft.PowerApps.TestEngine/Microsoft.PowerApps.TestEngine.csproj
+++ b/src/Microsoft.PowerApps.TestEngine/Microsoft.PowerApps.TestEngine.csproj
@@ -30,7 +30,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Playwright" Version="1.35.0" />
-    <PackageReference Include="Microsoft.PowerFx.Interpreter" Version="0.2.6-preview" />
+    <PackageReference Include="Microsoft.PowerFx.Interpreter" Version="1.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageReference Include="YamlDotNet" Version="11.2.1" />
   </ItemGroup>


### PR DESCRIPTION
PowerFx version update.
Please note that `currently PowerApps does not support decimal fully but floating-point numbers` which was handled here https://github.com/microsoft/PowerApps-TestEngine/pull/278. 
Whereas, PowerFx by default considers numbers as decimal. Hence in the tests we had to convert number to right type since we do not handle case for decimal types yet in testengine.
 
## Validation
Tested the new version with PAC CLI. Looks good and runs well.
<img width="667" alt="image" src="https://github.com/microsoft/PowerApps-TestEngine/assets/98551644/88d74f39-5922-47e6-a94d-38dac51e95f4">

## Checklist

- [x] The code change is covered by unit tests. I have added tests that prove my fix is effective or that my feature works
- [x] I have performed end-to-end test locally.
- [x] New and existing unit tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I used clear names for everything
- [x] I have performed a self-review of my own code
