### PR TITLE
NuGet Update and Splitting and adding js file based on pagetype

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -64,7 +64,7 @@ jobs:
           reporter: dotnet-trx        # Format of test results
       
       - name: Upload test results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: test-results-coverage-report
           path: src/TestResults/**/coverage.cobertura.xml

--- a/samples/buttonclicker/README.md
+++ b/samples/buttonclicker/README.md
@@ -1,0 +1,20 @@
+# Overview
+
+This Power Apps Test Engine sample demonstrates how to clicking button of a canvas application
+
+## Usage
+
+1. Build the Test Engine solution
+
+2. Get the Environment Id and Tenant of the environment that the samplication solution has been imported into
+
+3. Execute the test for custom page changing the example below to the url of your organization using browser persistant cookies
+
+```pwsh
+cd bin\Debug\PowerAppsEngine
+dotnet PowerAppsTestEngine.dll -i ..\..\..\samples\buttonclicker\testPlan.fx.yaml -e 00000000-0000-0000-0000-11112223333 -t 11112222-3333-4444-5555-666677778888 -u browser -p canvas
+```
+
+NOTES:
+- If the BrowserCache folder does not exist with valid Persistent Session cookies an interactive login will be required
+- After an interactive login has been completed a headless test session can be run

--- a/samples/mda/testPlan.fx.yaml
+++ b/samples/mda/testPlan.fx.yaml
@@ -19,6 +19,7 @@ testSettings:
   browserConfigurations:
     - browser: Chromium
       channel: msedge
+  timeout: 600000
 
 environmentVariables:
   users:

--- a/samples/mda/testPlan.fx.yaml
+++ b/samples/mda/testPlan.fx.yaml
@@ -18,6 +18,7 @@ testSettings:
     enable: true
   browserConfigurations:
     - browser: Chromium
+      channel: msedge
 
 environmentVariables:
   users:

--- a/samples/testSettings.yaml
+++ b/samples/testSettings.yaml
@@ -1,6 +1,8 @@
 locale: "en-US"
+headless: false
 recordVideo: true
 extensionModules:
   enable: true
 browserConfigurations:
   - browser: Chromium
+    channel: msedge

--- a/src/Microsoft.PowerApps.TestEngine.Tests/Config/SingleTestInstanceStateTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/Config/SingleTestInstanceStateTests.cs
@@ -44,7 +44,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Config
         [Theory]
         [InlineData("")]
         [InlineData(null)]
-        public void SetTestRunIdThrowsOnInvalidInputTest(string invalidInput)
+        public void SetTestRunIdThrowsOnInvalidInputTest(string? invalidInput)
         {
             var state = new SingleTestInstanceState();
             Assert.Throws<ArgumentNullException>(() => state.SetTestRunId(invalidInput));
@@ -53,7 +53,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Config
         [Theory]
         [InlineData("")]
         [InlineData(null)]
-        public void SetTestIdThrowsOnInvalidInputTest(string invalidInput)
+        public void SetTestIdThrowsOnInvalidInputTest(string? invalidInput)
         {
             var state = new SingleTestInstanceState();
             Assert.Throws<ArgumentNullException>(() => state.SetTestId(invalidInput));
@@ -62,7 +62,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Config
         [Theory]
         [InlineData("")]
         [InlineData(null)]
-        public void SetTestResultsDirectoryThrowsOnInvalidInputTest(string invalidInput)
+        public void SetTestResultsDirectoryThrowsOnInvalidInputTest(string? invalidInput)
         {
             var state = new SingleTestInstanceState();
             Assert.Throws<ArgumentNullException>(() => state.SetTestResultsDirectory(invalidInput));

--- a/src/Microsoft.PowerApps.TestEngine.Tests/Config/TestStateTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/Config/TestStateTests.cs
@@ -189,7 +189,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Config
         [Theory]
         [InlineData(null)]
         [InlineData("")]
-        public void ParseAndSetTestStateThrowsOnInvalidTestConfigFile(string testConfigPath)
+        public void ParseAndSetTestStateThrowsOnInvalidTestConfigFile(string? testConfigPath)
         {
             var state = new TestState(MockTestConfigParser.Object);
             MockLoggerFactory.Setup(x => x.CreateLogger(It.IsAny<string>())).Returns(MockLogger.Object);
@@ -218,7 +218,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Config
         [Theory]
         [InlineData(null)]
         [InlineData("")]
-        public void ParseAndSetTestStateThrowsOnNoNameInTestSuiteDefinition(string testName)
+        public void ParseAndSetTestStateThrowsOnNoNameInTestSuiteDefinition(string? testName)
         {
             var state = new TestState(MockTestConfigParser.Object);
             var testConfigFile = "testPlan.fx.yaml";
@@ -237,7 +237,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Config
         [Theory]
         [InlineData(null)]
         [InlineData("")]
-        public void ParseAndSetTestStateThrowsOnNoPersonaInTestSuiteDefinition(string persona)
+        public void ParseAndSetTestStateThrowsOnNoPersonaInTestSuiteDefinition(string? persona)
         {
             var state = new TestState(MockTestConfigParser.Object);
             var testConfigFile = "testPlan.fx.yaml";
@@ -258,7 +258,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Config
         [InlineData("", "")]
         [InlineData(null, "")]
         [InlineData("", null)]
-        public void ParseAndSetTestStateThrowsOnNoAppLogicalNameOrAppIdInTestSuiteDefinition(string appLogicalName, string appId)
+        public void ParseAndSetTestStateThrowsOnNoAppLogicalNameOrAppIdInTestSuiteDefinition(string? appLogicalName, string? appId)
         {
             var state = new TestState(MockTestConfigParser.Object);
             var testConfigFile = "testPlan.fx.yaml";
@@ -278,7 +278,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Config
         [Theory]
         [InlineData("appLogicalName", null)]
         [InlineData(null, "appId")]
-        public void ParseAndSetTestStateDoesNotThrowWhenEitherOfAppLogicalNameOrAppIdInTestSuiteDefinition(string appLogicalName, string appId)
+        public void ParseAndSetTestStateDoesNotThrowWhenEitherOfAppLogicalNameOrAppIdInTestSuiteDefinition(string? appLogicalName, string? appId)
         {
             var state = new TestState(MockTestConfigParser.Object);
             var testConfigFile = "testPlan.fx.yaml";
@@ -314,7 +314,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Config
         [Theory]
         [InlineData(null)]
         [InlineData("")]
-        public void ParseAndSetTestStateThrowsOnNoTestCaseNameInTestCase(string testCaseName)
+        public void ParseAndSetTestStateThrowsOnNoTestCaseNameInTestCase(string? testCaseName)
         {
             var state = new TestState(MockTestConfigParser.Object);
             var testConfigFile = "testPlan.fx.yaml";
@@ -333,7 +333,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Config
         [Theory]
         [InlineData(null)]
         [InlineData("")]
-        public void ParseAndSetTestStateThrowsOnNoTestStepsInTestCase(string testSteps)
+        public void ParseAndSetTestStateThrowsOnNoTestStepsInTestCase(string? testSteps)
         {
             var state = new TestState(MockTestConfigParser.Object);
             var testConfigFile = "testPlan.fx.yaml";
@@ -403,7 +403,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Config
         [Theory]
         [InlineData(null)]
         [InlineData("")]
-        public void ParseAndSetTestStateThrowsOnNoBrowserInBrowserConfigurationInTestSettings(string browser)
+        public void ParseAndSetTestStateThrowsOnNoBrowserInBrowserConfigurationInTestSettings(string? browser)
         {
             var state = new TestState(MockTestConfigParser.Object);
             var testConfigFile = "testPlan.fx.yaml";
@@ -497,7 +497,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Config
         [Theory]
         [InlineData("")]
         [InlineData(null)]
-        public void ParseAndSetTestStateThrowsOnNoPersonaNameInUserConfigurationInEnvironmentVariables(string personaName)
+        public void ParseAndSetTestStateThrowsOnNoPersonaNameInUserConfigurationInEnvironmentVariables(string? personaName)
         {
             var state = new TestState(MockTestConfigParser.Object);
             var testConfigFile = "testPlan.fx.yaml";
@@ -516,7 +516,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Config
         [Theory]
         [InlineData("")]
         [InlineData(null)]
-        public void ParseAndSetTestStateThrowsOnNoEmailKeyInUserConfigurationInEnvironmentVariables(string emailKey)
+        public void ParseAndSetTestStateThrowsOnNoEmailKeyInUserConfigurationInEnvironmentVariables(string? emailKey)
         {
             var state = new TestState(MockTestConfigParser.Object);
             var testConfigFile = "testPlan.fx.yaml";
@@ -574,7 +574,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Config
         [Theory]
         [InlineData("")]
         [InlineData(null)]
-        public void SetEnvironmentThrowsOnNullInput(string environment)
+        public void SetEnvironmentThrowsOnNullInput(string? environment)
         {
             var state = new TestState(MockTestConfigParser.Object);
             Assert.Throws<ArgumentNullException>(() => state.SetEnvironment(environment));
@@ -583,7 +583,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Config
         [Theory]
         [InlineData("")]
         [InlineData(null)]
-        public void SetDomainThrowsOnNullInput(string domain)
+        public void SetDomainThrowsOnNullInput(string? domain)
         {
             var state = new TestState(MockTestConfigParser.Object);
             Assert.Throws<ArgumentNullException>(() => state.SetDomain(domain));
@@ -592,7 +592,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Config
         [Theory]
         [InlineData("")]
         [InlineData(null)]
-        public void SetTenantThrowsOnNullInput(string tenant)
+        public void SetTenantThrowsOnNullInput(string? tenant)
         {
             var state = new TestState(MockTestConfigParser.Object);
             Assert.Throws<ArgumentNullException>(() => state.SetTenant(tenant));
@@ -601,7 +601,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Config
         [Theory]
         [InlineData("")]
         [InlineData(null)]
-        public void SetOutputDirectoryThrowsOnNullInput(string outputDirectory)
+        public void SetOutputDirectoryThrowsOnNullInput(string? outputDirectory)
         {
             var state = new TestState(MockTestConfigParser.Object);
             Assert.Throws<ArgumentNullException>(() => state.SetOutputDirectory(outputDirectory));

--- a/src/Microsoft.PowerApps.TestEngine.Tests/Config/YamlTestConfigParserTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/Config/YamlTestConfigParserTests.cs
@@ -360,7 +360,7 @@ enablePowerFxOverlay: false";
         [Theory]
         [InlineData("")]
         [InlineData(null)]
-        public void YamlTestConfigParserThrowsOnNullArguments(string filePath)
+        public void YamlTestConfigParserThrowsOnNullArguments(string? filePath)
         {
             var mockFileSystem = new Mock<IFileSystem>(MockBehavior.Strict);
             var parser = new YamlTestConfigParser(mockFileSystem.Object);

--- a/src/Microsoft.PowerApps.TestEngine.Tests/Helpers/PollingHelpersTest.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/Helpers/PollingHelpersTest.cs
@@ -58,10 +58,10 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Helpers
         }
 
         [Fact]
-        public void PollingAsyncTimeoutTest()
+        public async Task PollingAsyncTimeoutTest()
         {
             LoggingTestHelper.SetupMock(MockLogger);
-            Assert.ThrowsAsync<TimeoutException>(() => PollingHelper.PollAsync(false, conditionToCheck, () => functionToCallAsync(), _notEnoughRuntime, MockLogger.Object));
+            await Assert.ThrowsAsync<TimeoutException>(() => PollingHelper.PollAsync(false, conditionToCheck, () => functionToCallAsync(), _notEnoughRuntime, MockLogger.Object));
         }
 
         [Fact]
@@ -72,10 +72,10 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Helpers
         }
 
         [Fact]
-        public void PollingAsyncThrowsOnInvalidArgumentsTest()
+        public async Task PollingAsyncThrowsOnInvalidArgumentsTest()
         {
             LoggingTestHelper.SetupMock(MockLogger);
-            Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => PollingHelper.PollAsync(false, conditionToCheck, () => functionToCallAsync(), _invalidRuntime, MockLogger.Object));
+            await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => PollingHelper.PollAsync(false, conditionToCheck, () => functionToCallAsync(), _invalidRuntime, MockLogger.Object));
         }
 
     }

--- a/src/Microsoft.PowerApps.TestEngine.Tests/Microsoft.PowerApps.TestEngine.Tests.csproj
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/Microsoft.PowerApps.TestEngine.Tests.csproj
@@ -11,17 +11,20 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.5.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-    <PackageReference Include="Moq" Version="4.17.2" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.11.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="System.Formats.Asn1" Version="8.0.1" />
     <PackageReference Include="System.Security.Cryptography.Pkcs" Version="8.0.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
+    <PackageReference Include="System.Text.Json" Version="8.0.4" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/Microsoft.PowerApps.TestEngine.Tests/Modules/TestEngineModuleMEFLoaderTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/Modules/TestEngineModuleMEFLoaderTests.cs
@@ -28,7 +28,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Modules
             var catalog = loader.LoadModules(setting);
 
             Assert.NotNull(catalog);
-            Assert.Equal(0, catalog.Catalogs.Count);
+            Assert.Empty(catalog.Catalogs);
         }
 
         [Theory]

--- a/src/Microsoft.PowerApps.TestEngine.Tests/PowerFx/PowerFxEngineTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/PowerFx/PowerFxEngineTests.cs
@@ -66,15 +66,15 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx
         }
 
         [Fact]
-        public void UpdatePowerFxModelAsyncThrowsOnNoSetupTest()
+        public async Task UpdatePowerFxModelAsyncThrowsOnNoSetupTest()
         {
             var powerFxEngine = new PowerFxEngine(MockTestInfraFunctions.Object, MockTestWebProvider.Object, MockSingleTestInstanceState.Object, MockTestState.Object, MockFileSystem.Object);
-            Assert.ThrowsAsync<InvalidOperationException>(() => powerFxEngine.UpdatePowerFxModelAsync());
+            await Assert.ThrowsAsync<InvalidOperationException>(() => powerFxEngine.UpdatePowerFxModelAsync());
             LoggingTestHelper.VerifyLogging(MockLogger, "Engine is null, make sure to call Setup first", LogLevel.Error, Times.Once());
         }
 
         [Fact]
-        public async void UpdatePowerFxModelAsyncThrowsOnCantGetAppStatusTest()
+        public async Task UpdatePowerFxModelAsyncThrowsOnCantGetAppStatusTest()
         {
             var recordType = RecordType.Empty().Add("Text", FormulaType.String);
             var button1 = new ControlRecordValue(recordType, MockTestWebProvider.Object, "Button1");
@@ -93,7 +93,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx
         }
 
         [Fact]
-        public async void RunRequirementsCheckAsyncTest()
+        public async Task RunRequirementsCheckAsyncTest()
         {
             MockTestState.Setup(x => x.GetTestSettings()).Returns(new TestSettings());
             MockTestState.Setup(x => x.GetTestEngineModules()).Returns(new List<ITestEngineModule>());
@@ -111,7 +111,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx
         }
 
         [Fact]
-        public async void RunRequirementsCheckAsyncThrowsOnCheckAndHandleIfLegacyPlayerTest()
+        public async Task RunRequirementsCheckAsyncThrowsOnCheckAndHandleIfLegacyPlayerTest()
         {
             MockTestState.Setup(x => x.GetTestSettings()).Returns(new TestSettings());
             MockTestState.Setup(x => x.GetTestEngineModules()).Returns(new List<ITestEngineModule>());
@@ -129,7 +129,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx
         }
 
         [Fact]
-        public async void RunRequirementsCheckAsyncThrowsOnTestEngineReadyTest()
+        public async Task RunRequirementsCheckAsyncThrowsOnTestEngineReadyTest()
         {
             MockTestState.Setup(x => x.GetTestSettings()).Returns(new TestSettings());
             MockTestState.Setup(x => x.GetTestEngineModules()).Returns(new List<ITestEngineModule>());
@@ -270,7 +270,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx
         }
 
         [Fact]
-        public void ExecuteFailsWhenPowerFXThrowsTest()
+        public async Task ExecuteFailsWhenPowerFXThrowsTest()
         {
             MockTestState.Setup(x => x.GetTestSettings()).Returns(new TestSettings());
             MockTestState.Setup(x => x.GetTestEngineModules()).Returns(new List<ITestEngineModule>());
@@ -279,11 +279,11 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx
             MockTestWebProvider.Setup(x => x.LoadObjectModelAsync()).Returns(Task.FromResult(new Dictionary<string, ControlRecordValue>()));
             var powerFxEngine = new PowerFxEngine(MockTestInfraFunctions.Object, MockTestWebProvider.Object, MockSingleTestInstanceState.Object, MockTestState.Object, MockFileSystem.Object);
             powerFxEngine.Setup();
-            Assert.ThrowsAsync<Exception>(async () => await powerFxEngine.ExecuteWithRetryAsync(powerFxExpression, It.IsAny<CultureInfo>()));
+            await Assert.ThrowsAsync<AggregateException>(async () => await powerFxEngine.ExecuteWithRetryAsync(powerFxExpression, It.IsAny<CultureInfo>()));
         }
 
         [Fact]
-        public void ExecuteFailsWhenUsingNonExistentVariableTest()
+        public async Task ExecuteFailsWhenUsingNonExistentVariableTest()
         {
             MockTestState.Setup(x => x.GetTestSettings()).Returns(new TestSettings());
             MockTestState.Setup(x => x.GetTestEngineModules()).Returns(new List<ITestEngineModule>());
@@ -291,7 +291,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx
             var powerFxExpression = "Concatenate(Label1.Text, Label2.Text)";
             var powerFxEngine = new PowerFxEngine(MockTestInfraFunctions.Object, MockTestWebProvider.Object, MockSingleTestInstanceState.Object, MockTestState.Object, MockFileSystem.Object);
             powerFxEngine.Setup();
-            Assert.ThrowsAsync<Exception>(async () => await powerFxEngine.ExecuteWithRetryAsync(powerFxExpression, It.IsAny<CultureInfo>()));
+            await Assert.ThrowsAsync<AggregateException>(async () => await powerFxEngine.ExecuteWithRetryAsync(powerFxExpression, It.IsAny<CultureInfo>()));
         }
 
         [Fact]
@@ -505,7 +505,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerFx
             MockTestWebProvider.Verify(x => x.LoadObjectModelAsync(), Times.Once());
         }
 
-        public async Task TestStepByStep()
+        private async Task TestStepByStep()
         {
             // Arrange
             var powerFxEngine = GetPowerFxEngine();

--- a/src/Microsoft.PowerApps.TestEngine.Tests/Reporting/TestReporterTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/Reporting/TestReporterTests.cs
@@ -31,7 +31,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Reporting
         [InlineData(null)]
         [InlineData("")]
         [InlineData("nonexistentid")]
-        public void ThrowsOnInvalidTestRunIdTest(string testRunId)
+        public void ThrowsOnInvalidTestRunIdTest(string? testRunId)
         {
             var testReporter = new TestReporter(MockFileSystem.Object);
             Assert.Throws<ArgumentException>(() => testReporter.GetTestRun(testRunId));
@@ -290,7 +290,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.Reporting
         [InlineData(true, "some logs", new string[] { "file1.txt", "file2.txt", "file3.txt" }, null)]
         [InlineData(false, "some logs", new string[] { }, null)]
         [InlineData(true, "some logs", new string[] { }, "error message")]
-        public void EndTestTest(bool success, string stdout, string[] additionalFiles, string errorMessage)
+        public void EndTestTest(bool success, string stdout, string[] additionalFiles, string? errorMessage)
         {
             var testRunName = "testRunName";
             var testUser = "testUser";

--- a/src/Microsoft.PowerApps.TestEngine.Tests/SingleTestRunnerTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/SingleTestRunnerTests.cs
@@ -318,7 +318,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
             VerifyFinallyExecution(testData.testResultDirectory, 1, 0, 1);
         }
 
-        public async Task SingleTestRunnerHandlesExceptionsThrownCorrectlyHelper(Action<Exception> additionalMockSetup)
+        private async Task SingleTestRunnerHandlesExceptionsThrownCorrectlyHelper(Action<Exception> additionalMockSetup)
         {
             var singleTestRunner = new SingleTestRunner(MockTestReporter.Object,
                                                            MockPowerFxEngine.Object,

--- a/src/Microsoft.PowerApps.TestEngine.Tests/System/FileSystemTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/System/FileSystemTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.System
         [InlineData("", false)]
         [InlineData(null, false)]
         [InlineData("C:/fold:er", false)]
-        public void IsValidFilePathTest(string filePath, bool expectedResult)
+        public void IsValidFilePathTest(string? filePath, bool expectedResult)
         {
             var fileSystem = new FileSystem();
             var result = fileSystem.IsValidFilePath(filePath);

--- a/src/Microsoft.PowerApps.TestEngine.Tests/TestEngineTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/TestEngineTests.cs
@@ -321,7 +321,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
         [InlineData(null, "Default-EnvironmentId", "a01af035-a529-4aaf-aded-011ad676f976", "apps.powerapps.com")]
         [InlineData("C:\\testPlan.fx.yaml", "", "a01af035-a529-4aaf-aded-011ad676f976", "apps.powerapps.com")]
         [InlineData("C:\\testPlan.fx.yaml", "Default-EnvironmentId", "a01af035-a529-4aaf-aded-011ad676f976", "")]
-        public async Task TestEngineThrowsOnNullArguments(string testConfigFilePath, string environmentId, Guid tenantId, string domain)
+        public async Task TestEngineThrowsOnNullArguments(string? testConfigFilePath, string environmentId, Guid tenantId, string domain)
         {
             MockTestReporter.Setup(x => x.CreateTestRun(It.IsAny<string>(), It.IsAny<string>())).Returns(Guid.NewGuid().ToString());
             MockTestReporter.Setup(x => x.StartTestRun(It.IsAny<string>()));
@@ -380,7 +380,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests
         [Theory]
         [InlineData(null)]
         [InlineData("")]
-        public async Task GetLocaleFromTestSettingsUseSystemLocaleIfNull(string localeInput)
+        public async Task GetLocaleFromTestSettingsUseSystemLocaleIfNull(string? localeInput)
         {
             // Arrange
             LoggingTestHelper.SetupMock(MockLogger);

--- a/src/Microsoft.PowerApps.TestEngine.Tests/TestInfra/PlaywrightTestInfraFunctionTests.cs
+++ b/src/Microsoft.PowerApps.TestEngine.Tests/TestInfra/PlaywrightTestInfraFunctionTests.cs
@@ -63,7 +63,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.TestInfra
         [InlineData("Chromium", "Pixel 2", null, null)]
         [InlineData("Safari", "iPhone 8", 400, null)]
         [InlineData("Safari", "iPhone 8", 400, 800)]
-        public async Task SetupAsyncTest(string browser, string device, int? screenWidth, int? screenHeight)
+        public async Task SetupAsyncTest(string browser, string? device, int? screenWidth, int? screenHeight)
         {
             var browserConfig = new BrowserConfiguration()
             {
@@ -219,7 +219,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.TestInfra
         [Theory]
         [InlineData("")]
         [InlineData(null)]
-        public async Task SetupAsyncThrowsOnNullOrEmptyBrowserTest(string browser)
+        public async Task SetupAsyncThrowsOnNullOrEmptyBrowserTest(string? browser)
         {
             var browserConfig = new BrowserConfiguration()
             {
@@ -308,7 +308,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.TestInfra
         [Fact]
         public async Task EndTestRunSuccessTest()
         {
-            MockBrowserContext.Setup(x => x.CloseAsync()).Returns(Task.CompletedTask);
+            MockBrowserContext.Setup(x => x.CloseAsync(null)).Returns(Task.CompletedTask);
             MockPage.Setup(x => x.WaitForRequestFinishedAsync(It.IsAny<PageWaitForRequestFinishedOptions>())).Returns(Task.FromResult(MockRequest.Object));
 
             var playwrightTestInfraFunctions = new PlaywrightTestInfraFunctions(MockTestState.Object, MockSingleTestInstanceState.Object,
@@ -316,7 +316,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.TestInfra
 
             await playwrightTestInfraFunctions.EndTestRunAsync();
 
-            MockBrowserContext.Verify(x => x.CloseAsync(), Times.Once);
+            MockBrowserContext.Verify(x => x.CloseAsync(null), Times.Once);
         }
 
         [Fact]
@@ -580,7 +580,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.TestInfra
         [InlineData("www.microsoft.com")]
         [InlineData("file://c:/test.txt")]
         [InlineData("hi")]
-        public async Task GoToUrlThrowsOnInvalidUrlTest(string url)
+        public async Task GoToUrlThrowsOnInvalidUrlTest(string? url)
         {
             MockSingleTestInstanceState.Setup(x => x.GetLogger()).Returns(MockLogger.Object);
             LoggingTestHelper.SetupMock(MockLogger);

--- a/src/Microsoft.PowerApps.TestEngine/Config/TestState.cs
+++ b/src/Microsoft.PowerApps.TestEngine/Config/TestState.cs
@@ -114,7 +114,13 @@ namespace Microsoft.PowerApps.TestEngine.Config
                 }
                 else if (!string.IsNullOrEmpty(TestPlanDefinition.TestSettings?.FilePath))
                 {
-                    TestPlanDefinition.TestSettings = _testConfigParser.ParseTestConfig<TestSettings>(TestPlanDefinition.TestSettings.FilePath, logger);
+                    var testSettingFile = TestPlanDefinition.TestSettings.FilePath;
+                    if ( ! Path.IsPathRooted(testSettingFile))
+                    {
+                        // Generate a absolte path relative to the test file
+                        testSettingFile = Path.GetFullPath(Path.Combine(Path.GetDirectoryName(testConfigFile), testSettingFile));
+                    }
+                    TestPlanDefinition.TestSettings = _testConfigParser.ParseTestConfig<TestSettings>(testSettingFile, logger);
                 }
 
                 if (TestPlanDefinition.TestSettings?.BrowserConfigurations == null
@@ -145,7 +151,12 @@ namespace Microsoft.PowerApps.TestEngine.Config
                 }
                 else if (!string.IsNullOrEmpty(TestPlanDefinition.EnvironmentVariables.FilePath))
                 {
-                    TestPlanDefinition.EnvironmentVariables = _testConfigParser.ParseTestConfig<EnvironmentVariables>(TestPlanDefinition.EnvironmentVariables.FilePath, logger);
+                    var testEnvironmentFile = TestPlanDefinition.EnvironmentVariables.FilePath;
+                    if (!Path.IsPathRooted(testEnvironmentFile))
+                    {
+                        testEnvironmentFile = Path.GetFullPath(Path.Combine(Path.GetDirectoryName(testConfigFile), testEnvironmentFile));
+                    }
+                    TestPlanDefinition.EnvironmentVariables = _testConfigParser.ParseTestConfig<EnvironmentVariables>(testEnvironmentFile, logger);
                 }
 
                 if (TestPlanDefinition.EnvironmentVariables?.Users == null

--- a/src/Microsoft.PowerApps.TestEngine/Microsoft.PowerApps.TestEngine.csproj
+++ b/src/Microsoft.PowerApps.TestEngine/Microsoft.PowerApps.TestEngine.csproj
@@ -27,15 +27,15 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Playwright" Version="1.35.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Playwright" Version="1.47.0" />
     <PackageReference Include="Microsoft.PowerFx.Interpreter" Version="1.2.0" />
     <PackageReference Include="Mono.Cecil" Version="0.11.5" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
-    <PackageReference Include="NuGet.Configuration" Version="6.5.0" />
-    <PackageReference Include="System.ComponentModel.Composition" Version="5.0.0" />
-    <PackageReference Include="YamlDotNet" Version="11.2.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="NuGet.Configuration" Version="6.11.0" />
+    <PackageReference Include="System.ComponentModel.Composition" Version="8.0.0" />
+    <PackageReference Include="YamlDotNet" Version="16.1.3" />
   </ItemGroup>
   <ItemGroup Condition="'$(GitExists)' == true">
     <PackageReference Include="MinVer" Version="2.3.0">

--- a/src/PowerAppsTestEngine.sln
+++ b/src/PowerAppsTestEngine.sln
@@ -67,8 +67,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items (2)", "Solut
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Users", "Users", "{4E409805-A766-4F65-B058-C5264BA1F1CE}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Providers", "Providers", "{1009A533-2243-4EBF-BA85-8A8CC02F3FB9}"
-EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Actions", "Actions", "{65FAC4EC-553A-4293-8484-2427A76BB4A0}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "testengine.provider.mda", "testengine.provider.mda\testengine.provider.mda.csproj", "{25CEB2CE-B6D5-4BE1-ACD7-3CF00441EF94}"

--- a/src/PowerAppsTestEngine/PowerAppsTestEngine.csproj
+++ b/src/PowerAppsTestEngine/PowerAppsTestEngine.csproj
@@ -12,8 +12,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
-    <PackageReference Include="System.ComponentModel.Composition" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
+    <PackageReference Include="System.ComponentModel.Composition" Version="8.0.0" />
+    <PackageReference Include="System.Text.Json" Version="8.0.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PowerAppsTestEngine/Properties/launchSettings.json
+++ b/src/PowerAppsTestEngine/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "PowerAppsTestEngine": {
       "commandName": "Project",
-      "commandLineArgs": "-i ..\\..\\..\\samples\\mda\\testPlan.fx.yaml -e 00000000-0000-0000-0000-11112223333 -t 11112222-3333-4444-5555-666677778888 -u browser -p mda -d \"https://contoso.crm4.dynamics.com/main.aspx?appid=9e9c25f3-1851-ef11-bfe2-6045bd8f802c&pagetype=custom&name=sample_custom_cf8e6\""
+      "commandLineArgs": "-i ..\\..\\..\\samples\\mda\\testPlan.fx.yaml -e a1234567-1111-2222-3333-444444444444 -t b1234567-1111-2222-3333-444444444444 -u browser -p mda -d \"https://contso.crm.dynamics.com/main.aspx?appid=d5c0321b-a2b7-4207-889f-f0af833f2309&pagetype=custom&name=sample_custom_cf8e6\""
     }
   }
 }

--- a/src/PowerAppsTestEngine/app.config
+++ b/src/PowerAppsTestEngine/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/testengine.auth.certificatestore.tests/CertificateStoreProviderTests.cs
+++ b/src/testengine.auth.certificatestore.tests/CertificateStoreProviderTests.cs
@@ -79,7 +79,7 @@ namespace testengine.auth.certificatestore.tests
         [Theory]
         [InlineData(null)]
         [InlineData("")]
-        public void RetrieveCertificateForUser_NullOrEmptyUsername_ThrowsArgumentException(string userSubjectName)
+        public void RetrieveCertificateForUser_NullOrEmptyUsername_ThrowsArgumentException(string? userSubjectName)
         {
             // Act & Assert
             Assert.Null(provider.RetrieveCertificateForUser(userSubjectName));

--- a/src/testengine.auth.certificatestore.tests/testengine.auth.certificatestore.tests.csproj
+++ b/src/testengine.auth.certificatestore.tests/testengine.auth.certificatestore.tests.csproj
@@ -15,14 +15,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="Moq" Version="4.18.4" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.2">
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/testengine.auth.localcertificate.tests/testengine.auth.localcertificate.tests.csproj
+++ b/src/testengine.auth.localcertificate.tests/testengine.auth.localcertificate.tests.csproj
@@ -15,14 +15,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="Moq" Version="4.18.4" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.2">
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/testengine.module.mda.tests/testengine.module.mda.tests.csproj
+++ b/src/testengine.module.mda.tests/testengine.module.mda.tests.csproj
@@ -15,14 +15,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="Moq" Version="4.18.4" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.2">
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/testengine.module.mda/testengine.module.mda.csproj
+++ b/src/testengine.module.mda/testengine.module.mda.csproj
@@ -28,10 +28,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Playwright" Version="1.35.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Playwright" Version="1.47.0" />
     <PackageReference Include="Microsoft.PowerFx.Interpreter" Version="1.2.0" />
-    <PackageReference Include="System.ComponentModel.Composition" Version="5.0.0" />
+    <PackageReference Include="System.ComponentModel.Composition" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/testengine.module.pause.tests/testengine.module.pause.tests.csproj
+++ b/src/testengine.module.pause.tests/testengine.module.pause.tests.csproj
@@ -15,14 +15,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="Moq" Version="4.18.4" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.2">
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/testengine.module.pause/testengine.module.pause.csproj
+++ b/src/testengine.module.pause/testengine.module.pause.csproj
@@ -28,10 +28,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Playwright" Version="1.35.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Playwright" Version="1.47.0" />
     <PackageReference Include="Microsoft.PowerFx.Interpreter" Version="1.2.0" />
-    <PackageReference Include="System.ComponentModel.Composition" Version="5.0.0" />
+    <PackageReference Include="System.ComponentModel.Composition" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -39,13 +39,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <MySourceFiles Include="..\..\bin\$(configuration)\testengine.module.pause\testengine.module.pause.dll"/>
+    <MySourceFiles Include="..\..\bin\$(configuration)\testengine.module.pause\testengine.module.pause.dll" />
   </ItemGroup>
 
   <Target Name="CopyFiles" AfterTargets="AfterBuild">
-    <Copy
-        SourceFiles="@(MySourceFiles)"
-        DestinationFolder="..\..\bin\$(configuration)\PowerAppsTestEngine"
-      />
+    <Copy SourceFiles="@(MySourceFiles)" DestinationFolder="..\..\bin\$(configuration)\PowerAppsTestEngine" />
   </Target>
 </Project>

--- a/src/testengine.module.sample/testengine.module.sample.csproj
+++ b/src/testengine.module.sample/testengine.module.sample.csproj
@@ -22,8 +22,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
-    <PackageReference Include="System.ComponentModel.Composition" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
+    <PackageReference Include="System.ComponentModel.Composition" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -31,13 +31,10 @@
   </ItemGroup>
 
   <ItemGroup>
-      <MySourceFiles Include="..\..\bin\$(configuration)\testengine.module.sample\testengine.module.sample.dll"/>
+      <MySourceFiles Include="..\..\bin\$(configuration)\testengine.module.sample\testengine.module.sample.dll" />
   </ItemGroup>
 
   <Target Name="CopyFiles" AfterTargets="AfterBuild">
-      <Copy
-          SourceFiles="@(MySourceFiles)"
-          DestinationFolder="..\..\bin\$(configuration)\PowerAppsTestEngine"
-      />
+      <Copy SourceFiles="@(MySourceFiles)" DestinationFolder="..\..\bin\$(configuration)\PowerAppsTestEngine" />
   </Target>
 </Project>

--- a/src/testengine.provider.canvas.tests/PowerAppFunctionsTest.cs
+++ b/src/testengine.provider.canvas.tests/PowerAppFunctionsTest.cs
@@ -407,7 +407,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerApps
         [InlineData("")]
         [InlineData("{}")]
         [InlineData("{ controls: [] }")]
-        public async Task LoadObjectModelAsyncWithNoModelTest(string jsObjectModelString)
+        public async Task LoadObjectModelAsyncWithNoModelTest(string? jsObjectModelString)
         {
             MockSingleTestInstanceState.Setup(x => x.GetLogger()).Returns(MockLogger.Object);
             MockTestInfraFunctions.Setup(x => x.AddScriptTagAsync(It.IsAny<string>(), It.IsAny<string>())).Returns(Task.CompletedTask);
@@ -878,7 +878,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerApps
         [InlineData("myEnvironment", "apps.powerapps.com", "myApp", "appId", "myTenant", "https://apps.powerapps.com/play/e/myEnvironment/an/myApp?tenantId=myTenant&source=testengine", "")]
         [InlineData("defaultEnvironment", "apps.test.powerapps.com", "defaultApp", "appId", "defaultTenant", "https://apps.test.powerapps.com/play/e/defaultEnvironment/an/defaultApp?tenantId=defaultTenant&source=testengine", "")]
         [InlineData("defaultEnvironment", "apps.powerapps.com", null, "appId", "defaultTenant", "https://apps.powerapps.com/play/e/defaultEnvironment/a/appId?tenantId=defaultTenant&source=testengine", "")]
-        public void GenerateAppUrlTest(string environmentId, string domain, string appLogicalName, string appId, string tenantId, string expectedAppUrl, string queryParams)
+        public void GenerateAppUrlTest(string environmentId, string domain, string? appLogicalName, string appId, string tenantId, string expectedAppUrl, string queryParams)
         {
             MockTestState.Setup(x => x.GetEnvironment()).Returns(environmentId);
             MockTestState.Setup(x => x.GetDomain()).Returns(domain);
@@ -898,7 +898,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerApps
         [InlineData("environmentId", null, null, "tenantId")]
         [InlineData("environmentId", "appLogicalName", "appId", "")]
         [InlineData("environmentId", "appLogicalName", "appId", null)]
-        public void GenerateLoginUrlThrowsOnInvalidSetupTest(string environmentId, string appLogicalName, string appId, string tenantId)
+        public void GenerateLoginUrlThrowsOnInvalidSetupTest(string? environmentId, string? appLogicalName, string? appId, string? tenantId)
         {
             MockTestState.Setup(x => x.GetEnvironment()).Returns(environmentId);
             MockSingleTestInstanceState.Setup(x => x.GetTestSuiteDefinition()).Returns(new TestSuiteDefinition() { AppLogicalName = appLogicalName, AppId = appId });

--- a/src/testengine.provider.canvas.tests/testengine.provider.canvas.tests.csproj
+++ b/src/testengine.provider.canvas.tests/testengine.provider.canvas.tests.csproj
@@ -12,14 +12,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="Moq" Version="4.20.70" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.2">
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/testengine.provider.mda.tests/ModelDrivenApplicationProviderCommonTest.cs
+++ b/src/testengine.provider.mda.tests/ModelDrivenApplicationProviderCommonTest.cs
@@ -10,8 +10,11 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerApps
 {
     internal class Common
     {
-        public static string MockJavaScript(string text, string pageType, bool includeMocks = true, bool includeInterface = true)
+        public static string MockJavaScript(string text, string pageType, bool includeMocks = true, bool includeInterface = true, List<string> interfaceResourceNames = null)
         {
+            // Initialize the list with the default value if it is null
+            interfaceResourceNames ??= new List<string> { "testengine.provider.mda.PowerAppsTestEngineMDA.js" };
+
             StringBuilder javaScript = new StringBuilder();
 
             Assembly assembly;
@@ -33,13 +36,15 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerApps
             if (includeInterface)
             {
                 assembly = typeof(ModelDrivenApplicationProvider).Assembly;
-                resourceName = "testengine.provider.mda.PowerAppsTestEngineMDA.js";
-                using (Stream stream = assembly.GetManifestResourceStream(resourceName))
-                using (StreamReader reader = new StreamReader(stream))
+                foreach (string name in interfaceResourceNames)
                 {
-                    javaScript.Append(reader.ReadToEnd());
+                    using (Stream stream = assembly.GetManifestResourceStream(name))
+                    using (StreamReader reader = new StreamReader(stream))
+                    {
+                        javaScript.Append(reader.ReadToEnd());
 
-                    javaScript.Append(text + ";");
+                        javaScript.Append(text + ";");
+                    }
                 }
             }
             javaScript.Append(text + ";");

--- a/src/testengine.provider.mda.tests/ModelDrivenApplicationProviderCustomPageTest.cs
+++ b/src/testengine.provider.mda.tests/ModelDrivenApplicationProviderCustomPageTest.cs
@@ -75,7 +75,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerApps
         {
             // Arrange
             var engine = new Engine();
-            engine.Execute(Common.MockJavaScript("mockPageType = 'custom'", "custom"));
+            engine.Execute(Common.MockJavaScript("mockPageType = 'custom'", "custom", interfaceResourceNames: new List<string> { "testengine.provider.mda.PowerAppsTestEngineMDA.js", "testengine.provider.mda.PowerAppsTestEngineMDACustom.js" }));
             expected = expected == null ? "function" : expected;
 
             scenario += "";
@@ -109,7 +109,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerApps
         {
             // Arrange
             var engine = new Engine();
-            engine.Execute(Common.MockJavaScript("mockPageType = 'custom'", "custom"));
+            engine.Execute(Common.MockJavaScript("mockPageType = 'custom'", "custom", interfaceResourceNames: new List<string> { "testengine.provider.mda.PowerAppsTestEngineMDA.js", "testengine.provider.mda.PowerAppsTestEngineMDACustom.js" }));
 
             // Act
             var result = engine.Evaluate(javaScript).AsString();
@@ -170,7 +170,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerApps
         {
             // Special case text should use the getValue()
             yield return new object[] {
-                    Common.MockJavaScript("mockPageType = 'custom';mockValue = 'Hello'", "custom"),
+                    Common.MockJavaScript("mockPageType = 'custom';mockValue = 'Hello'", "custom", interfaceResourceNames: new List<string> { "testengine.provider.mda.PowerAppsTestEngineMDA.js", "testengine.provider.mda.PowerAppsTestEngineMDACustom.js"}),
                     "TextInput1",
                     "Text",
                     "Hello"
@@ -227,7 +227,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerApps
         {
             // Default Values
             yield return new object[] {
-                    Common.MockJavaScript("mockPageType = 'custom';mockValue = 'Hello'", "custom"),
+                    Common.MockJavaScript("mockPageType = 'custom';mockValue = 'Hello'", "custom", interfaceResourceNames: new List<string> { "testengine.provider.mda.PowerAppsTestEngineMDA.js", "testengine.provider.mda.PowerAppsTestEngineMDACustom.js"}),
                     "TextInput1",
                     "{ Text: 'Hello' }"
             };

--- a/src/testengine.provider.mda.tests/ModelDrivenApplicationProviderTest.cs
+++ b/src/testengine.provider.mda.tests/ModelDrivenApplicationProviderTest.cs
@@ -18,7 +18,7 @@ using Newtonsoft.Json;
 
 namespace Microsoft.PowerApps.TestEngine.Tests.PowerApps
 {
-    public class ModelDrivenApplicationProviderTests
+    public class ModelDrivenApplicationProviderTests: IDisposable
     {
         private Mock<ITestInfraFunctions> MockTestInfraFunctions;
         private Mock<ITestState> MockTestState;
@@ -26,6 +26,16 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerApps
         private Mock<ILogger> MockLogger;
         private Mock<IBrowserContext> MockBrowserContext;
         private JSObjectModel JsObjectModel;
+
+        //adding this to reset the behavior after each test case for the assembly static function
+        private readonly Func<Assembly> originalGetExecutingAssembly = ModelDrivenApplicationProvider.GetExecutingAssembly;
+
+        //adding this IDispose function for tear down that runs after each test and resets the AssemblyMock since it is static and can carry over between testcases
+        public void Dispose()
+        {
+            // Reset static Func to its original value after each test
+            ModelDrivenApplicationProvider.GetExecutingAssembly = originalGetExecutingAssembly;
+        }
 
         public ModelDrivenApplicationProviderTests()
         {
@@ -490,7 +500,6 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerApps
             MockTestInfraFunctions1.Setup(f => f.Page.RouteAsync(It.IsAny<string>(), It.IsAny<Func<IRoute, Task>>(), null)).Returns(Task.CompletedTask);
             var mockElementHandle = new Mock<IElementHandle>();
             MockTestInfraFunctions1.Setup(f => f.Page.AddScriptTagAsync(It.IsAny<PageAddScriptTagOptions>())).ReturnsAsync(mockElementHandle.Object);
-
             var provider = new ModelDrivenApplicationProvider(MockTestInfraFunctions1.Object, MockSingleTestInstanceState.Object, MockTestState.Object);
             // Act
             await provider.CheckProviderAsync();

--- a/src/testengine.provider.mda.tests/ModelDrivenApplicationProviderTest.cs
+++ b/src/testengine.provider.mda.tests/ModelDrivenApplicationProviderTest.cs
@@ -42,10 +42,17 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerApps
 
         [Theory]
         [MemberData(nameof(TestJavaScript))]
-        public void ValidJavaScript(string javaScript, bool includeMocks, bool includeInterface)
+        public void ValidJavaScript(string javaScript, bool includeMocks, bool includeInterface, List<string> interfaceResourceNames = null)
         {
             var engine = new Engine();
-            engine.Evaluate(Common.MockJavaScript(javaScript, "custom", includeMocks, includeInterface));
+            if (interfaceResourceNames == null)
+            {
+                engine.Evaluate(Common.MockJavaScript(javaScript, "custom", includeMocks, includeInterface));
+            }
+            else
+            {
+                engine.Evaluate(Common.MockJavaScript(javaScript, "custom", includeMocks, includeInterface, interfaceResourceNames));
+            }
         }
 
         public static IEnumerable<object[]> TestJavaScript()
@@ -64,17 +71,17 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerApps
 
             yield return new object[] { "PowerAppsTestEngine.pageType()", true, true };
 
-            yield return new object[] { "PowerAppsModelDrivenCanvas.getAppMagic()", true, true };
+            yield return new object[] { "PowerAppsModelDrivenCanvas.getAppMagic()", true, true, new List<string> { "testengine.provider.mda.PowerAppsTestEngineMDACustom.js" } };
 
-            yield return new object[] { "PowerAppsModelDrivenCanvas.parseControl('TextInput1', mockCanvasControl)", true, true };
+            yield return new object[] { "PowerAppsModelDrivenCanvas.parseControl('TextInput1', mockCanvasControl)", true, true, new List<string> { "testengine.provider.mda.PowerAppsTestEngineMDACustom.js" } };
 
-            yield return new object[] { "PowerAppsModelDrivenCanvas.getAppMagic().Controls?.GlobalContextManager?.bindingContext", true, true };
+            yield return new object[] { "PowerAppsModelDrivenCanvas.getAppMagic().Controls?.GlobalContextManager?.bindingContext", true, true, new List<string> { "testengine.provider.mda.PowerAppsTestEngineMDACustom.js" } };
 
-            yield return new object[] { "PowerAppsModelDrivenCanvas.getAppMagic().Controls.GlobalContextManager.bindingContext.componentBindingContexts.lookup('TextInput1')", true, true };
+            yield return new object[] { "PowerAppsModelDrivenCanvas.getAppMagic().Controls.GlobalContextManager.bindingContext.componentBindingContexts.lookup('TextInput1')", true, true, new List<string> { "testengine.provider.mda.PowerAppsTestEngineMDACustom.js" } };
 
-            yield return new object[] { "PowerAppsModelDrivenCanvas.getBindingContext({controlName: 'TextInput1', propertyName: 'Text'})", true, true };
+            yield return new object[] { "PowerAppsModelDrivenCanvas.getBindingContext({controlName: 'TextInput1', propertyName: 'Text'})", true, true, new List<string> { "testengine.provider.mda.PowerAppsTestEngineMDACustom.js" } };
 
-            yield return new object[] { "PowerAppsModelDrivenCanvas.getPropertyValueFromControl({controlName: 'TextInput1', propertyName: 'Text'})", true, true };
+            yield return new object[] { "PowerAppsModelDrivenCanvas.getPropertyValueFromControl({controlName: 'TextInput1', propertyName: 'Text'})", true, true, new List<string> { "testengine.provider.mda.PowerAppsTestEngineMDACustom.js" } };
         }
 
         [Theory]
@@ -220,7 +227,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerApps
         {
             // Special case text should use the getValue()
             yield return new object[] {
-                    Common.MockJavaScript("mockValue = 'Hello'", "entityrecord"),
+                    Common.MockJavaScript("mockValue = 'Hello'", "entityrecord", interfaceResourceNames: new List<string> { "testengine.provider.mda.PowerAppsTestEngineMDA.js", "testengine.provider.mda.PowerAppsTestEngineMDAEntityRecord.js"}),
                     "prefix_Name",
                     "Text",
                     "Hello"
@@ -228,7 +235,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerApps
 
             // Disabled by default controlDescriptor property
             yield return new object[] {
-                    Common.MockJavaScript("", "entityrecord"),
+                    Common.MockJavaScript("", "entityrecord", interfaceResourceNames: new List<string> { "testengine.provider.mda.PowerAppsTestEngineMDA.js", "testengine.provider.mda.PowerAppsTestEngineMDAEntityRecord.js"}),
                     "prefix_Name",
                     "Disabled",
                     false
@@ -236,7 +243,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerApps
 
             // test Disabled in controlDescriptor property
             yield return new object[] {
-                    Common.MockJavaScript("mockControlDescriptor.Disabled = true", "entityrecord"),
+                    Common.MockJavaScript("mockControlDescriptor.Disabled = true", "entityrecord", interfaceResourceNames: new List<string> { "testengine.provider.mda.PowerAppsTestEngineMDA.js", "testengine.provider.mda.PowerAppsTestEngineMDAEntityRecord.js"}),
                     "prefix_Name",
                     "Disabled",
                     true
@@ -299,35 +306,35 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerApps
         {
             // Default Values
             yield return new object[] {
-                    Common.MockJavaScript("mockValue = 'Hello'", "entityrecord"),
+                    Common.MockJavaScript("mockValue = 'Hello'", "entityrecord", interfaceResourceNames: new List<string> { "testengine.provider.mda.PowerAppsTestEngineMDA.js", "testengine.provider.mda.PowerAppsTestEngineMDAEntityRecord.js"}),
                     "test",
                     "{ Disabled: false, Text: 'Hello', ShowLabel: true, Label: 'Text Input', Visible: true, IsRequired: false }"
             };
 
             // Change control name
             yield return new object[] {
-                    Common.MockJavaScript("mockControlName = 'test2';mockValue = 'New value'", "entityrecord"),
+                    Common.MockJavaScript("mockControlName = 'test2';mockValue = 'New value'", "entityrecord", interfaceResourceNames: new List<string> { "testengine.provider.mda.PowerAppsTestEngineMDA.js", "testengine.provider.mda.PowerAppsTestEngineMDAEntityRecord.js"}),
                     "test2",
                     "{ Disabled: false, Text: 'New value', ShowLabel: true, Label: 'Text Input', Visible: true, IsRequired: false }"
             };
 
             // Change Label
             yield return new object[] {
-                    Common.MockJavaScript("mockControlDescriptor.Label = 'Item'", "entityrecord"),
+                    Common.MockJavaScript("mockControlDescriptor.Label = 'Item'", "entityrecord", interfaceResourceNames: new List<string> { "testengine.provider.mda.PowerAppsTestEngineMDA.js", "testengine.provider.mda.PowerAppsTestEngineMDAEntityRecord.js"}),
                     "test",
                     "{ Label: 'Item' }"
             };
 
             // Change Visible
             yield return new object[] {
-                    Common.MockJavaScript("mockControlDescriptor.Visible = false", "entityrecord"),
+                    Common.MockJavaScript("mockControlDescriptor.Visible = false", "entityrecord", interfaceResourceNames: new List<string> { "testengine.provider.mda.PowerAppsTestEngineMDA.js", "testengine.provider.mda.PowerAppsTestEngineMDAEntityRecord.js"}),
                     "test",
                     "{ Visible: false }"
             };
 
             // Change IsRequired
             yield return new object[] {
-                    Common.MockJavaScript("mockControlDescriptor.IsRequired = true", "entityrecord"),
+                    Common.MockJavaScript("mockControlDescriptor.IsRequired = true", "entityrecord", interfaceResourceNames: new List<string> { "testengine.provider.mda.PowerAppsTestEngineMDA.js", "testengine.provider.mda.PowerAppsTestEngineMDAEntityRecord.js"}),
                     "test",
                     "{ IsRequired: true }"
             };
@@ -352,9 +359,10 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerApps
 
             MockTestInfraFunctions.Setup(m => m.RunJavascriptAsync<object>(It.IsAny<string>()))
             .Returns(
-                async (string query) => {
+                async (string query) =>
+                {
                     var result = engine.Evaluate(query);
-                    if ( result.IsBoolean() )
+                    if (result.IsBoolean())
                     {
                         return result.AsBoolean();
                     }
@@ -412,7 +420,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerApps
         {
             // Default Values
             yield return new object[] {
-                    Common.MockJavaScript("mockValue = 'Hello'", "entityrecord"),
+                    Common.MockJavaScript("mockValue = 'Hello'", "entityrecord", interfaceResourceNames: new List<string> { "testengine.provider.mda.PowerAppsTestEngineMDA.js", "testengine.provider.mda.PowerAppsTestEngineMDAEntityRecord.js"}),
                     "test",
                     "Text",
                     "value",
@@ -421,7 +429,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerApps
 
             // Visible Values
             yield return new object[] {
-                    Common.MockJavaScript("mockValue = 'Hello'", "entityrecord"),
+                    Common.MockJavaScript("mockValue = 'Hello'", "entityrecord", interfaceResourceNames: new List<string> { "testengine.provider.mda.PowerAppsTestEngineMDA.js", "testengine.provider.mda.PowerAppsTestEngineMDAEntityRecord.js"}),
                     "test",
                     "Visible",
                     "visible",
@@ -430,7 +438,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerApps
 
             // Disabled Values
             yield return new object[] {
-                    Common.MockJavaScript("", "entityrecord"),
+                    Common.MockJavaScript("", "entityrecord", interfaceResourceNames: new List<string> { "testengine.provider.mda.PowerAppsTestEngineMDA.js", "testengine.provider.mda.PowerAppsTestEngineMDAEntityRecord.js"}),
                     "test",
                     "Disabled",
                     "disabled",
@@ -473,7 +481,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerApps
             blankPage.Setup(p => p.Url).Returns("about:blank");
             var MockPage = new Mock<IPage>(MockBehavior.Strict);
             MockPage.Setup(p => p.Url).Returns("https://example.com");
-            MockBrowserContext.Setup(c => c.Pages).Returns(new[] { blankPage.Object, MockPage.Object});
+            MockBrowserContext.Setup(c => c.Pages).Returns(new[] { blankPage.Object, MockPage.Object });
             MockSingleTestInstanceState.Setup(m => m.GetLogger()).Returns(MockLogger.Object);
             MockTestInfraFunctions1.Setup(m => m.GetContext()).Returns(MockBrowserContext.Object);
             MockTestInfraFunctions1.Setup(m => m.Page).Returns(MockPage.Object);
@@ -542,7 +550,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerApps
             MockLogger.Verify(l => l.Log(LogLevel.Debug, It.IsAny<EventId>(), It.Is<It.IsAnyType>((o, t) => o.ToString() == "Finish loading PowerAppsTestEngine."), It.IsAny<Exception>(), It.IsAny<Func<It.IsAnyType, Exception, string>>()), Times.Once);
         }
 
-       
+
         [Theory]
         [MemberData(nameof(DebugInfoProperties))]
         public async Task DebugInfo(string propertyName, object expectedValue, string javaScript)
@@ -571,7 +579,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerApps
 
             // Act
             var provider = new ModelDrivenApplicationProvider(MockTestInfraFunctions.Object, MockSingleTestInstanceState.Object, MockTestState.Object);
-            var result = (IDictionary<string, object>) (await provider.GetDebugInfo());
+            var result = (IDictionary<string, object>)(await provider.GetDebugInfo());
 
             // Assert
             Assert.Equal(expectedValue, result[propertyName]);
@@ -594,6 +602,171 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerApps
                     0,
                     Common.MockJavaScript("", "entityrecord"),
             };
+        }
+
+        [Fact]
+        public async Task EmbedMDAJSScripts_ResourceStreamIsNull_ThrowsException()
+        {
+            // Arrange
+            MockSingleTestInstanceState.Setup(m => m.GetLogger()).Returns(MockLogger.Object);
+            MockTestState.Setup(m => m.GetTimeout()).Returns(1000);
+            string resourceName = "invalidResource";
+            var _assemblyMock = new Mock<Assembly>();
+            _assemblyMock.Setup(a => a.GetManifestResourceStream(resourceName))
+                .Returns((Stream)null); // Simulate invalid resource name
+
+            ModelDrivenApplicationProvider.GetExecutingAssembly = () => _assemblyMock.Object;
+            var provider = new ModelDrivenApplicationProvider(MockTestInfraFunctions.Object, MockSingleTestInstanceState.Object, MockTestState.Object);
+
+            // Act & Assert
+
+            await Assert.ThrowsAsync<ArgumentNullException>(async () =>
+            {
+                await provider.EmbedMDAJSScripts(resourceName, "testScript.js");
+            });
+        }
+
+        [Fact]
+        public async Task EmbedMDAJSScripts_StreamUnreadable_ThrowsException()
+        {
+            // Arrange
+            MockSingleTestInstanceState.Setup(m => m.GetLogger()).Returns(MockLogger.Object);
+            MockTestState.Setup(m => m.GetTimeout()).Returns(1000);
+            var resourceName = "testResource";
+            var embeddedScriptName = "testScript.js";
+
+            // Mock a stream that is unreadable
+            var streamMock = new Mock<Stream>();
+            streamMock.Setup(s => s.CanRead).Returns(false); // Simulate an unreadable stream
+
+            var assemblyMock = new Mock<Assembly>();
+            assemblyMock.Setup(a => a.GetManifestResourceStream(resourceName))
+                .Returns(streamMock.Object); // Return the unreadable stream
+
+            ModelDrivenApplicationProvider.GetExecutingAssembly = () => assemblyMock.Object;
+
+            var provider = new ModelDrivenApplicationProvider(MockTestInfraFunctions.Object, MockSingleTestInstanceState.Object, MockTestState.Object);
+
+            // Act & Assert
+            await Assert.ThrowsAsync<ArgumentException>(async () =>
+            {
+                await provider.EmbedMDAJSScripts(resourceName, embeddedScriptName);
+            });
+        }
+
+        [Fact]
+        public async Task EmbedMDAJSScripts_RouteAsyncFails_ThrowsException()
+        {
+            // Arrange
+            MockSingleTestInstanceState.Setup(m => m.GetLogger()).Returns(MockLogger.Object);
+            MockTestState.Setup(m => m.GetTimeout()).Returns(1000);
+            var resourceName = "testResource";
+            var embeddedScriptName = "testScript.js";
+            var streamMock = new Mock<Stream>();
+            streamMock.Setup(s => s.CanRead).Returns(true);
+
+            var assemblyMock = new Mock<Assembly>();
+            assemblyMock.Setup(a => a.GetManifestResourceStream(resourceName))
+                .Returns(streamMock.Object);
+
+            ModelDrivenApplicationProvider.GetExecutingAssembly = () => assemblyMock.Object;
+
+            var pageMock = new Mock<IPage>();
+
+            // Simulate failure during RouteAsync
+            pageMock.Setup(p => p.RouteAsync(It.IsAny<string>(), It.IsAny<Func<IRoute, Task>>(), null))
+                .ThrowsAsync(new InvalidOperationException("RouteAsync failed"));
+
+            MockTestInfraFunctions.Setup(f => f.Page).Returns(pageMock.Object);
+
+            var provider = new ModelDrivenApplicationProvider(MockTestInfraFunctions.Object, MockSingleTestInstanceState.Object, MockTestState.Object);
+
+            // Act & Assert
+            await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            {
+                await provider.EmbedMDAJSScripts(resourceName, embeddedScriptName);
+            });
+        }
+
+        [Fact]
+        public async Task EmbedMDAJSScripts_AddScriptTagFails_ThrowsException()
+        {
+            // Arrange
+            MockSingleTestInstanceState.Setup(m => m.GetLogger()).Returns(MockLogger.Object);
+            MockTestState.Setup(m => m.GetTimeout()).Returns(1000);
+            var resourceName = "testResource";
+            var embeddedScriptName = "testScript.js";
+            var streamMock = new Mock<Stream>();
+            streamMock.Setup(s => s.CanRead).Returns(true);
+
+            var assemblyMock = new Mock<Assembly>();
+            assemblyMock.Setup(a => a.GetManifestResourceStream(resourceName))
+                .Returns(streamMock.Object);
+
+            ModelDrivenApplicationProvider.GetExecutingAssembly = () => assemblyMock.Object;
+
+            var pageMock = new Mock<IPage>();
+
+            // Simulate failure during AddScriptTagAsync
+            pageMock.Setup(p => p.AddScriptTagAsync(It.IsAny<PageAddScriptTagOptions>()))
+                .ThrowsAsync(new InvalidOperationException("AddScriptTagAsync failed"));
+
+            MockTestInfraFunctions.Setup(f => f.Page).Returns(pageMock.Object);
+
+            var provider = new ModelDrivenApplicationProvider(MockTestInfraFunctions.Object, MockSingleTestInstanceState.Object, MockTestState.Object);
+
+            // Act & Assert
+            await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            {
+                await provider.EmbedMDAJSScripts(resourceName, embeddedScriptName);
+            });
+        }
+
+        [Fact]
+        public async Task EmbedMDAJSScripts_EmbedsScriptSuccessfully()
+        {
+            // Arrange
+            MockSingleTestInstanceState.Setup(m => m.GetLogger()).Returns(MockLogger.Object);
+            MockTestState.Setup(m => m.GetTimeout()).Returns(1000);
+
+            var resourceName = "testResource";
+            var embeddedScriptName = "testScript.js";
+            string scriptContent = "console.log('test');"; // The content of the embedded JS file
+
+            // Create a mock memory stream to simulate reading the embedded resource
+            var memoryStream = new MemoryStream(Encoding.UTF8.GetBytes(scriptContent));
+
+            // Mock the assembly to return the memory stream for the resource
+            var assemblyMock = new Mock<Assembly>();
+            assemblyMock.Setup(a => a.GetManifestResourceStream(resourceName))
+                        .Returns(memoryStream);
+
+            // Replace the GetExecutingAssembly function with our mocked assembly
+            ModelDrivenApplicationProvider.GetExecutingAssembly = () => assemblyMock.Object;
+
+            // Calculate the expected script hash
+            string expectedScriptHash = "sha256-" + Convert.ToBase64String(SHA256.HashData(memoryStream.ToArray()));
+            string expectedScriptUrl = $"/{embeddedScriptName}?hash={expectedScriptHash}";
+
+            // Mocking the page and route fulfillment
+            var mockPage = new Mock<IPage>();
+            MockTestInfraFunctions.Setup(f => f.Page).Returns(mockPage.Object);
+            mockPage.Setup(p => p.RouteAsync(It.IsAny<string>(), It.IsAny<Func<IRoute, Task>>(), null)).Returns(Task.CompletedTask);
+            var mockElementHandle = new Mock<IElementHandle>();
+            mockPage.Setup(p => p.AddScriptTagAsync(It.IsAny<PageAddScriptTagOptions>())).ReturnsAsync(mockElementHandle.Object);
+
+            // Create the ModelDrivenApplicationProvider with mocked dependencies
+            var provider = new ModelDrivenApplicationProvider(MockTestInfraFunctions.Object, MockSingleTestInstanceState.Object, MockTestState.Object);
+
+            // Act
+            await provider.EmbedMDAJSScripts(resourceName, embeddedScriptName);
+
+            // Assert
+            // Verify that the RouteAsync method was called with the correct script URL containing the hash
+            mockPage.Verify(p => p.RouteAsync(It.Is<string>(url => url.Contains(expectedScriptHash)), It.IsAny<Func<IRoute, Task>>(), null), Times.Once);
+
+            // Verify that AddScriptTagAsync was called with the correct PageAddScriptTagOptions
+            mockPage.Verify(p => p.AddScriptTagAsync(It.Is<PageAddScriptTagOptions>(opt => opt.Url.Contains(expectedScriptHash))), Times.Once);
         }
     }
 }

--- a/src/testengine.provider.mda.tests/ModelDrivenApplicationProviderTest.cs
+++ b/src/testengine.provider.mda.tests/ModelDrivenApplicationProviderTest.cs
@@ -146,7 +146,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerApps
         [InlineData("class UCWorkBlockTracker {}", false)]
         [InlineData("class UCWorkBlockTracker { static isAppIdle() { return false; } }", false)]
         [InlineData("class UCWorkBlockTracker { static isAppIdle() { return true; } }", true)]
-        public void IsIdle(string javaScript, bool expectedIdle)
+        public async Task IsIdle(string javaScript, bool expectedIdle)
         {
             var engine = new Engine();
             engine.Execute(javaScript);
@@ -158,7 +158,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerApps
 
             // Act
             var provider = new ModelDrivenApplicationProvider(MockTestInfraFunctions.Object, MockSingleTestInstanceState.Object, MockTestState.Object);
-            var result = provider.CheckIsIdleAsync().Result;
+            var result = await provider.CheckIsIdleAsync();
 
             // Assert
             Assert.Equal(expectedIdle, result);
@@ -169,7 +169,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerApps
         [InlineData("class UCWorkBlockTracker {}", false)]
         [InlineData("class UCWorkBlockTracker { static isAppIdle() { return false; } }", false)]
         [InlineData("class UCWorkBlockTracker { static isAppIdle() { return true; } }", true)]
-        public void IsReady(string javaScript, bool expectedIdle)
+        public async Task IsReady(string javaScript, bool expectedIdle)
         {
             var engine = new Engine();
             engine.Execute(javaScript);
@@ -189,7 +189,7 @@ namespace Microsoft.PowerApps.TestEngine.Tests.PowerApps
 
             // Act
             var provider = new ModelDrivenApplicationProvider(MockTestInfraFunctions.Object, MockSingleTestInstanceState.Object, MockTestState.Object);
-            var result = provider.TestEngineReady().Result;
+            var result = await provider.TestEngineReady();
 
             // Assert
             Assert.Equal(expectedIdle, result);

--- a/src/testengine.provider.mda.tests/testengine.provider.mda.tests.csproj
+++ b/src/testengine.provider.mda.tests/testengine.provider.mda.tests.csproj
@@ -20,15 +20,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Jint" Version="3.1.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="Moq" Version="4.20.70" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="Jint" Version="4.0.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.2">
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/testengine.provider.mda/ModelDrivenApplicationProvider.cs
+++ b/src/testengine.provider.mda/ModelDrivenApplicationProvider.cs
@@ -247,7 +247,7 @@ namespace Microsoft.PowerApps.TestEngine.Providers
             SingleTestInstanceState.GetLogger().LogDebug($"Finish loading PowerAppsTestEngine.");
         }
 
-        // defining this for improved testability
+        // defining this for improved testability, this needs the tear down (dispose method) for it to not carry over between tests
         internal static Func<Assembly> GetExecutingAssembly = () => Assembly.GetExecutingAssembly();
 
         internal async Task EmbedMDAJSScripts(string resourceName, string embeddedScriptName)

--- a/src/testengine.provider.mda/PowerAppsTestEngineMDA.js
+++ b/src/testengine.provider.mda/PowerAppsTestEngineMDA.js
@@ -1,276 +1,13 @@
 // WARNING:
 // The JavaScript object model of the page is subject to change. Do not take dependencies on the implementation of methods as they could be updated
-
-class PowerAppsModelDrivenCanvas {
-    static getAppMagic() {
-        if (typeof AppDependencyHandler === "undefined" || typeof AppDependencyHandler.containers === "undefined") {
-            return undefined;
-        }
-        var key = Object.keys(AppDependencyHandler.containers).filter(k => k != AppDependencyHandler.prebuiltContainerId && AppDependencyHandler.containers[k] != null)
-        if (key.length == 0) {
-            return undefined;
-        }
-        return AppDependencyHandler.containers[key[0]].AppMagic;
-    }
-
-    static executePublishedAppScript(scriptToExecute) {
-        var promise = new Promise((resolve) => {
-            var result = eval(scriptToExecute);
-            resolve(result)
-        });
-
-        return promise;
-    }
-
-    static getOngoingActionsInPublishedApp() {
-        return PowerAppsModelDrivenCanvas.executePublishedAppScript("AppDependencyHandler.containers[Object.keys(AppDependencyHandler.containers).filter(k => k != AppDependencyHandler.prebuiltContainerId)[0]].AppMagic.AuthoringTool.Runtime.existsOngoingAsync()");
-    }
-
-    static getControlObjectModel() {
-        return PowerAppsModelDrivenCanvas.executePublishedAppScript("PowerAppsTestEngine.buildControlObjectModel()");
-    }
-
-    static getPropertyValueFromPublishedApp(itemPath) {
-        var script = `PowerAppsModelDrivenCanvas.getPropertyValueFromControl(${JSON.stringify(itemPath)})`;
-        return PowerAppsModelDrivenCanvas.executePublishedAppScript(script);
-    }
-
-    static getPropertyValueFromPublishedApp(itemPath) {
-        var script = `PowerAppsModelDrivenCanvas.getPropertyValueFromControl(${JSON.stringify(itemPath)})`;
-        return PowerAppsModelDrivenCanvas.executePublishedAppScript(script);
-    }
-
-    static selectControl(itemPath) {
-        var script = `PowerAppsModelDrivenCanvas.selectControl(${JSON.stringify(itemPath)})`;
-        return PowerAppsModelDrivenCanvas.executePublishedAppScript(script);
-    }
-
-    static interactWithControl(itemPath, value) {
-        var script = "";
-        if (isArray(Object.values(value))) {
-            var valuesJsonArr = [];
-            var values = Object.values(value);
-            for (var index in values) {
-                valuesJsonArr[`${index}`] = `${JSON.stringify(values[index])}`;
-            }
-            var valueJson = `{"${itemPath.propertyName}":${valuesJsonArr}}`;
-            script = `PowerAppsModelDrivenCanvas.interactWithControl(${JSON.stringify(itemPath)}, ${valueJson})`;
-        } else {
-            var valueJson = `{"${itemPath.propertyName}":${value}}`;
-            script = `PowerAppsModelDrivenCanvas.interactWithControl(${JSON.stringify(itemPath)}, ${valueJson})`;
-        }
-        return PowerAppsModelDrivenCanvas.executePublishedAppScript(script);
-    }
-
-    static setPropertyValueForControl(itemPath, value) {
-        if (typeof value == "object") {
-            return PowerAppsModelDrivenCanvas.interactWithControl(itemPath, value);
-        } else if (typeof value == "string") {
-            value = JSON.stringify(value);
-        }
-        var script = `PowerAppsModelDrivenCanvas.setPropertyValueForControl(${JSON.stringify(itemPath)}, ${value})`;
-        return PowerAppsModelDrivenCanvas.executePublishedAppScript(script);
-    }
-
-    static fetchArrayItemCount(itemPath) {
-        var script = `PowerAppsModelDrivenCanvas.fetchArrayItemCount(${JSON.stringify(itemPath)})`;
-        return PowerAppsModelDrivenCanvas.executePublishedAppScript(script);
-    }
-
-    static isArray(obj) {
-        return obj.constructor === Array;
-    }
-
-    static parseControl(controlName, controlObject) {
-        var propertiesList = [];
-        var properties = Object.keys(controlObject.modelProperties);
-        var controls = [];
-        if (controlObject.controlWidget.replicatedContextManager) {
-            var childrenControlContext = controlObject.controlWidget.replicatedContextManager.authoringAreaBindingContext.controlContexts;
-            var childControlNames = Object.keys(childrenControlContext);
-            childControlNames.forEach((childControlName) => {
-                var childControlObject = childrenControlContext[childControlName];
-                var childControlsList = PowerAppsModelDrivenCanvas.parseControl(childControlName, childControlObject);
-                controls = controls.concat(childControlsList);
-            });
-        }
-
-        var appMagic = PowerAppsModelDrivenCanvas.getAppMagic()
-
-        var componentBindingContext = appMagic.Controls.GlobalContextManager.bindingContext.componentBindingContexts.lookup(controlName);
-        if (componentBindingContext) {
-            var componentChildrenControlContext = componentBindingContext.controlContexts;
-            var componentChildrenControlNames = Object.keys(componentChildrenControlContext);
-            componentChildrenControlNames.forEach((childControlName) => {
-                if (childControlName !== controlName) {
-                    var componentChildControlObject = componentChildrenControlContext[childControlName];
-                    var childControlsList = PowerAppsModelDrivenCanvas.parseControl(childControlName, componentChildControlObject);
-                    controls = controls.concat(childControlsList);
-                    propertiesList.push({ propertyName: childControlName, propertyType: childControlName });
-                }
-            });
-        }
-
-        properties.forEach((propertyName) => {
-            var propertyType = controlObject.controlWidget.controlProperties[propertyName].propertyType;
-
-            propertiesList.push({ propertyName: propertyName, propertyType: propertyType });
-        })
-
-        var control = { name: controlName, properties: propertiesList };
-        controls.push(control);
-
-        return controls;
-    }
-
-    static fetchArrayItemCount(itemPath) {
-        if (itemPath.parentControl && itemPath.parentControl.index === null) {
-            // Components do not have an item count
-            throw "Not a gallery, no item count available. Most likely a component";
-        }
-
-        var appMagic = PowerAppsModelDrivenCanvas.getAppMagic();
-
-        var replicatedContexts = appMagic.Controls.GlobalContextManager.bindingContext.replicatedContexts
-
-        if (itemPath.parentControl && itemPath.parentControl.index !== null) {
-            // Nested gallery - Power Apps only supports one level of nesting so we don't have to go recursively to find it
-            // Get parent replicated context
-            replicatedContexts = OpenAjax.widget.byId(itemPath.parentControl.controlName).OpenAjax.getAuthoringControlContext()._replicatedContext.bindingContextAt(itemPath.parentControl.index).replicatedContexts;
-        }
-
-        var replicatedContext = OpenAjax.widget.byId(itemPath.controlName).OpenAjax.getAuthoringControlContext()._replicatedContext;
-
-        if (!replicatedContext) {
-            // This is not a gallery
-            throw "Not a gallery, no item count available. Most likely a control";
-        }
-
-        var managerId = replicatedContext.manager.managerId;
-        return replicatedContexts[managerId].getBindingContextCount()
-    }
-
-    static getBindingContext(itemPath) {
-        var appMagic = PowerAppsModelDrivenCanvas.getAppMagic()
-
-        var bindingContext = appMagic.Controls?.GlobalContextManager?.bindingContext;
-
-        if (itemPath.parentControl) {
-            // Control is inside a component or gallery
-            bindingContext = PowerAppsModelDrivenCanvas.getBindingContext(itemPath.parentControl);
-        }
-
-        if (typeof itemPath.index !== 'undefined' && itemPath.index !== null) {
-            // Gallery control
-            var managerId = OpenAjax.widget.byId(itemPath.controlName).OpenAjax.getAuthoringControlContext()._replicatedContext.manager.managerId;
-            return bindingContext.replicatedContexts[managerId].bindingContextAt(itemPath.index);
-        }
-
-        var componentBindingContext = appMagic.Controls.GlobalContextManager.bindingContext.componentBindingContexts.lookup(itemPath.controlName);
-
-        if (typeof componentBindingContext !== 'undefined') {
-            // Component control
-            return componentBindingContext;
-        }
-
-        return bindingContext;
-    }
-
-    static getPropertyValueFromControl(itemPath) {
-        var bindingContext = PowerAppsModelDrivenCanvas.getBindingContext(itemPath);
-
-        var propertyValue = undefined
-
-        var controlContext = bindingContext.controlContexts[itemPath.controlName];
-
-        if (controlContext) {
-            if (controlContext.modelProperties[itemPath.propertyName]) {
-                propertyValue = controlContext.modelProperties[itemPath.propertyName]?.getValue();
-            }
-        }
-
-        return {
-            propertyValue: propertyValue
-        };
-    }
-
-    static selectControl(itemPath) {
-        var appMagic = PowerAppsModelDrivenCanvas.getAppMagic();
-
-        var screenId = appMagic.AuthoringTool.Runtime.getNamedControl(appMagic.AuthoringTool.Runtime.getCurrentScreenName()).OpenAjax.uniqueId;
-
-        if (itemPath.parentControl && itemPath.parentControl.index !== null) {
-            // Gallery
-            var bindingContext = appMagic.Controls.GlobalContextManager.bindingContext;
-            if (itemPath.parentControl.parentControl) {
-                // Nested gallery
-                bindingContext = PowerAppsModelDrivenCanvas.getBindingContext(itemPath.parentControl);
-                var currentControl = bindingContext.controlContexts[itemPath.controlName].controlWidget;
-                return appMagic.Functions.select(null,
-                    bindingContext,
-                    currentControl.control,
-                    null, // row number
-                    null, // child control
-                    screenId)
-            }
-            else {
-                // One level gallery - the nested gallery approach doesn't work for one level so we have to do it differently
-                // select function is starts with 1, while the C# code indexes from 0
-                rowOrColumnNumber = itemPath.parentControl.index + 1;
-                return appMagic.Functions.select(null,
-                    bindingContext,
-                    appMagic.AuthoringTool.Runtime.getNamedControl(itemPath.parentControl.controlName),
-                    rowOrColumnNumber,
-                    appMagic.AuthoringTool.Runtime.getNamedControl(itemPath.controlName).OpenAjax._icontrol,
-                    screenId)
-            }
-        }
-
-        if (itemPath.parentControl) {
-            // Component
-            var bindingContext = appMagic.Controls.GlobalContextManager.bindingContext.componentBindingContexts.lookup(itemPath.parentControl.controlName);
-            var buttonWidget = bindingContext.controlContexts[itemPath.controlName].controlWidget;
-            var controlContext = buttonWidget.getOnSelectControlContext(bindingContext);
-            buttonWidget.select(controlContext);
-            return true;
-        }
-
-        return appMagic.Functions.select(null,
-            appMagic.Controls.GlobalContextManager.bindingContext,
-            appMagic.AuthoringTool.Runtime.getNamedControl(itemPath.controlName),
-            null,
-            null,
-            screenId);
-    }
-
-    static setPropertyValueForControl(itemPath, value) {
-        var appMagic = PowerAppsModelDrivenCanvas.getAppMagic()
-
-        if (itemPath.parentControl && itemPath.parentControl.index !== null) {
-            // Gallery & Nested gallery
-            var galleryBindingContext = PowerAppsModelDrivenCanvas.getBindingContext(itemPath.parentControl);
-            return appMagic.AuthoringTool.Runtime.getNamedControl(itemPath.controlName, galleryBindingContext).OpenAjax.setPropertyValueInternal(itemPath.propertyName, value, galleryBindingContext)
-        }
-
-        if (itemPath.parentControl) {
-            // Component
-            var componentBindingContext = appMagic.Controls.GlobalContextManager.bindingContext.componentBindingContexts.lookup(itemPath.parentControl.controlName);
-            return (appMagic.AuthoringTool.Runtime.getNamedControl(itemPath.controlName, componentBindingContext).OpenAjax.setPropertyValueInternal(itemPath.propertyName, value, componentBindingContext));
-        }
-
-        return appMagic.AuthoringTool.Runtime.getNamedControl(itemPath.controlName, appMagic.Controls.GlobalContextManager.bindingContext).OpenAjax.setPropertyValueInternal(itemPath.propertyName, value, appMagic.Controls.GlobalContextManager.bindingContext);
-    }
-
-    static interactWithControl(itemPath, value) {
-        var appMagic = PowerAppsModelDrivenCanvas.getAppMagic()
-
-        var e = appMagic.AuthoringTool.Runtime.getNamedControl(itemPath.controlName, appMagic.Controls.GlobalContextManager.bindingContext).OpenAjax.interactWithControlAsync(appMagic.Controls.GlobalContextManager.bindingContext.controlContexts[itemPath.controlName], value).then(() => true, () => false);
-
-        return e._value;
-    }
-}
-
 class PowerAppsTestEngine {
+    static CONSTANTS = Object.freeze({
+        EntityList: "entitylist",
+        Custom: "custom",
+        EntityRecord: "entityrecord",
+        Dashboard: "dashboard"
+    });
+
     static idleStatus() {
         // Reference:
         // https://github.com/microsoft/EasyRepro/blob/1935401875313a9059481d8af0a3708f66a3fe08/Microsoft.Dynamics365.UIAutomation.Browser/Extensions/SeleniumExtensions.cs#L347
@@ -287,56 +24,22 @@ class PowerAppsTestEngine {
 
     static buildControlObjectModel() {
         switch (PowerAppsTestEngine.pageType()) {
-            case 'entitylist':
+            case PowerAppsTestEngine.CONSTANTS.EntityList:
                 // TODO - Load list as collection
                 break;
-            case 'custom':
-                var appMagic = PowerAppsModelDrivenCanvas.getAppMagic()
-
-                var controls = [];
-                var controlContext = appMagic.Controls.GlobalContextManager.bindingContext.controlContexts;
-                var controlNames = Object.keys(controlContext);
-                controlNames.forEach((controlName) => {
-                    var control = controlContext[controlName];
-                    var controlList = PowerAppsModelDrivenCanvas.parseControl(controlName, control);
-                    controls = controls.concat(controlList);
-                });
-
-                return JSON.stringify({ Controls: controls });
-            case 'entityrecord':
-                // TODO - Load Grid and Other control type
-
-                // Reference
-                // https://learn.microsoft.com/en-us/power-apps/developer/model-driven-apps/clientapi/reference/controls
-                return JSON.stringify({
-                    Controls: Xrm.Page.ui.controls.getAll().map(item => {
-                        var control = {};
-                        control.Name = item.getName();
-                        control.Properties = [];
-                        control.Properties.push({ PropertyName: 'Disabled', PropertyType: 'b' });
-                        control.Properties.push({ PropertyName: 'ShowLabel', PropertyType: 'b' });
-                        control.Properties.push({ PropertyName: 'Label', PropertyType: 's' });
-                        control.Properties.push({ PropertyName: 'Visible', PropertyType: 'b' });
-                        control.Properties.push({ PropertyName: 'IsRequired', PropertyType: 'b' });
-                        control.Properties.push({ PropertyName: 'Type', PropertyType: 's' });
-                        // TODO Handle non standard controls
-
-                        // Reference
-                        // https://learn.microsoft.com/en-us/power-apps/developer/model-driven-apps/clientapi/reference/controls/getcontroltype
-                        switch (item.getControlType()) {
-                            case 'standard':
-                                control.Properties.push({ PropertyName: 'Text', PropertyType: 's' });
-                                break;
-                        }
-                        return control;
-                    })
-                })
+            case PowerAppsTestEngine.CONSTANTS.Custom:
+                return PowerAppsModelDrivenCanvas.buildControlObjectModel();
+            case PowerAppsTestEngine.CONSTANTS.EntityRecord:
+                return PowerAppsModelDrivenEntityRecord.buildControlObjectModel();
         }
     }
 
     static getPropertyValue(itemPath) {
+        if (typeof itemPath === 'string') {
+            itemPath = JSON.parse(itemPath)
+        }
         switch (PowerAppsTestEngine.pageType()) {
-            case 'custom':
+            case PowerAppsTestEngine.CONSTANTS.Custom:
                 // TODO
                 break;
         }
@@ -344,16 +47,11 @@ class PowerAppsTestEngine {
 
     static getValue(name) {
         switch (PowerAppsTestEngine.pageType()) {
-            case 'custom':
+            case PowerAppsTestEngine.CONSTANTS.Custom:
                 // TODO
                 break;
-            case 'entityrecord':
-                // TODO: Handle multiple control types. For example lookup, grids
-
-                // References:
-                // https://learn.microsoft.com/en-us/power-apps/developer/model-driven-apps/clientapi/reference/controls
-                // https://learn.microsoft.com/en-us/power-apps/developer/model-driven-apps/clientapi/reference/controls/getvalue
-                return Xrm.Page.ui.controls.getByName(name).getValue();
+            case PowerAppsTestEngine.CONSTANTS.EntityRecord:
+                return PowerAppsModelDrivenEntityRecord.getValue(name);
         }
     }    
 
@@ -365,109 +63,50 @@ class PowerAppsTestEngine {
         }
 
         switch (PowerAppsTestEngine.pageType()) {
-            case 'custom':
-                var appMagic = PowerAppsModelDrivenCanvas.getAppMagic()
-
-                var controls = [];
-                var controlContext = appMagic.Controls.GlobalContextManager.bindingContext.controlContexts;
-                var controlNames = Object.keys(controlContext);
-                controlNames.forEach((controlName) => {
-                    var control = controlContext[controlName];
-                    var controlList = PowerAppsModelDrivenCanvas.parseControl(controlName, control);
-                    controls = controls.concat(controlList);
-                });
-
-                var match = controls.filter(c => c.name == itemPath.controlName);
-                if (match.length >= 0 && typeof match[0] == 'object') {
-                    match[0].properties.forEach((item) => {
-                        data.push(
-                            {
-                                Key: item.propertyName,
-                                Value: PowerAppsModelDrivenCanvas.getPropertyValueFromControl({ controlName: itemPath.controlName, propertyName: item.propertyName })?.propertyValue
-                            })
-                    })
-                }
-
-                break;
-            case 'entitylist':
-                // TODO: Get Grid properties
-                var row = getCurrentXrmStatus().mainGrid.getGrid().getRows().get(0).data.entity.attributes.getAll();
-                break;
-            case 'entityrecord':
-                // WARNING:
-                // controlDescriptor JavaScript object is subject to change. Do not take dependencies on the object or properties returned as they could change without notice.
-                var controlDescriptor = Xrm.Page.ui.controls.getByName(itemPath.controlName).controlDescriptor;
-
-                // Alternative: https://learn.microsoft.com/en-us/power-apps/developer/model-driven-apps/clientapi/reference/controls/getdisabled
-                data.push({ Key: 'Disabled', Value: controlDescriptor.Disabled.toString().toLowerCase() });
-                data.push({ Key: 'ShowLabel', Value: controlDescriptor.ShowLabel.toString().toLowerCase() });
-                if (controlDescriptor.ShowLabel) {
-                    // Alternative https://learn.microsoft.com/en-us/power-apps/developer/model-driven-apps/clientapi/reference/controls/getlabel
-                    data.push({ Key: 'Label', Value: controlDescriptor.Label });
-                }
-                // Alternative: https://learn.microsoft.com/en-us/power-apps/developer/model-driven-apps/clientapi/reference/controls/getvisible
-                data.push({ Key: 'Visible', Value: controlDescriptor.Visible.toString().toLowerCase() });
-                data.push({ Key: 'IsRequired', Value: controlDescriptor.IsRequired.toString().toLowerCase() });
-                break;
+            case PowerAppsTestEngine.CONSTANTS.Custom:
+                return PowerAppsModelDrivenCanvas.getControlProperties(itemPath);
+            case PowerAppsTestEngine.CONSTANTS.EntityRecord:
+                return PowerAppsModelDrivenEntityRecord.getControlProperties(itemPath);
         }
         return JSON.stringify(data);
     }
     
     static setPropertyValue(item, data) {
+        if (typeof item === 'string') {
+            item = JSON.parse(item)
+        }
         switch (PowerAppsTestEngine.pageType()) {
-            case 'custom':
+            case PowerAppsTestEngine.CONSTANTS.Custom:
                 return PowerAppsModelDrivenCanvas.setPropertyValueForControl(item, data);
-            case 'entityrecord':
-                var control = Xrm.Page.ui.controls.getByName(item.controlName);
-                var propertyName = typeof item.propertyName === 'string' ? item.propertyName.toLowerCase() : ''
-                // TODO - Set the Xrm SDK Value and update state for any JS to run
-                // TODO: Handle Grid
-                switch (propertyName) {
-                    case '':
-                    case 'text':
-                        // https://learn.microsoft.com/power-apps/developer/model-driven-apps/clientapi/reference/controls/getattribute
-                        var attribute = control.getAttribute();
-                        // https://learn.microsoft.com/power-apps/developer/model-driven-apps/clientapi/reference/attributes/setvalue
-                        // TODO: Handle different control types. For example lookup, options
-                        attribute.setValue(data);
-                        attribute.fireOnChange();
-                        return true;
-                    case 'label':
-                        // https://learn.microsoft.com/power-apps/developer/model-driven-apps/clientapi/reference/controls/setlabel
-                        control.setLabel(data);
-                        return true;
-                    case 'disabled':
-                        // https://learn.microsoft.com/power-apps/developer/model-driven-apps/clientapi/reference/controls/setdisabled
-                        control.setDisabled(data);
-                        return true;
-                    case 'visible':
-                        // https://learn.microsoft.com/power-apps/developer/model-driven-apps/clientapi/reference/controls/setvisible
-                        control.setVisible(data);
-                        return true;
-                }
-                return false;
-                break;
+            case PowerAppsTestEngine.CONSTANTS.EntityRecord:
+                return PowerAppsModelDrivenEntityRecord.setPropertyValueForControl(item, data);
         }
         return false;
     }
     
     static getItemCount(itemPath) {
+        if (typeof itemPath === 'string') {
+            itemPath = JSON.parse(itemPath)
+        }
         switch (PowerAppsTestEngine.pageType()) {
-            case 'custom':
+            case PowerAppsTestEngine.CONSTANTS.Custom:
                 return PowerAppsModelDrivenCanvas.fetchArrayItemCount(itemPath);
-            case 'entitylist':
+            case PowerAppsTestEngine.CONSTANTS.EntityList:
                 return PowerAppsModelDrivenCanvas.fetchArrayItemCount(itemPath);
-            case 'entityrecord':
+            case PowerAppsTestEngine.CONSTANTS.EntityRecord:
                 // TODO - Get count of items for name
                 break;
         }
     }
 
     static select(itemPath) {
+        if (typeof itemPath === 'string') {
+            itemPath = JSON.parse(itemPath)
+        }
         switch (PowerAppsTestEngine.pageType()) {
-            case 'custom':
+            case PowerAppsTestEngine.CONSTANTS.Custom:
                 return PowerAppsModelDrivenCanvas.selectControl(itemPath);
-            case 'entityrecord':
+            case PowerAppsTestEngine.CONSTANTS.EntityRecord:
                 // TODO - Selectitem
                 break;
         }

--- a/src/testengine.provider.mda/PowerAppsTestEngineMDACustom.js
+++ b/src/testengine.provider.mda/PowerAppsTestEngineMDACustom.js
@@ -1,0 +1,314 @@
+﻿// WARNING:
+// The JavaScript object model of the page is subject to change. Do not take dependencies on the implementation of methods as they could be updated
+
+class PowerAppsModelDrivenCanvas {
+    static getAppMagic() {
+        if (typeof AppDependencyHandler === "undefined" || typeof AppDependencyHandler.containers === "undefined") {
+            return undefined;
+        }
+        var key = Object.keys(AppDependencyHandler.containers).filter(k => k != AppDependencyHandler.prebuiltContainerId && AppDependencyHandler.containers[k] != null)
+        if (key.length == 0) {
+            return undefined;
+        }
+        return AppDependencyHandler.containers[key[0]].AppMagic;
+    }
+
+    static executePublishedAppScript(scriptToExecute) {
+        var promise = new Promise((resolve) => {
+            var result = eval(scriptToExecute);
+            resolve(result)
+        });
+
+        return promise;
+    }
+
+    static getOngoingActionsInPublishedApp() {
+        return PowerAppsModelDrivenCanvas.executePublishedAppScript("AppDependencyHandler.containers[Object.keys(AppDependencyHandler.containers).filter(k => k != AppDependencyHandler.prebuiltContainerId)[0]].AppMagic.AuthoringTool.Runtime.existsOngoingAsync()");
+    }
+
+    static getControlObjectModel() {
+        return PowerAppsModelDrivenCanvas.executePublishedAppScript("PowerAppsTestEngine.buildControlObjectModel()");
+    }
+
+    static getPropertyValueFromPublishedApp(itemPath) {
+        var script = `PowerAppsModelDrivenCanvas.getPropertyValueFromControl(${JSON.stringify(itemPath)})`;
+        return PowerAppsModelDrivenCanvas.executePublishedAppScript(script);
+    }
+
+    static getPropertyValueFromPublishedApp(itemPath) {
+        var script = `PowerAppsModelDrivenCanvas.getPropertyValueFromControl(${JSON.stringify(itemPath)})`;
+        return PowerAppsModelDrivenCanvas.executePublishedAppScript(script);
+    }
+
+    static selectControl(itemPath) {
+        var script = `PowerAppsModelDrivenCanvas.selectControl(${JSON.stringify(itemPath)})`;
+        return PowerAppsModelDrivenCanvas.executePublishedAppScript(script);
+    }
+
+    static interactWithControl(itemPath, value) {
+        var script = "";
+        if (isArray(Object.values(value))) {
+            var valuesJsonArr = [];
+            var values = Object.values(value);
+            for (var index in values) {
+                valuesJsonArr[`${index}`] = `${JSON.stringify(values[index])}`;
+            }
+            var valueJson = `{"${itemPath.propertyName}":${valuesJsonArr}}`;
+            script = `PowerAppsModelDrivenCanvas.interactWithControl(${JSON.stringify(itemPath)}, ${valueJson})`;
+        } else {
+            var valueJson = `{"${itemPath.propertyName}":${value}}`;
+            script = `PowerAppsModelDrivenCanvas.interactWithControl(${JSON.stringify(itemPath)}, ${valueJson})`;
+        }
+        return PowerAppsModelDrivenCanvas.executePublishedAppScript(script);
+    }
+
+    static setPropertyValueForControl(itemPath, value) {
+        if (typeof value == "object") {
+            return PowerAppsModelDrivenCanvas.interactWithControl(itemPath, value);
+        } else if (typeof value == "string") {
+            value = JSON.stringify(value);
+        }
+        var script = `PowerAppsModelDrivenCanvas.setPropertyValueForControl(${JSON.stringify(itemPath)}, ${value})`;
+        return PowerAppsModelDrivenCanvas.executePublishedAppScript(script);
+    }
+
+    static fetchArrayItemCount(itemPath) {
+        var script = `PowerAppsModelDrivenCanvas.fetchArrayItemCount(${JSON.stringify(itemPath)})`;
+        return PowerAppsModelDrivenCanvas.executePublishedAppScript(script);
+    }
+
+    static isArray(obj) {
+        return obj.constructor === Array;
+    }
+
+    static parseControl(controlName, controlObject) {
+        var propertiesList = [];
+        var properties = Object.keys(controlObject.modelProperties);
+        var controls = [];
+        if (controlObject.controlWidget.replicatedContextManager) {
+            var childrenControlContext = controlObject.controlWidget.replicatedContextManager.authoringAreaBindingContext.controlContexts;
+            var childControlNames = Object.keys(childrenControlContext);
+            childControlNames.forEach((childControlName) => {
+                var childControlObject = childrenControlContext[childControlName];
+                var childControlsList = PowerAppsModelDrivenCanvas.parseControl(childControlName, childControlObject);
+                controls = controls.concat(childControlsList);
+            });
+        }
+
+        var appMagic = PowerAppsModelDrivenCanvas.getAppMagic()
+
+        var componentBindingContext = appMagic.Controls.GlobalContextManager.bindingContext.componentBindingContexts.lookup(controlName);
+        if (componentBindingContext) {
+            var componentChildrenControlContext = componentBindingContext.controlContexts;
+            var componentChildrenControlNames = Object.keys(componentChildrenControlContext);
+            componentChildrenControlNames.forEach((childControlName) => {
+                if (childControlName !== controlName) {
+                    var componentChildControlObject = componentChildrenControlContext[childControlName];
+                    var childControlsList = PowerAppsModelDrivenCanvas.parseControl(childControlName, componentChildControlObject);
+                    controls = controls.concat(childControlsList);
+                    propertiesList.push({ propertyName: childControlName, propertyType: childControlName });
+                }
+            });
+        }
+
+        properties.forEach((propertyName) => {
+            var propertyType = controlObject.controlWidget.controlProperties[propertyName].propertyType;
+
+            propertiesList.push({ propertyName: propertyName, propertyType: propertyType });
+        })
+
+        var control = { name: controlName, properties: propertiesList };
+        controls.push(control);
+
+        return controls;
+    }
+
+    static fetchArrayItemCount(itemPath) {
+        if (itemPath.parentControl && itemPath.parentControl.index === null) {
+            // Components do not have an item count
+            throw "Not a gallery, no item count available. Most likely a component";
+        }
+
+        var appMagic = PowerAppsModelDrivenCanvas.getAppMagic();
+
+        var replicatedContexts = appMagic.Controls.GlobalContextManager.bindingContext.replicatedContexts
+
+        if (itemPath.parentControl && itemPath.parentControl.index !== null) {
+            // Nested gallery - Power Apps only supports one level of nesting so we don't have to go recursively to find it
+            // Get parent replicated context
+            replicatedContexts = OpenAjax.widget.byId(itemPath.parentControl.controlName).OpenAjax.getAuthoringControlContext()._replicatedContext.bindingContextAt(itemPath.parentControl.index).replicatedContexts;
+        }
+
+        var replicatedContext = OpenAjax.widget.byId(itemPath.controlName).OpenAjax.getAuthoringControlContext()._replicatedContext;
+
+        if (!replicatedContext) {
+            // This is not a gallery
+            throw "Not a gallery, no item count available. Most likely a control";
+        }
+
+        var managerId = replicatedContext.manager.managerId;
+        return replicatedContexts[managerId].getBindingContextCount()
+    }
+
+    static getBindingContext(itemPath) {
+        var appMagic = PowerAppsModelDrivenCanvas.getAppMagic()
+
+        var bindingContext = appMagic.Controls?.GlobalContextManager?.bindingContext;
+
+        if (itemPath.parentControl) {
+            // Control is inside a component or gallery
+            bindingContext = PowerAppsModelDrivenCanvas.getBindingContext(itemPath.parentControl);
+        }
+
+        if (typeof itemPath.index !== 'undefined' && itemPath.index !== null) {
+            // Gallery control
+            var managerId = OpenAjax.widget.byId(itemPath.controlName).OpenAjax.getAuthoringControlContext()._replicatedContext.manager.managerId;
+            return bindingContext.replicatedContexts[managerId].bindingContextAt(itemPath.index);
+        }
+
+        var componentBindingContext = appMagic.Controls.GlobalContextManager.bindingContext.componentBindingContexts.lookup(itemPath.controlName);
+
+        if (typeof componentBindingContext !== 'undefined') {
+            // Component control
+            return componentBindingContext;
+        }
+
+        return bindingContext;
+    }
+
+    static getPropertyValueFromControl(itemPath) {
+        var bindingContext = PowerAppsModelDrivenCanvas.getBindingContext(itemPath);
+
+        var propertyValue = undefined
+
+        var controlContext = bindingContext.controlContexts[itemPath.controlName];
+
+        if (controlContext) {
+            if (controlContext.modelProperties[itemPath.propertyName]) {
+                propertyValue = controlContext.modelProperties[itemPath.propertyName]?.getValue();
+            }
+        }
+
+        return {
+            propertyValue: propertyValue
+        };
+    }
+
+    static selectControl(itemPath) {
+        var appMagic = PowerAppsModelDrivenCanvas.getAppMagic();
+
+        var screenId = appMagic.AuthoringTool.Runtime.getNamedControl(appMagic.AuthoringTool.Runtime.getCurrentScreenName()).OpenAjax.uniqueId;
+
+        if (itemPath.parentControl && itemPath.parentControl.index !== null) {
+            // Gallery
+            var bindingContext = appMagic.Controls.GlobalContextManager.bindingContext;
+            if (itemPath.parentControl.parentControl) {
+                // Nested gallery
+                bindingContext = PowerAppsModelDrivenCanvas.getBindingContext(itemPath.parentControl);
+                var currentControl = bindingContext.controlContexts[itemPath.controlName].controlWidget;
+                return appMagic.Functions.select(null,
+                    bindingContext,
+                    currentControl.control,
+                    null, // row number
+                    null, // child control
+                    screenId)
+            }
+            else {
+                // One level gallery - the nested gallery approach doesn't work for one level so we have to do it differently
+                // select function is starts with 1, while the C# code indexes from 0
+                var rowOrColumnNumber = itemPath.parentControl.index + 1;
+                return appMagic.Functions.select(null,
+                    bindingContext,
+                    appMagic.AuthoringTool.Runtime.getNamedControl(itemPath.parentControl.controlName),
+                    rowOrColumnNumber,
+                    appMagic.AuthoringTool.Runtime.getNamedControl(itemPath.controlName).OpenAjax._icontrol,
+                    screenId)
+            }
+        }
+
+        if (itemPath.parentControl) {
+            // Component
+            var bindingContext = appMagic.Controls.GlobalContextManager.bindingContext.componentBindingContexts.lookup(itemPath.parentControl.controlName);
+            var buttonWidget = bindingContext.controlContexts[itemPath.controlName].controlWidget;
+            var controlContext = buttonWidget.getOnSelectControlContext(bindingContext);
+            buttonWidget.select(controlContext);
+            return true;
+        }
+
+        return appMagic.Functions.select(null,
+            appMagic.Controls.GlobalContextManager.bindingContext,
+            appMagic.AuthoringTool.Runtime.getNamedControl(itemPath.controlName),
+            null,
+            null,
+            screenId);
+    }
+
+    static setPropertyValueForControl(itemPath, value) {
+        var appMagic = PowerAppsModelDrivenCanvas.getAppMagic()
+
+        if (itemPath.parentControl && itemPath.parentControl.index !== null) {
+            // Gallery & Nested gallery
+            var galleryBindingContext = PowerAppsModelDrivenCanvas.getBindingContext(itemPath.parentControl);
+            return appMagic.AuthoringTool.Runtime.getNamedControl(itemPath.controlName, galleryBindingContext).OpenAjax.setPropertyValueInternal(itemPath.propertyName, value, galleryBindingContext)
+        }
+
+        if (itemPath.parentControl) {
+            // Component
+            var componentBindingContext = appMagic.Controls.GlobalContextManager.bindingContext.componentBindingContexts.lookup(itemPath.parentControl.controlName);
+            return (appMagic.AuthoringTool.Runtime.getNamedControl(itemPath.controlName, componentBindingContext).OpenAjax.setPropertyValueInternal(itemPath.propertyName, value, componentBindingContext));
+        }
+
+        return appMagic.AuthoringTool.Runtime.getNamedControl(itemPath.controlName, appMagic.Controls.GlobalContextManager.bindingContext).OpenAjax.setPropertyValueInternal(itemPath.propertyName, value, appMagic.Controls.GlobalContextManager.bindingContext);
+    }
+
+    static interactWithControl(itemPath, value) {
+        var appMagic = PowerAppsModelDrivenCanvas.getAppMagic()
+
+        var e = appMagic.AuthoringTool.Runtime.getNamedControl(itemPath.controlName, appMagic.Controls.GlobalContextManager.bindingContext).OpenAjax.interactWithControlAsync(appMagic.Controls.GlobalContextManager.bindingContext.controlContexts[itemPath.controlName], value).then(() => true, () => false);
+
+        return e._value;
+    }
+
+    static buildControlObjectModel()
+    {
+        var appMagic = PowerAppsModelDrivenCanvas.getAppMagic()
+
+        var controls = [];
+        var controlContext = appMagic.Controls.GlobalContextManager.bindingContext.controlContexts;
+        var controlNames = Object.keys(controlContext);
+        controlNames.forEach((controlName) => {
+            var control = controlContext[controlName];
+            var controlList = PowerAppsModelDrivenCanvas.parseControl(controlName, control);
+            controls = controls.concat(controlList);
+        });
+
+        return JSON.stringify({ Controls: controls });
+    }
+
+    static getControlProperties(itemPath)
+    {
+        var data = [];
+        var appMagic = PowerAppsModelDrivenCanvas.getAppMagic()
+
+        var controls = [];
+        var controlContext = appMagic.Controls.GlobalContextManager.bindingContext.controlContexts;
+        var controlNames = Object.keys(controlContext);
+        controlNames.forEach((controlName) => {
+            var control = controlContext[controlName];
+            var controlList = PowerAppsModelDrivenCanvas.parseControl(controlName, control);
+            controls = controls.concat(controlList);
+        });
+
+        var match = controls.filter(c => c.name == itemPath.controlName);
+        if (match.length >= 0 && typeof match[0] == 'object') {
+            match[0].properties.forEach((item) => {
+                data.push(
+                    {
+                        Key: item.propertyName,
+                        Value: PowerAppsModelDrivenCanvas.getPropertyValueFromControl({ controlName: itemPath.controlName, propertyName: item.propertyName })?.propertyValue
+                    })
+            })
+        }
+        return JSON.stringify(data);
+    }
+}

--- a/src/testengine.provider.mda/PowerAppsTestEngineMDADashboard.js
+++ b/src/testengine.provider.mda/PowerAppsTestEngineMDADashboard.js
@@ -1,0 +1,5 @@
+﻿// WARNING:
+// The JavaScript object model of the page is subject to change. Do not take dependencies on the implementation of methods as they could be updated
+
+class PowerAppsModelDrivenDashboard {
+}

--- a/src/testengine.provider.mda/PowerAppsTestEngineMDAEntityList.js
+++ b/src/testengine.provider.mda/PowerAppsTestEngineMDAEntityList.js
@@ -1,0 +1,5 @@
+﻿// WARNING:
+// The JavaScript object model of the page is subject to change. Do not take dependencies on the implementation of methods as they could be updated
+
+class PowerAppsModelDrivenEntityList {
+}

--- a/src/testengine.provider.mda/PowerAppsTestEngineMDAEntityRecord.js
+++ b/src/testengine.provider.mda/PowerAppsTestEngineMDAEntityRecord.js
@@ -1,0 +1,97 @@
+﻿// WARNING:
+// The JavaScript object model of the page is subject to change. Do not take dependencies on the implementation of methods as they could be updated
+
+class PowerAppsModelDrivenEntityRecord {
+    static getValue(name)
+    {
+        // TODO: Handle multiple control types. For example lookup, grids
+
+        // References:
+        // https://learn.microsoft.com/en-us/power-apps/developer/model-driven-apps/clientapi/reference/controls
+        // https://learn.microsoft.com/en-us/power-apps/developer/model-driven-apps/clientapi/reference/controls/getvalue
+        return Xrm.Page.ui.controls.getByName(name).getValue();
+    }
+
+    static setPropertyValueForControl(item, data)
+    {
+        var control = Xrm.Page.ui.controls.getByName(item.controlName);
+        var propertyName = typeof item.propertyName === 'string' ? item.propertyName.toLowerCase() : ''
+        // TODO - Set the Xrm SDK Value and update state for any JS to run
+        // TODO: Handle Grid
+        switch (propertyName) {
+            case '':
+            case 'text':
+                // https://learn.microsoft.com/power-apps/developer/model-driven-apps/clientapi/reference/controls/getattribute
+                var attribute = control.getAttribute();
+                // https://learn.microsoft.com/power-apps/developer/model-driven-apps/clientapi/reference/attributes/setvalue
+                // TODO: Handle different control types. For example lookup, options
+                attribute.setValue(data);
+                attribute.fireOnChange();
+                return true;
+            case 'label':
+                // https://learn.microsoft.com/power-apps/developer/model-driven-apps/clientapi/reference/controls/setlabel
+                control.setLabel(data);
+                return true;
+            case 'disabled':
+                // https://learn.microsoft.com/power-apps/developer/model-driven-apps/clientapi/reference/controls/setdisabled
+                control.setDisabled(data);
+                return true;
+            case 'visible':
+                // https://learn.microsoft.com/power-apps/developer/model-driven-apps/clientapi/reference/controls/setvisible
+                control.setVisible(data);
+                return true;
+        }
+        return false;
+    }
+
+    static buildControlObjectModel()
+    {
+        // TODO - Load Grid and Other control type
+
+        // Reference
+        // https://learn.microsoft.com/en-us/power-apps/developer/model-driven-apps/clientapi/reference/controls
+        return JSON.stringify({
+            Controls: Xrm.Page.ui.controls.getAll().map(item => {
+                var control = {};
+                control.Name = item.getName();
+                control.Properties = [];
+                control.Properties.push({ PropertyName: 'Disabled', PropertyType: 'b' });
+                control.Properties.push({ PropertyName: 'ShowLabel', PropertyType: 'b' });
+                control.Properties.push({ PropertyName: 'Label', PropertyType: 's' });
+                control.Properties.push({ PropertyName: 'Visible', PropertyType: 'b' });
+                control.Properties.push({ PropertyName: 'IsRequired', PropertyType: 'b' });
+                control.Properties.push({ PropertyName: 'Type', PropertyType: 's' });
+                // TODO Handle non standard controls
+
+                // Reference
+                // https://learn.microsoft.com/en-us/power-apps/developer/model-driven-apps/clientapi/reference/controls/getcontroltype
+                switch (item.getControlType()) {
+                    case 'standard':
+                        control.Properties.push({ PropertyName: 'Text', PropertyType: 's' });
+                        break;
+                }
+                return control;
+            })
+        })
+    }
+
+    static getControlProperties(itemPath)
+    {
+        // WARNING:
+        // controlDescriptor JavaScript object is subject to change. Do not take dependencies on the object or properties returned as they could change without notice.
+        var data = [];
+        var controlDescriptor = Xrm.Page.ui.controls.getByName(itemPath.controlName).controlDescriptor;
+
+        // Alternative: https://learn.microsoft.com/en-us/power-apps/developer/model-driven-apps/clientapi/reference/controls/getdisabled
+        data.push({ Key: 'Disabled', Value: controlDescriptor.Disabled.toString().toLowerCase() });
+        data.push({ Key: 'ShowLabel', Value: controlDescriptor.ShowLabel.toString().toLowerCase() });
+        if (controlDescriptor.ShowLabel) {
+            // Alternative https://learn.microsoft.com/en-us/power-apps/developer/model-driven-apps/clientapi/reference/controls/getlabel
+            data.push({ Key: 'Label', Value: controlDescriptor.Label });
+        }
+        // Alternative: https://learn.microsoft.com/en-us/power-apps/developer/model-driven-apps/clientapi/reference/controls/getvisible
+        data.push({ Key: 'Visible', Value: controlDescriptor.Visible.toString().toLowerCase() });
+        data.push({ Key: 'IsRequired', Value: controlDescriptor.IsRequired.toString().toLowerCase() });
+        return JSON.stringify(data);
+    }
+}

--- a/src/testengine.provider.mda/testengine.provider.mda.csproj
+++ b/src/testengine.provider.mda/testengine.provider.mda.csproj
@@ -14,6 +14,10 @@
 
   <ItemGroup>
     <None Remove="PowerAppsTestEngineMDA.js" />
+    <None Remove="PowerAppsTestEngineMDACustom.js" />
+    <None Remove="PowerAppsTestEngineMDADashboard.js" />
+    <None Remove="PowerAppsTestEngineMDAEntityList.js" />
+    <None Remove="PowerAppsTestEngineMDAEntityRecord.js" />
   </ItemGroup>
 
   <ItemGroup>
@@ -26,6 +30,10 @@
 
   <ItemGroup>
     <EmbeddedResource Include="PowerAppsTestEngineMDA.js" />
+    <EmbeddedResource Include="PowerAppsTestEngineMDACustom.js" />
+    <EmbeddedResource Include="PowerAppsTestEngineMDADashboard.js" />
+    <EmbeddedResource Include="PowerAppsTestEngineMDAEntityList.js" />
+    <EmbeddedResource Include="PowerAppsTestEngineMDAEntityRecord.js" />
   </ItemGroup>
 
   <Target Name="CopyFiles" AfterTargets="AfterBuild">

--- a/src/testengine.user.browser.tests/testengine.user.browser.tests.csproj
+++ b/src/testengine.user.browser.tests/testengine.user.browser.tests.csproj
@@ -15,14 +15,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="Moq" Version="4.18.4" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.2">
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/testengine.user.certificate.tests/CertificateUserManagerModuleTests.cs
+++ b/src/testengine.user.certificate.tests/CertificateUserManagerModuleTests.cs
@@ -108,9 +108,12 @@ namespace testengine.user.environment.tests
             MockSingleTestInstanceState.Setup(x => x.GetLogger()).Returns(MockLogger.Object);
             var keyboard = new Mock<IKeyboard>(MockBehavior.Strict);
 
+            var mockEmailLocatorObject = new Mock<ILocator>();
+
+
             // Email Address
-            MockPage.Setup(x => x.Locator(CertificateUserManagerModule.EmailSelector, null)).Returns(new Mock<ILocator>().Object);
-            MockPage.Setup(x => x.TypeAsync(CertificateUserManagerModule.EmailSelector, email, It.IsAny<PageTypeOptions>())).Returns(Task.CompletedTask);
+            MockPage.Setup(x => x.Locator(CertificateUserManagerModule.EmailSelector, null)).Returns(mockEmailLocatorObject.Object);
+            mockEmailLocatorObject.Setup(x => x.PressSequentiallyAsync(email, It.IsAny<LocatorPressSequentiallyOptions>())).Returns(Task.CompletedTask);
             keyboard.Setup(x => x.PressAsync("Tab", It.IsAny<KeyboardPressOptions>()))
                     .Returns(Task.CompletedTask);
             MockPage.SetupGet(x => x.Keyboard).Returns(keyboard.Object);
@@ -185,7 +188,7 @@ namespace testengine.user.environment.tests
         [Theory]
         [InlineData(null)]
         [InlineData("")]
-        public async Task LoginUserAsyncThrowsOnInvalidPersonaTest(string persona)
+        public async Task LoginUserAsyncThrowsOnInvalidPersonaTest(string? persona)
         {
             var testSuiteDefinition = new TestSuiteDefinition()
             {
@@ -239,7 +242,7 @@ namespace testengine.user.environment.tests
         [Theory]
         [InlineData(null)]
         [InlineData("")]
-        public async Task LoginUserAsyncThrowsOnInvalidUserConfigTest(string emailKey)
+        public async Task LoginUserAsyncThrowsOnInvalidUserConfigTest(string? emailKey)
         {
             UserConfiguration userConfiguration = new UserConfiguration()
             {
@@ -268,7 +271,7 @@ namespace testengine.user.environment.tests
         [InlineData("someone@example.com", "CN=test", "setCert", "Certificate cannot be null. Please ensure certificate for user.")]
         [InlineData("someone@example.com", null, "set", "User certificate subject name cannot be null. Please check if the environment variable is set properly.")]
         [InlineData("someone@example.com", "", "set", "User certificate subject name cannot be null. Please check if the environment variable is set properly.")]
-        public async Task LoginUserAsyncThrowsOnInvalidEnviromentVariablesTest(string email, string certname, string setAsNull, string message)
+        public async Task LoginUserAsyncThrowsOnInvalidEnviromentVariablesTest(string? email, string? certname, string setAsNull, string message)
         {
             UserConfiguration userConfiguration = new UserConfiguration()
             {

--- a/src/testengine.user.certificate.tests/CertificateUserManagerModuleTests.cs
+++ b/src/testengine.user.certificate.tests/CertificateUserManagerModuleTests.cs
@@ -18,7 +18,7 @@ using testengine.user.environment;
 
 namespace testengine.user.environment.tests
 {
-    public class CertificateUserManagerModuleTests
+    public class CertificateUserManagerModuleTests: IDisposable
     {
         private Mock<IBrowserContext> MockBrowserState;
         private Mock<ITestInfraFunctions> MockTestInfraFunctions;
@@ -34,6 +34,18 @@ namespace testengine.user.environment.tests
         private Mock<IUserManagerLogin> MockUserManagerLogin;
         private Mock<IUserCertificateProvider> MockUserCertificateProvider;
         private X509Certificate2 MockCert;
+
+        //adding this to reset the behavior after each test case for the static function
+        private readonly Func<HttpClientHandler> GetHttpClientHandler = CertificateUserManagerModule.GetHttpClientHandler;
+        private readonly Func<HttpClientHandler, HttpClient> GetHttpClient = CertificateUserManagerModule.GetHttpClient;
+
+        //adding this IDispose function for tear down that runs after each test and resets the GetHttpClientHandlerMock since it is static and can carry over between testcases
+        public void Dispose()
+        {
+            // Reset static Func to its original value after each test
+            CertificateUserManagerModule.GetHttpClientHandler = GetHttpClientHandler;
+            CertificateUserManagerModule.GetHttpClient = GetHttpClient;
+        }
 
         public CertificateUserManagerModuleTests()
         {

--- a/src/testengine.user.certificate.tests/testengine.user.certificate.tests.csproj
+++ b/src/testengine.user.certificate.tests/testengine.user.certificate.tests.csproj
@@ -15,14 +15,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="Moq" Version="4.18.4" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.2">
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/testengine.user.certificate/CertificateUserManagerModule.cs
+++ b/src/testengine.user.certificate/CertificateUserManagerModule.cs
@@ -242,7 +242,7 @@ namespace testengine.user.environment
         {
             ValidatePage();
             await Page.Locator(selector).WaitForAsync();
-            await Page.TypeAsync(selector, value, new PageTypeOptions { Delay = 50 });
+            await Page.Locator(selector).PressSequentiallyAsync(value, new LocatorPressSequentiallyOptions { Delay = 50 });
             await Page.Keyboard.PressAsync("Tab", new KeyboardPressOptions { Delay = 20 });
         }
 

--- a/src/testengine.user.environment.tests/EnvironmentUserManagerModuleTests.cs
+++ b/src/testengine.user.environment.tests/EnvironmentUserManagerModuleTests.cs
@@ -80,9 +80,11 @@ namespace testengine.user.environment.tests
             MockSingleTestInstanceState.Setup(x => x.GetLogger()).Returns(MockLogger.Object);
             var keyboard = new Mock<IKeyboard>(MockBehavior.Strict);
 
+            var mockEmailSelectorLocator = new Mock<ILocator>();
+
             // Email Address
-            MockPage.Setup(x => x.Locator(EnvironmentUserManagerModule.EmailSelector, null)).Returns(new Mock<ILocator>().Object);
-            MockPage.Setup(x => x.TypeAsync(EnvironmentUserManagerModule.EmailSelector, email, It.IsAny<PageTypeOptions>())).Returns(Task.CompletedTask);
+            MockPage.Setup(x => x.Locator(EnvironmentUserManagerModule.EmailSelector, null)).Returns(mockEmailSelectorLocator.Object);
+            mockEmailSelectorLocator.Setup(x => x.PressSequentiallyAsync(email, It.IsAny<LocatorPressSequentiallyOptions>())).Returns(Task.CompletedTask);
             keyboard.Setup(x => x.PressAsync("Tab", It.IsAny<KeyboardPressOptions>()))
                     .Returns(Task.CompletedTask);
             MockPage.SetupGet(x => x.Keyboard).Returns(keyboard.Object);
@@ -135,7 +137,7 @@ namespace testengine.user.environment.tests
         [Theory]
         [InlineData(null)]
         [InlineData("")]
-        public async Task LoginUserAsyncThrowsOnInvalidPersonaTest(string persona)
+        public async Task LoginUserAsyncThrowsOnInvalidPersonaTest(string? persona)
         {
             var testSuiteDefinition = new TestSuiteDefinition()
             {
@@ -191,7 +193,7 @@ namespace testengine.user.environment.tests
         [InlineData("", "myPassword1234")]
         [InlineData("user1Email", null)]
         [InlineData("user1Email", "")]
-        public async Task LoginUserAsyncThrowsOnInvalidUserConfigTest(string emailKey, string passwordKey)
+        public async Task LoginUserAsyncThrowsOnInvalidUserConfigTest(string? emailKey, string? passwordKey)
         {
             UserConfiguration userConfiguration = new UserConfiguration()
             {
@@ -219,7 +221,7 @@ namespace testengine.user.environment.tests
         [InlineData("", "user1Password")]
         [InlineData("someone@example.com", null)]
         [InlineData("someone@example.com", "")]
-        public async Task LoginUserAsyncThrowsOnInvalidEnviromentVariablesTest(string email, string password)
+        public async Task LoginUserAsyncThrowsOnInvalidEnviromentVariablesTest(string? email, string? password)
         {
             UserConfiguration userConfiguration = new UserConfiguration()
             {

--- a/src/testengine.user.environment.tests/testengine.user.environment.tests.csproj
+++ b/src/testengine.user.environment.tests/testengine.user.environment.tests.csproj
@@ -15,14 +15,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="Moq" Version="4.18.4" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.2">
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/testengine.user.environment/EnvironmentUserManagerModule.cs
+++ b/src/testengine.user.environment/EnvironmentUserManagerModule.cs
@@ -137,7 +137,7 @@ namespace testengine.user.environment
         {
             ValidatePage();
             await Page.Locator(selector).WaitForAsync();
-            await Page.TypeAsync(selector, value, new PageTypeOptions { Delay = 50 });
+            await Page.Locator(selector).PressSequentiallyAsync(value, new LocatorPressSequentiallyOptions { Delay = 50 });
             await Page.Keyboard.PressAsync("Tab", new KeyboardPressOptions { Delay = 20 });
         }
 


### PR DESCRIPTION
# Pull Request Template

## Description

Update of NuGet packages to later versions.

NOTE: New version of Playwright in use and will need to run ```.\playwright.ps1 install``` to install the new browser versions.

Update to Model Driven Application provider to split the JavaScript for each page type (entitylist, entity record and custom) into separate JavaScript files

## Checklist

- [-] The code change is covered by unit tests. I have added tests that prove my fix is effective or that my feature works
- [-] I have performed end-to-end test locally.
- [-] New and existing unit tests pass locally with my changes
- [-] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [-] My changes generate no new warnings
- [-] I used clear names for everything
- [-] I have performed a self-review of my own code
