### PR TITLE
[s360-breeze-toolkit: SFI-ES5.2] Fix CVE-2026-33116 and CVE-2026-26171: Pin System.Security.Cryptography.Xml to 8.0.3

### DIFF
--- a/src/PowerAppsTestEngineWrapper/PowerAppsTestEngineWrapper.csproj
+++ b/src/PowerAppsTestEngineWrapper/PowerAppsTestEngineWrapper.csproj
@@ -48,6 +48,7 @@
       <NoWarn>NU1701</NoWarn>
     </PackageReference>
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/testengine.user.storagestate/testengine.user.storagestate.csproj
+++ b/src/testengine.user.storagestate/testengine.user.storagestate.csproj
@@ -45,7 +45,7 @@
       <NoWarn>NU1701</NoWarn>
     </PackageReference>
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.2" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.3" />
   </ItemGroup>
 
 </Project>

--- a/src/testengine.user.storagestate/testengine.user.storagestate.csproj
+++ b/src/testengine.user.storagestate/testengine.user.storagestate.csproj
@@ -45,6 +45,7 @@
       <NoWarn>NU1701</NoWarn>
     </PackageReference>
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.2" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
Fixes CVE-2026-33116 and GHSA-37gx-xxp4-5rgx (High severity), CVE-2026-26171 and GHSA-w3x6-4m5h-cxqf in `System.Security.Cryptography.Xml` by pinning the transitive dependency to version 8.0.3.

## Changes
- Added direct PackageReference for `System.Security.Cryptography.Xml` version `8.0.3` in:
  - `src/testengine.user.storagestate/testengine.user.storagestate.csproj`
  - `src/PowerAppsTestEngineWrapper/PowerAppsTestEngineWrapper.csproj`

## Context
- **CG Alert:** https://dev.azure.com/dynamicscrm/b276c3e1-2902-46bd-a686-484157b97f48/_componentGovernance/209961?alertId=13356873&branchMoniker=main
- **CG Alert:** https://dev.azure.com/dynamicscrm/OneCRM/_componentGovernance/209961/alert/13356873?typeId=28589416
- **Affected component:** System.Security.Cryptography.Xml 8.0.0 (transitive via Microsoft.AspNetCore.DataProtection)
- **Fix version:** 8.0.3 (8.0.2 also has a known vulnerability)
- **S360 KPI:** ES5.2 (1ES Open Source Vulnerabilities)
- **Due date:** 2026-07-15

## Validation
- [x] `dotnet restore` succeeds
- [x] `dotnet build` succeeds for both affected projects
- [x] Semantic verification gates S1-S3: PASS

---
:wrench: s360-breeze-toolkit - SFI-ES5.2 - run `431c5164`
<!-- s360-toolkit-attribution: {"schema":"1.1","run_id":"431c5164-d417-42db-986e-d5a45590f76a","kpi_id":"SFI-ES5.2","program":"SFI","skill":"dependabot:dependency-update-orchestrator","arm":"dedicated_skill","action_items":["928b7015-db58-41a3-94ea-ab73c7bb9f4d:a24b6f0b-0416-4325-9164-4b0b7d41520b"],"plugin_version":"unknown","plugin_channel":"playground"} -->