### PR TITLE
Add new code owner for CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,5 +5,4 @@
 # the repo. Unless a later match takes precedence,
 # @global-owner1 and @global-owner2 will be requested for
 # review when someone opens a pull request.
-*       @microsoft/powerapps-testengine-codeowners
 *       @microsoft/powerapps-testengine-code-owners

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,3 +6,4 @@
 # @global-owner1 and @global-owner2 will be requested for
 # review when someone opens a pull request.
 *       @microsoft/powerapps-testengine-codeowners
+*       @microsoft/powerapps-testengine-code-owners


### PR DESCRIPTION
Adding new codeowners team since the old team does not have a maintainer it can nolonger be modified.
https://github.com/orgs/microsoft/teams/powerapps-testengine-code-owners
