### PR TITLE
Fix protocol string in SimulateDataverseFunction.GetRequestUri

### DIFF
--- a/src/testengine.module.simulation/SimulateDataverseFunction.cs
+++ b/src/testengine.module.simulation/SimulateDataverseFunction.cs
@@ -345,7 +345,7 @@ OData-Version: 4.0
                     if (line.StartsWith("GET "))
                     {
                         var text = line.Replace("GET ", "");
-                        text = text.Replace(" HTTPS/1.1", "");
+                        text = text.Replace(" HTTP/1.1", "");
                         return new Uri(text, UriKind.Relative);
                     }
                 }


### PR DESCRIPTION
Fixes #667

`GetRequestUri` parses a raw HTTP request line like:

```
GET accounts?%24select=...&%24count=true HTTP/1.1
```

by stripping the `GET ` prefix and then trying to strip a trailing `" HTTPS/1.1"` before building the relative `Uri`. But request lines here always end in `HTTP/1.1`, not `HTTPS/1.1` — that's true both for real Dataverse OData batch payloads and for this project's own test fixtures in `SimulateDataverseFunctionTests.cs` (e.g. the `BatchData` test builds a request ending in `...&%24count=true HTTP/1.1`).

Since the replace never matches, the trailing `" HTTP/1.1"` stays attached to the constructed URI text, which corrupts the value of whatever query parameter happens to be last (e.g. `$count=true` becomes `$count=true HTTP/1.1`), matching the "incorrectly parsed query parameters" symptom described in the issue.

Changed the replaced string from `" HTTPS/1.1"` to `" HTTP/1.1"`.

I don't have a .NET toolchain set up to run the test suite locally, so I traced this by reading the code and cross-checking it against the existing test fixtures in `SimulateDataverseFunctionTests.cs`, which already use the real `HTTP/1.1` format this fix targets.