### PR TITLE
Fix CWE-94 code injection in MDA and canvas interactWithControl

### DIFF
--- a/src/testengine.provider.canvas.tests/CanvasAppSdkInjectionTests.cs
+++ b/src/testengine.provider.canvas.tests/CanvasAppSdkInjectionTests.cs
@@ -1,0 +1,178 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System.Reflection;
+using Jint;
+using Newtonsoft.Json;
+
+namespace Microsoft.PowerApps.TestEngine.Tests.PowerApps
+{
+    /// <summary>
+    /// Regression tests for the CWE-94 code injection fix in CanvasAppSdk.js.
+    ///
+    /// interactWithControl() builds a script string that executePublishedAppScript() marshals into
+    /// the published app and evaluates there. The property name comes from the test plan
+    /// (.fx.yaml), so it has to be escaped with JSON.stringify() instead of being wrapped in hand
+    /// written quotes, otherwise a crafted name can close the object literal and the argument list
+    /// and append arbitrary statements to the script that crosses into the app.
+    /// </summary>
+    public class CanvasAppSdkInjectionTests
+    {
+        private const string SdkResourceName = "testengine.provider.canvas.tests.CanvasAppSdk.js";
+
+        /// <summary>
+        /// Property name that closes the generated object literal and the enclosing argument list,
+        /// appends a statement, then reopens both so the injected script still parses.
+        /// </summary>
+        private const string InjectionPropertyName = "a\":0});injected = true;({\"b";
+
+        private static string GetCanvasSdkSource()
+        {
+            var assembly = Assembly.GetExecutingAssembly();
+
+            using (var stream = assembly.GetManifestResourceStream(SdkResourceName))
+            {
+                Assert.True(stream != null, $"Embedded resource {SdkResourceName} was not found");
+
+                using (var reader = new StreamReader(stream))
+                {
+                    return reader.ReadToEnd();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Loads the shipped SDK and replaces executePublishedAppScript so the script that would be
+        /// sent to the published app can be inspected instead of dispatched.
+        /// </summary>
+        /// <param name="forceScalarBranch">
+        /// Object.values() always returns an array, so the scalar branch of interactWithControl is
+        /// only reachable when isArray is stubbed out.
+        /// </param>
+        private static Engine CreateSdkEngine(bool forceScalarBranch)
+        {
+            var engine = new Engine();
+
+            // debugInfo is evaluated while the SDK loads and reads the published app telemetry
+            engine.Execute("var Core = { Telemetry: {} };");
+            engine.Execute("var capturedScript = null; var injected = false; var probedKeys = null;");
+
+            engine.Execute(GetCanvasSdkSource());
+
+            engine.Execute("executePublishedAppScript = function (scriptToExecute) { capturedScript = scriptToExecute; return scriptToExecute; };");
+
+            if (forceScalarBranch)
+            {
+                engine.Execute("isArray = function () { return false; };");
+            }
+
+            return engine;
+        }
+
+        private static string ItemPathJson(string propertyName)
+        {
+            return JsonConvert.SerializeObject(new { controlName = "Label1", propertyName });
+        }
+
+        private static string BuildScript(Engine engine, string propertyName, string valueLiteral)
+        {
+            engine.Execute($"interactWithControl({ItemPathJson(propertyName)}, {valueLiteral});");
+
+            return engine.Evaluate("capturedScript").AsString();
+        }
+
+        /// <summary>
+        /// Stands in for the published app side implementation so the captured script can be run.
+        /// </summary>
+        private static void InstallProbe(Engine engine)
+        {
+            engine.Execute("interactWithControl = function (itemPath, value) { probedKeys = Object.keys(value); return true; };");
+        }
+
+        [Theory]
+        [InlineData(true, "{ Value: 1 }")]
+        [InlineData(false, "1")]
+        public void InteractWithControlEscapesPropertyNameInGeneratedScript(bool useArrayBranch, string valueLiteral)
+        {
+            // Arrange
+            var engine = CreateSdkEngine(forceScalarBranch: !useArrayBranch);
+
+            // Act
+            var script = BuildScript(engine, InjectionPropertyName, valueLiteral);
+
+            // Assert - the quote that would terminate the key is escaped
+            Assert.Contains("a\\\":0});injected", script);
+
+            // Assert - the payload stays inert when the script reaches the published app
+            InstallProbe(engine);
+            engine.Execute($"eval({JsonConvert.SerializeObject(script)});");
+            Assert.False(engine.Evaluate("injected").AsBoolean());
+        }
+
+        [Theory]
+        [InlineData(true, "{ Value: 1 }")]
+        [InlineData(false, "1")]
+        public void InteractWithControlDeliversPropertyNameAsSingleKey(bool useArrayBranch, string valueLiteral)
+        {
+            // Arrange
+            var engine = CreateSdkEngine(forceScalarBranch: !useArrayBranch);
+            var script = BuildScript(engine, InjectionPropertyName, valueLiteral);
+
+            InstallProbe(engine);
+
+            // Act
+            engine.Execute($"eval({JsonConvert.SerializeObject(script)});");
+
+            // Assert - the whole payload arrives as one inert key rather than as extra statements
+            Assert.False(engine.Evaluate("injected").AsBoolean());
+            Assert.Equal(1, (int)engine.Evaluate("probedKeys.length").AsNumber());
+            Assert.Equal(InjectionPropertyName, engine.Evaluate("probedKeys[0]").AsString());
+        }
+
+        [Theory]
+        [InlineData(true, "{ Value: 1 }")]
+        [InlineData(false, "1")]
+        public void InteractWithControlIsUnchangedForOrdinaryPropertyNames(bool useArrayBranch, string valueLiteral)
+        {
+            // Arrange
+            var engine = CreateSdkEngine(forceScalarBranch: !useArrayBranch);
+
+            // Act
+            var script = BuildScript(engine, "Text", valueLiteral);
+
+            // Assert - escaping the key must not alter the script produced for a normal plan
+            var expected = "interactWithControl({\"controlName\":\"Label1\",\"propertyName\":\"Text\"}, {\"Text\":1})";
+
+            Assert.Equal(expected, script);
+        }
+
+        [Fact]
+        public void SetPropertyValueDoesNotExecuteInjectedPropertyName()
+        {
+            // Arrange - setPropertyValue routes object values through interactWithControl
+            var engine = CreateSdkEngine(forceScalarBranch: false);
+
+            // Act
+            engine.Execute($"PowerAppsTestEngine.setPropertyValue({ItemPathJson(InjectionPropertyName)}, {{ Value: 1 }});");
+            var script = engine.Evaluate("capturedScript").AsString();
+
+            InstallProbe(engine);
+            engine.Execute($"eval({JsonConvert.SerializeObject(script)});");
+
+            // Assert
+            Assert.False(engine.Evaluate("injected").AsBoolean());
+            Assert.Equal(InjectionPropertyName, engine.Evaluate("probedKeys[0]").AsString());
+        }
+
+        [Fact]
+        public void SourceDoesNotInterpolatePropertyNameUnescaped()
+        {
+            // Arrange
+            var source = GetCanvasSdkSource();
+
+            // Assert - guards against reintroducing the hand written quoting of the property name
+            Assert.DoesNotContain("{\"${itemPath.propertyName}\"", source);
+            Assert.Contains("JSON.stringify(itemPath.propertyName)", source);
+        }
+    }
+}

--- a/src/testengine.provider.canvas.tests/testengine.provider.canvas.tests.csproj
+++ b/src/testengine.provider.canvas.tests/testengine.provider.canvas.tests.csproj
@@ -19,6 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Jint" Version="4.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.2" />
@@ -35,6 +36,11 @@
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.PowerApps.TestEngine.Tests\Microsoft.PowerApps.TestEngine.Tests.csproj" />
     <ProjectReference Include="..\testengine.provider.canvas\testengine.provider.canvas.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Linked so the injection tests assert against the shipped script rather than a copy -->
+    <EmbeddedResource Include="..\testengine.provider.canvas\JS\CanvasAppSdk.js" Link="CanvasAppSdk.js" LogicalName="testengine.provider.canvas.tests.CanvasAppSdk.js" />
   </ItemGroup>
 
 </Project>

--- a/src/testengine.provider.canvas/JS/CanvasAppSdk.js
+++ b/src/testengine.provider.canvas/JS/CanvasAppSdk.js
@@ -66,10 +66,10 @@ function interactWithControl(itemPath, value) {
         for (var index in values) {
             valuesJsonArr[`${index}`] = `${JSON.stringify(values[index])}`;
         }
-        var valueJson = `{"${itemPath.propertyName}":${valuesJsonArr}}`;
+        var valueJson = `{${JSON.stringify(itemPath.propertyName)}:${valuesJsonArr}}`;
         script = `interactWithControl(${JSON.stringify(itemPath)}, ${valueJson})`;
     } else {
-        var valueJson = `{"${itemPath.propertyName}":${value}}`;
+        var valueJson = `{${JSON.stringify(itemPath.propertyName)}:${value}}`;
         script = `interactWithControl(${JSON.stringify(itemPath)}, ${valueJson})`;
     }
     return executePublishedAppScript(script);

--- a/src/testengine.provider.mda.tests/PowerAppsTestEngineMDACustomInjectionTests.cs
+++ b/src/testengine.provider.mda.tests/PowerAppsTestEngineMDACustomInjectionTests.cs
@@ -1,0 +1,210 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Jint;
+using Microsoft.PowerApps.TestEngine.Providers;
+using Newtonsoft.Json;
+
+namespace Microsoft.PowerApps.TestEngine.Tests.PowerApps
+{
+    /// <summary>
+    /// Regression tests for the CWE-94 code injection fix in PowerAppsTestEngineMDACustom.js.
+    ///
+    /// PowerAppsModelDrivenCanvas.interactWithControl() builds a script string that is handed to
+    /// executePublishedAppScript(), which runs it through eval(). The property name comes from the
+    /// test plan (.fx.yaml), so it has to be escaped with JSON.stringify() instead of being wrapped
+    /// in hand written quotes, otherwise a crafted name can close the object literal and the
+    /// argument list and append arbitrary statements to the evaluated script.
+    /// </summary>
+    public class PowerAppsTestEngineMDACustomInjectionTests
+    {
+        private const string CustomResourceName = "testengine.provider.mda.PowerAppsTestEngineMDACustom.js";
+
+        /// <summary>
+        /// Property name that closes the generated object literal and the enclosing argument list,
+        /// appends a statement, then reopens both so the injected script still parses.
+        /// </summary>
+        private const string InjectionPropertyName = "a\":0});injected = true;({\"b";
+
+        private static string GetCustomScriptSource()
+        {
+            var assembly = typeof(ModelDrivenApplicationProvider).Assembly;
+
+            using (var stream = assembly.GetManifestResourceStream(CustomResourceName))
+            {
+                Assert.True(stream != null, $"Embedded resource {CustomResourceName} was not found");
+
+                using (var reader = new StreamReader(stream))
+                {
+                    return reader.ReadToEnd();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Returns the source of the script building interactWithControl overload.
+        /// The class declares interactWithControl twice and the later in-app definition wins at
+        /// runtime, so the builder has to be evaluated on its own in order to be exercised.
+        /// </summary>
+        private static string ExtractScriptBuildingInteractWithControl(string source)
+        {
+            var start = source.IndexOf("static interactWithControl", StringComparison.Ordinal);
+            Assert.True(start >= 0, $"interactWithControl was not found in {CustomResourceName}");
+
+            var open = source.IndexOf('{', start);
+            Assert.True(open > start, "The body of interactWithControl could not be located");
+
+            var depth = 0;
+            for (var index = open; index < source.Length; index++)
+            {
+                if (source[index] == '{')
+                {
+                    depth++;
+                }
+                else if (source[index] == '}')
+                {
+                    depth--;
+
+                    if (depth == 0)
+                    {
+                        return source.Substring(start, index - start + 1);
+                    }
+                }
+            }
+
+            Assert.Fail("The body of interactWithControl is not brace balanced");
+            return string.Empty;
+        }
+
+        /// <summary>
+        /// Hosts the real builder next to a stubbed executePublishedAppScript so the generated
+        /// script can be inspected instead of evaluated straight away.
+        /// </summary>
+        /// <param name="treatValuesAsArray">Selects the array or the scalar branch of the builder.</param>
+        private static Engine CreateBuilderEngine(bool treatValuesAsArray)
+        {
+            var builder = ExtractScriptBuildingInteractWithControl(GetCustomScriptSource());
+
+            var harness = @"
+var capturedScript = null;
+var injected = false;
+function isArray(value) { return " + (treatValuesAsArray ? "true" : "false") + @"; }
+class PowerAppsModelDrivenCanvas {
+    static executePublishedAppScript(scriptToExecute) {
+        capturedScript = scriptToExecute;
+        return scriptToExecute;
+    }
+
+    " + builder + @"
+}";
+
+            var engine = new Engine();
+            engine.Execute(harness);
+            return engine;
+        }
+
+        private static string BuildScript(Engine engine, string propertyName, string valueLiteral)
+        {
+            var itemPath = JsonConvert.SerializeObject(new { controlName = "TextInput1", propertyName });
+
+            engine.Execute($"PowerAppsModelDrivenCanvas.interactWithControl({itemPath}, {valueLiteral});");
+
+            return engine.Evaluate("capturedScript").AsString();
+        }
+
+        [Theory]
+        [InlineData(true, "{ Value: 1 }")]
+        [InlineData(false, "1")]
+        public void InteractWithControlEscapesPropertyNameInGeneratedScript(bool treatValuesAsArray, string valueLiteral)
+        {
+            // Arrange
+            var engine = CreateBuilderEngine(treatValuesAsArray);
+
+            // Act
+            var script = BuildScript(engine, InjectionPropertyName, valueLiteral);
+
+            // Assert - the quote that would terminate the key is escaped
+            Assert.Contains("a\\\":0});injected", script);
+
+            // Assert - the payload stays inert when the generated script is evaluated
+            engine.Execute("eval(capturedScript);");
+            Assert.False(engine.Evaluate("injected").AsBoolean());
+        }
+
+        [Theory]
+        [InlineData(true, "{ Value: 1 }")]
+        [InlineData(false, "1")]
+        public void InteractWithControlDeliversPropertyNameAsSingleKey(bool treatValuesAsArray, string valueLiteral)
+        {
+            // Arrange
+            var engine = CreateBuilderEngine(treatValuesAsArray);
+            var script = BuildScript(engine, InjectionPropertyName, valueLiteral);
+
+            // Swap the builder for a probe so the evaluated script reports what it actually passes on
+            engine.Execute("var receivedKeys = null;");
+            engine.Execute("PowerAppsModelDrivenCanvas.interactWithControl = function (itemPath, value) { receivedKeys = Object.keys(value); return true; };");
+
+            // Act
+            engine.Execute($"eval({JsonConvert.SerializeObject(script)});");
+
+            // Assert - the whole payload arrives as one inert key rather than as extra statements
+            Assert.False(engine.Evaluate("injected").AsBoolean());
+            Assert.Equal(1, (int)engine.Evaluate("receivedKeys.length").AsNumber());
+            Assert.Equal(InjectionPropertyName, engine.Evaluate("receivedKeys[0]").AsString());
+        }
+
+        [Theory]
+        [InlineData(true, "{ Value: 1 }", "{\"Text\":1}")]
+        [InlineData(false, "1", "{\"Text\":1}")]
+        public void InteractWithControlIsUnchangedForOrdinaryPropertyNames(bool treatValuesAsArray, string valueLiteral, string expectedValueJson)
+        {
+            // Arrange
+            var engine = CreateBuilderEngine(treatValuesAsArray);
+
+            // Act
+            var script = BuildScript(engine, "Text", valueLiteral);
+
+            // Assert - escaping the key must not alter the script produced for a normal plan
+            var expected = "PowerAppsModelDrivenCanvas.interactWithControl("
+                + "{\"controlName\":\"TextInput1\",\"propertyName\":\"Text\"}, "
+                + expectedValueJson
+                + ")";
+
+            Assert.Equal(expected, script);
+        }
+
+        [Fact]
+        public void SetPropertyValueDoesNotExecuteInjectedPropertyName()
+        {
+            // Arrange
+            var engine = new Engine();
+            engine.Execute(Common.MockJavaScript(
+                "mockPageType = 'custom'; var injected = false",
+                "custom",
+                interfaceResourceNames: new List<string>
+                {
+                    "testengine.provider.mda.PowerAppsTestEngineMDA.js",
+                    "testengine.provider.mda.PowerAppsTestEngineMDACustom.js"
+                }));
+
+            var itemPath = JsonConvert.SerializeObject(new { controlName = "TextInput1", propertyName = InjectionPropertyName });
+
+            // Act
+            engine.Execute($"PowerAppsTestEngine.setPropertyValue({itemPath}, {{ Value: 1 }});");
+
+            // Assert
+            Assert.False(engine.Evaluate("injected").AsBoolean());
+        }
+
+        [Fact]
+        public void SourceDoesNotInterpolatePropertyNameUnescaped()
+        {
+            // Arrange
+            var source = GetCustomScriptSource();
+
+            // Assert - guards against reintroducing the hand written quoting of the property name
+            Assert.DoesNotContain("{\"${itemPath.propertyName}\"", source);
+            Assert.Contains("JSON.stringify(itemPath.propertyName)", source);
+        }
+    }
+}

--- a/src/testengine.provider.mda/PowerAppsTestEngineMDACustom.js
+++ b/src/testengine.provider.mda/PowerAppsTestEngineMDACustom.js
@@ -56,10 +56,10 @@ class PowerAppsModelDrivenCanvas {
             for (var index in values) {
                 valuesJsonArr[`${index}`] = `${JSON.stringify(values[index])}`;
             }
-            var valueJson = `{"${itemPath.propertyName}":${valuesJsonArr}}`;
+            var valueJson = `{${JSON.stringify(itemPath.propertyName)}:${valuesJsonArr}}`;
             script = `PowerAppsModelDrivenCanvas.interactWithControl(${JSON.stringify(itemPath)}, ${valueJson})`;
         } else {
-            var valueJson = `{"${itemPath.propertyName}":${value}}`;
+            var valueJson = `{${JSON.stringify(itemPath.propertyName)}:${value}}`;
             script = `PowerAppsModelDrivenCanvas.interactWithControl(${JSON.stringify(itemPath)}, ${valueJson})`;
         }
         return PowerAppsModelDrivenCanvas.executePublishedAppScript(script);


### PR DESCRIPTION
## Summary

Fixes a **CWE-94 code injection** reported by Glasswing Mythos against the model driven provider, and the identical defect in the canvas provider.

Both SDKs built the value object literal by wrapping the control property name in hand written quotes:

```js
var valueJson = `{"${itemPath.propertyName}":${value}}`;
```

That string is concatenated into a script which is then evaluated. The property name comes from the test plan (`.fx.yaml`), so a crafted name such as `a":0});payload();({"b` closes the object literal and the argument list and appends arbitrary statements to the evaluated script.

| File | Sink | Reachable today |
| --- | --- | --- |
| `testengine.provider.mda/PowerAppsTestEngineMDACustom.js` | `eval()` in `executePublishedAppScript()` | No, see note below |
| `testengine.provider.canvas/JS/CanvasAppSdk.js` | `invokeScriptAsync()` into the published app | **Yes**, via `PowerAppsTestEngine.setPropertyValue` |

## Fix

Escape the key with `JSON.stringify()` in both the array and the scalar branch of each file:

```js
var valueJson = `{${JSON.stringify(itemPath.propertyName)}:${value}}`;
```

Ordinary property names serialize identically (`{"Text":1}`), so the generated script is byte for byte unchanged for existing test plans. Value serialization and all surrounding logic are untouched.

## Tests

Two new suites, 16 tests total, xUnit + Jint, following the existing pattern in these projects.

`PowerAppsTestEngineMDACustomInjectionTests` and `CanvasAppSdkInjectionTests` each cover:

| Test | Covers |
| --- | --- |
| `InteractWithControlEscapesPropertyNameInGeneratedScript` (x2) | The breakout quote is escaped and the payload stays inert when the generated script is evaluated |
| `InteractWithControlDeliversPropertyNameAsSingleKey` (x2) | The payload arrives as exactly one inert object key rather than as extra statements |
| `InteractWithControlIsUnchangedForOrdinaryPropertyNames` (x2) | No regression: identical script output for normal property names |
| `SetPropertyValueDoesNotExecuteInjectedPropertyName` | End to end guard on the `PowerAppsTestEngine.setPropertyValue` path |
| `SourceDoesNotInterpolatePropertyNameUnescaped` | Static guard against reintroducing the hand written quoting |

Both branches of the builder are covered by parameterizing `isArray`, since `Object.values()` always returns an array and the scalar branch is otherwise unreachable.

Each suite reads the real shipped script rather than a copy. The MDA test pulls it from the existing embedded resource; `CanvasAppSdk.js` is linked into the canvas test project as an embedded resource for the same reason.

### Note on reachability in the MDA provider

`PowerAppsModelDrivenCanvas` declares `interactWithControl` twice (lines 51 and 345). Per JS class semantics the later in-app definition wins, so the script building overload there is currently shadowed and not reachable through the public API. The fix is still worth making, and the test extracts that overload from the embedded resource and evaluates it in isolation so it exercises the shipped source. The canvas provider has no such shadowing, so its path is live.

## Validation

- All 16 new tests pass.
- Full suites green: MDA 128 passed / 3 pre-existing skips, canvas 136 passed / 0 skipped.
- Mutation checked. Reverting the one line change makes **5 of 8** MDA tests and **6 of 8** canvas tests fail, and restoring it returns them to green. The payload was chosen so the pre-fix script is syntactically valid and genuinely executes the injected statement, proving real code execution rather than a parse error.

## Note

`testengine.provider.canvas.tests.csproj` gains a `Jint` reference, pinned to 4.1.0 to match the version already flowing in from `Microsoft.PowerApps.TestEngine.Tests` and avoid an NU1605 downgrade.